### PR TITLE
Initial component extraction from flight-data metagraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,187 @@
-*.class
-*.log
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+### Development Environment and Editor Settings
+# General IDEs and Editors
+.idea
+.idea/*
+.idea_modules
+.vscode
+.vscode/
+*.sublime-project
+*.sublime-workspace
+
+# Ensime (Scala)
+.ensime
+.ensime_lucene
+.ensime_cache
+.ensime_snapshot
+ensime.sbt
+
+# Metals (Scala)
+.metals/
+.bloop/
+
+# Other
+.DS_Store
+.history
+.*.swp
+*~
+.#*
+
+### Build and Project Artifacts
+# SBT (Scala Build Tool)
+.scala-build
+.sbtrc
+.sbt
+target
+.project
+.lib
+.bsp/
+.logs/
+
+# General Build Artifacts
+artifacts
+cache
+node_modules
+out/
+run/
+.env
+.authconfig.json
+.simba.json
+
+# Auto-copied by sbt-microsites
+docs/src/main/tut/contributing.md
+
+# Test Results
+tests.iml
+result*
+
+### Docker and Infrastructure Configurations
+# Docker Shared Configurations
+infra/docker/shared/genesis/*
+infra/docker/shared/jars/**/*.jar
+
+# Docker Monitoring (Prometheus, Grafana)
+infra/docker/monitoring/grafana/config/
+infra/docker/monitoring/prometheus/data/
+infra/docker/monitoring/prometheus/monitoring/
+
+# Source Specific
+source/metagraph-l0/genesis/*
+
+### Miscellaneous
+# Various Config Files and Directories
+.ignore
+.envrc
+.direnv/
+TAGS
+tmp/
+.ldb/
+
+# Additional General Filters
+*.log
+*.tmp
+*.temp
+
+# Scala and SBT Specific
+project/target/
+project/project/
+
+# NodeJS Specific
+.npm
+package-lock.json
+yarn.lock
+dist/
+
+# Local Environment Specific
+.env.local
+.env.*.local
+
+# Security and Private Keys
+*.pem
+*.key
+deploy_rsa
+
+# Ansible Specific
+.ansible/
+*.retry
+inventory
+
+# Vagrant
+.vagrant/
+
+# Bash Scripts
+.bash_history
+
+# Docker
+docker-compose.override.yml
+
+# ------------------------
+# Python
+# ------------------------
+*.pyc
+*.pyo
+*.pyd
+__pycache__
+*.so
+*.egg
+*.egg-info
+dist
+build
+
+# ------------------------
+# Development environment
+# ------------------------
+.vscode
+.idea
+*.swp
+*.swo
+*.swn
+*~
+# PyCharm, IntelliJ IDEA
+/.idea/
+
+# ------------------------
+# Poetry
+# ------------------------
+# Ignore poetry lock file (create consistent environments locally)
+/poetry.lock
+
+# ------------------------
+# Virtual environment
+# ------------------------
+.venv/
+.env
+
+# ------------------------
+# Test and coverage reports
+# ------------------------
+.tox/
+.coverage
+.coverage.*
+# py.test cache
+.cache
+.pytest_cache/
+htmlcov/
+
+# ------------------------
+# IPython, Jupyter notebooks
+# ------------------------
+.ipynb_checkpoints/
+
+# ------------------------
+# Miscellaneous
+# ------------------------
+.DS_Store
+*.log
+*.pot
+# Ignore generated/compiled files
+*.mo
+*.py[co]
+/node_modules/
+/jspm_packages/
+
+# ------------------------
+# Directories to ignore
+# ------------------------
+ENV/
+env/

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,10 @@
+rules = [
+    OrganizeImports
+]
+
+OrganizeImports {
+  groupedImports                    = Merge
+  coalesceToWildcardImportThreshold = 6
+  groups                            = ["re:javax?\\.", "cats.", "scala.", "org.tessellation.", "io.constellationnetwork", "*"]
+  removeUnused                      = true
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,41 @@
+version = "3.7.14"
+
+runner.dialect = scala213
+
+style = defaultWithAlign
+
+align.openParenCallSite = false
+align.openParenDefnSite = false
+align.tokens = [
+  {code = "->"},
+  {code = "<-"},
+  {code = "=>", owner = "Case"},
+  {code = "%", owner = "Term.ApplyInfix"},
+  {code = "%%", owner = "Term.ApplyInfix"},
+  {code = ":", owner = "Term.Param"}
+]
+align.preset = some
+
+rewriteTokens = {
+  "⇒": "=>"
+  "→": "->"
+  "←": "<-"
+}
+
+continuationIndent.callSite = 2
+continuationIndent.defnSite = 2
+danglingParentheses.preset = true
+indentOperator.preset = spray
+indentOperator.exemptScope = all
+maxColumn = 120
+lineEndings = preserve
+newlines.topLevelStatementBlankLines = [{ blanks { before = 1 } }]
+project.excludeFilters = [".*\\.sbt"]
+rewrite.rules = [RedundantParens, SortImports]
+spaces.inImportCurlyBraces = false
+docstrings = JavaDoc
+docstrings.style = Asterisk
+docstrings.wrap = false
+optIn.configStyleArguments = true
+
+rewrite.rules = [RedundantBraces, SortImports, sortModifiers]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# metakit
+# Metakit
 A toolkit for developing decentralized data applications using the Constellation Metagraph framework.
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,62 @@
+import Dependencies.*
+import sbt.*
+import sbt.Keys.*
+
+ThisBuild / version := "0.1.0"
+ThisBuild / organization := "io.constellationnetwork"
+ThisBuild / scalaVersion := "2.13.15"
+ThisBuild / evictionErrorLevel := Level.Warn
+ThisBuild / scalafixDependencies += Libraries.organizeImports
+
+ThisBuild / assemblyMergeStrategy := {
+  case "logback.xml" => MergeStrategy.first
+  case x if x.contains("io.netty.versions.properties") => MergeStrategy.discard
+  case PathList("io", "constellationnetwork", "buildinfo", xs @ _*) => MergeStrategy.first
+  case PathList(xs@_*) if xs.last == "module-info.class" => MergeStrategy.first
+  case x =>
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
+    oldStrategy(x)
+}
+
+lazy val commonSettings = Seq(
+  scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
+  resolvers += Resolver.mavenLocal,
+  resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
+  libraryDependencies ++= Seq(
+    CompilerPlugin.kindProjector,
+    CompilerPlugin.betterMonadicFor,
+    CompilerPlugin.semanticDB,
+    Libraries.tessellationSdk,
+    Libraries.declineCore,
+    Libraries.cats,
+    Libraries.catsEffect,
+    Libraries.levelDb
+  )
+) ++ Defaults.itSettings
+
+lazy val commonTestSettings = Seq(
+  testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
+  libraryDependencies ++= Seq(
+    Libraries.weaverCats,
+    Libraries.weaverDiscipline,
+    Libraries.weaverScalaCheck,
+    Libraries.catsEffectTestkit
+  ).map(_ % Test)
+)
+
+lazy val buildInfoSettings = Seq(
+  buildInfoKeys := Seq[BuildInfoKey](
+    name,
+    version,
+    scalaVersion,
+    sbtVersion
+  ),
+  buildInfoPackage := "io.constellationnetwork.buildinfo"
+)
+
+lazy val root = (project in file("."))
+  .settings(
+    commonSettings,
+    commonTestSettings,
+    name := "metakit",
+  )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,45 @@
+import sbt._
+
+object Dependencies {
+
+  object V {
+    val tessellation = "2.12.0"
+    val decline = "2.4.1"
+    val cats = "2.9.0"
+    val catsEffect = "3.4.2"
+    val weaver = "0.8.1"
+    val levelDb = "0.12"
+    val organizeImports = "0.5.0"
+    val betterMonadicFor = "0.3.1"
+    val kindProjector = "0.13.3"
+    val semanticDB = "4.11.2"
+  }
+
+  object Libraries {
+    val tessellationSdk = "org.constellation" %% s"tessellation-sdk" % V.tessellation
+    val declineCore = "com.monovore" %% "decline" % V.decline
+    val cats = "org.typelevel" %% "cats-core" % V.cats
+    val catsEffect = "org.typelevel" %% "cats-effect" % V.catsEffect
+    val catsEffectTestkit = "org.typelevel" %% "cats-effect-testkit" % V.catsEffect
+    val weaverCats = "com.disneystreaming" %% "weaver-cats" % V.weaver
+    val weaverDiscipline = "com.disneystreaming" %% "weaver-discipline" % V.weaver
+    val weaverScalaCheck = "com.disneystreaming" %% "weaver-scalacheck" % V.weaver
+    val levelDb = "org.iq80.leveldb" % "leveldb" % V.levelDb
+    val organizeImports = "com.github.liancheng" %% "organize-imports" % V.organizeImports
+  }
+
+  object CompilerPlugin {
+
+    val betterMonadicFor = compilerPlugin(
+      "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor
+    )
+
+    val kindProjector = compilerPlugin(
+      ("org.typelevel" % "kind-projector" % V.kindProjector).cross(CrossVersion.full)
+    )
+
+    val semanticDB = compilerPlugin(
+      ("org.scalameta" % "semanticdb-scalac" % V.semanticDB).cross(CrossVersion.full)
+    )
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,13 @@
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.2")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
+
+addDependencyTreePlugin

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/MetagraphCommonService.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/MetagraphCommonService.scala
@@ -1,0 +1,61 @@
+package io.constellationnetwork.metagraph_sdk
+
+import cats.effect.Async
+
+import org.tessellation.currency.dataApplication.dataApplication.DataApplicationBlock
+import org.tessellation.currency.dataApplication.{DataCalculatedState, DataOnChainState, DataUpdate}
+import org.tessellation.security.signature.Signed
+
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryCodec
+
+import io.circe.{Decoder, Encoder}
+import org.http4s.EntityDecoder
+import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
+
+abstract class MetagraphCommonService[F[_], TX <: DataUpdate, PUB <: DataOnChainState, PRV <: DataCalculatedState](
+  implicit
+  txEncoder:     Encoder[TX],
+  txDecoder:     Decoder[TX],
+  prvEncoder:    Encoder[PRV],
+  prvDecoder:    Decoder[PRV],
+  txBinCodec:    JsonBinaryCodec[F, TX],
+  pubBinCodec:   JsonBinaryCodec[F, PUB],
+  prvBinCodec:   JsonBinaryCodec[F, PRV],
+  blockBinCodec: JsonBinaryCodec[F, Signed[DataApplicationBlock]],
+  async:         Async[F]
+) {
+
+  val signedDataEntityDecoder: EntityDecoder[F, Signed[TX]] = circeEntityDecoder
+
+  def serializeState(state: PUB): F[Array[Byte]] =
+    pubBinCodec.serialize(state)
+
+  def deserializeState(bytes: Array[Byte]): F[Either[Throwable, PUB]] =
+    pubBinCodec.deserialize(bytes)
+
+  def serializeCalculatedState(calculatedState: PRV): F[Array[Byte]] =
+    prvBinCodec.serialize(calculatedState)
+
+  def deserializeCalculatedState(bytes: Array[Byte]): F[Either[Throwable, PRV]] =
+    prvBinCodec.deserialize(bytes)
+
+  def serializeUpdate(update: TX): F[Array[Byte]] =
+    txBinCodec.serialize(update)
+
+  def deserializeUpdate(bytes: Array[Byte]): F[Either[Throwable, TX]] =
+    txBinCodec.deserialize(bytes)
+
+  def serializeBlock(block: Signed[DataApplicationBlock]): F[Array[Byte]] =
+    blockBinCodec.serialize(block)
+
+  def deserializeBlock(bytes: Array[Byte]): F[Either[Throwable, Signed[DataApplicationBlock]]] =
+    blockBinCodec.deserialize(bytes)
+
+  def dataEncoder: Encoder[TX] = txEncoder
+
+  def dataDecoder: Decoder[TX] = txDecoder
+
+  def calculatedStateEncoder: Encoder[PRV] = prvEncoder
+
+  def calculatedStateDecoder: Decoder[PRV] = prvDecoder
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/MetagraphPublicRoutes.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/MetagraphPublicRoutes.scala
@@ -1,0 +1,58 @@
+package io.constellationnetwork.metagraph_sdk
+
+import cats.effect.Concurrent
+import cats.implicits.{toBifunctorOps, toFlatMapOps, toFunctorOps}
+
+import org.tessellation.currency.dataApplication.DataApplicationValidationError
+import org.tessellation.routes.internal.{InternalUrlPrefix, PublicRoutes}
+
+import io.constellationnetwork.metagraph_sdk.MetagraphPublicRoutes.{DataApp404, StringError}
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import eu.timepit.refined.auto._
+import io.circe.Encoder
+import io.circe.syntax.EncoderOps
+import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
+import org.http4s.dsl.Http4sDsl
+import org.http4s.server.middleware.CORS
+import org.http4s.{HttpRoutes, Response}
+
+abstract class MetagraphPublicRoutes[F[_]: Concurrent] extends Http4sDsl[F] with PublicRoutes[F] {
+
+  override lazy val public: HttpRoutes[F] =
+    CORS.policy
+      .withAllowCredentials(false)
+      .httpRoutes(routes)
+
+  protected val routes: HttpRoutes[F]
+
+  override protected def prefixPath: InternalUrlPrefix = "/"
+
+  protected def prepareResponse[T: Encoder](result: Either[DataApplicationValidationError, T]): F[Response[F]] =
+    result match {
+      case Left(ex: DataApp404) => NotFound(ex.message)
+      case Left(ex)             => BadRequest(ex.message)
+      case Right(value)         => Ok(value.asJson)
+    }
+
+  implicit class dataAppErrorResponseOps[T: Encoder](result: F[Either[DataApplicationValidationError, T]]) {
+    def toResponse: F[Response[F]] = result.flatMap(prepareResponse(_))
+  }
+
+  implicit class throwableResponseOps[T: Encoder](result: F[Either[Throwable, T]]) {
+
+    def toResponse: F[Response[F]] = result
+      .map(_.leftMap(e => StringError(e.getMessage)))
+      .flatMap(prepareResponse(_))
+  }
+}
+
+object MetagraphPublicRoutes {
+
+  @derive(decoder, encoder)
+  case class StringError(message: String) extends DataApplicationValidationError
+
+  @derive(decoder, encoder)
+  case class DataApp404(message: String) extends DataApplicationValidationError
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/Checkpoint.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/Checkpoint.scala
@@ -1,0 +1,13 @@
+package io.constellationnetwork.metagraph_sdk.std
+
+import org.tessellation.schema.SnapshotOrdinal
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+
+@derive(decoder, encoder)
+case class Checkpoint[S](ordinal: SnapshotOrdinal, state: S)
+
+object Checkpoint {
+  def genesis[S](state: S): Checkpoint[S] = Checkpoint(SnapshotOrdinal.MinValue, state)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/CheckpointService.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/CheckpointService.scala
@@ -1,0 +1,47 @@
+package io.constellationnetwork.metagraph_sdk.std
+
+import cats.effect.Async
+import cats.effect.std.AtomicCell
+import cats.syntax.applicative._
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait CheckpointService[F[_], S] {
+  def get: F[Checkpoint[S]]
+  def set(checkpoint:  Checkpoint[S]): F[Boolean]
+  def evalModify[E](f: Checkpoint[S] => F[Either[E, Checkpoint[S]]]): F[Either[E, Checkpoint[S]]]
+}
+
+object CheckpointService {
+
+  def make[F[_]: Async, S](state: S): F[CheckpointService[F, S]] =
+    AtomicCell[F]
+      .of(Checkpoint.genesis(state))
+      .map { atomicCell =>
+        new CheckpointService[F, S] {
+
+          private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(CheckpointService.getClass)
+
+          override def get: F[Checkpoint[S]] =
+            atomicCell.get
+
+          override def set(checkpoint: Checkpoint[S]): F[Boolean] =
+            atomicCell
+              .set(checkpoint)
+              .as(true)
+              .handleErrorWith(logger.error(_)(s"Checkpoint set failed") >> false.pure[F])
+
+          override def evalModify[E](f: Checkpoint[S] => F[Either[E, Checkpoint[S]]]): F[Either[E, Checkpoint[S]]] =
+            atomicCell.evalModify { currentState =>
+              f(currentState).map {
+                case result @ Right(updatedState) => (updatedState, result)
+                case result @ Left(_)             => (currentState, result)
+              }
+            }
+        }
+      }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/CircularBuffer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/CircularBuffer.scala
@@ -1,0 +1,47 @@
+package io.constellationnetwork.metagraph_sdk.std
+
+import cats.effect.{Ref, Sync}
+import cats.syntax.functor._
+
+import scala.collection.mutable
+
+trait CircularBuffer[F[_], A] {
+  def put(items: List[A]): F[Unit]
+  def list: F[List[A]]
+  def contains(item:  A): F[Boolean]
+  def contains(items: List[A]): F[List[Boolean]]
+}
+
+object CircularBuffer {
+
+  def make[F[_]: Sync, A](size: Int): F[CircularBuffer[F, A]] =
+    Ref.of[F, (mutable.Buffer[A], Int)]((mutable.Buffer.empty[A], 0)).map { ref =>
+      new CircularBuffer[F, A] {
+        override def put(items: List[A]): F[Unit] =
+          ref.update { case (buffer, writePos) =>
+            items.foldLeft((buffer, writePos)) { case ((buf, pos), item) =>
+              if (buf.size < size) {
+                buf.append(item)
+              } else {
+                buf.update(pos, item)
+              }
+
+              (buf, (pos + 1) % size)
+            }
+          }
+
+        override def list: F[List[A]] =
+          ref.get.map(_._1.toList)
+
+        override def contains(item: A): F[Boolean] =
+          ref.get.map { case (buffer, _) =>
+            buffer.contains(item)
+          }
+
+        override def contains(items: List[A]): F[List[Boolean]] =
+          ref.get.map { case (buffer, _) =>
+            items.map(buffer.contains(_))
+          }
+      }
+    }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/JsonBinaryCodec.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/JsonBinaryCodec.scala
@@ -1,0 +1,82 @@
+package io.constellationnetwork.metagraph_sdk.std
+
+import java.nio.charset.StandardCharsets
+
+import cats.effect.Sync
+import cats.implicits.{toFlatMapOps, toFunctorOps}
+
+import org.tessellation.currency.dataApplication.DataUpdate
+import org.tessellation.currency.dataApplication.dataApplication.DataApplicationBlock
+import org.tessellation.currency.schema.currency.CurrencyIncrementalSnapshot
+import org.tessellation.schema.ID.Id
+import org.tessellation.security.signature.Signed
+
+import io.circe.jawn.JawnParser
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, Printer}
+import org.bouncycastle.util.encoders.Base64
+
+trait JsonBinaryCodec[F[_], A] {
+  def serialize(content:   A): F[Array[Byte]]
+  def deserialize(content: Array[Byte]): F[Either[Throwable, A]]
+}
+
+object JsonBinaryCodec {
+
+  private val printer = Printer(dropNullValues = true, indent = "", sortKeys = true)
+
+  def apply[F[_], A](implicit ev: JsonBinaryCodec[F, A]): JsonBinaryCodec[F, A] = ev
+
+  def simpleJsonSerialization[F[_]: Sync, A: Encoder](content: A): F[Array[Byte]] =
+    Sync[F].delay(content.asJson.printWith(printer).getBytes("UTF-8"))
+
+  def simpleJsonDeserialization[F[_]: Sync, A: Decoder](content: Array[Byte]): F[Either[Throwable, A]] =
+    Sync[F].delay(JawnParser(false).decodeByteArray[A](content))
+
+  def serializeDataUpdate[F[_]: Sync, U <: DataUpdate: Encoder](content: U): F[Array[Byte]] = for {
+    jsonBytes    <- simpleJsonSerialization(content)
+    base64String <- Sync[F].delay(Base64.toBase64String(jsonBytes))
+    prefixedString = s"\u0019Constellation Signed Data:\n${base64String.length}\n$base64String"
+  } yield prefixedString.getBytes("UTF-8")
+
+  def deserializeDataUpdate[F[_]: Sync, U <: DataUpdate: Decoder](
+    bytes: Array[Byte]
+  ): F[Either[Throwable, DataUpdate]] = for {
+    base64String <- Sync[F].pure(new String(bytes, StandardCharsets.UTF_8).split("\n").drop(2).mkString)
+    jsonBytes    <- Sync[F].delay(Base64.decode(base64String))
+    result       <- simpleJsonDeserialization(jsonBytes)
+  } yield result
+
+  implicit def dataBlockBinaryCodec[F[_]: Sync](implicit
+    updEnc: Encoder[DataUpdate],
+    updDec: Decoder[DataUpdate]
+  ): JsonBinaryCodec[F, Signed[DataApplicationBlock]] =
+    new JsonBinaryCodec[F, Signed[DataApplicationBlock]] {
+
+      override def serialize(obj: Signed[DataApplicationBlock]): F[Array[Byte]] =
+        simpleJsonSerialization(obj)
+
+      override def deserialize(bytes: Array[Byte]): F[Either[Throwable, Signed[DataApplicationBlock]]] =
+        simpleJsonDeserialization(bytes)
+    }
+
+  implicit def currencyIncrementalSnapshotCodec[F[_]: Sync]: JsonBinaryCodec[F, CurrencyIncrementalSnapshot] =
+    new JsonBinaryCodec[F, CurrencyIncrementalSnapshot] {
+
+      override def serialize(obj: CurrencyIncrementalSnapshot): F[Array[Byte]] =
+        simpleJsonSerialization(obj)
+
+      override def deserialize(bytes: Array[Byte]): F[Either[Throwable, CurrencyIncrementalSnapshot]] =
+        simpleJsonDeserialization(bytes)
+    }
+
+  implicit def idCodec[F[_]: Sync]: JsonBinaryCodec[F, Id] =
+    new JsonBinaryCodec[F, Id] {
+
+      override def serialize(obj: Id): F[Array[Byte]] =
+        simpleJsonSerialization(obj)
+
+      override def deserialize(bytes: Array[Byte]): F[Either[Throwable, Id]] =
+        simpleJsonDeserialization(bytes)
+    }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/JsonBinaryHasher.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/JsonBinaryHasher.scala
@@ -1,0 +1,18 @@
+package io.constellationnetwork.metagraph_sdk.std
+
+import cats.Functor
+import cats.implicits.toFunctorOps
+
+import org.tessellation.security.hash.Hash
+
+trait JsonBinaryHasher[F[_]] {
+  def hash[A](data: A): F[Hash]
+}
+
+object JsonBinaryHasher {
+  def apply[F[_]](implicit ev: JsonBinaryHasher[F]): JsonBinaryHasher[F] = ev
+
+  implicit class FromJsonBinaryCodec[F[_]: Functor, A](obj: A)(implicit bin: JsonBinaryCodec[F, A]) {
+    def hash: F[Hash] = bin.serialize(obj).map(Hash.fromBytes)
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/QueueDaemon.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/QueueDaemon.scala
@@ -1,0 +1,28 @@
+package io.constellationnetwork.metagraph_sdk.std
+
+import cats.effect.Sync
+import cats.effect.std.Queue
+import cats.syntax.applicativeError._
+
+import fs2.Stream
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+abstract class QueueDaemon[F[_]: Sync, A] {
+
+  val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(this.getClass)
+
+  val queue: Queue[F, A]
+
+  def process(a: A): F[Unit]
+
+  def run: F[Unit] =
+    Stream
+      .fromQueueUnterminated(queue)
+      .evalMap { elem =>
+        process(elem)
+          .handleErrorWith(logger.error(_)("Uncaught exception during queue processing"))
+      }
+      .compile
+      .drain
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/UpdateValidator.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/UpdateValidator.scala
@@ -1,0 +1,7 @@
+package io.constellationnetwork.metagraph_sdk.std
+
+import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+
+trait UpdateValidator[F[_], U, T] {
+  def verify(state: T, update: U): F[DataApplicationValidationErrorOr[Unit]]
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/storage/Collection.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/storage/Collection.scala
@@ -1,0 +1,34 @@
+package io.constellationnetwork.metagraph_sdk.storage
+
+import cats.data.OptionT
+import cats.implicits.showInterpolator
+import cats.{MonadThrow, Show}
+
+trait Collection[F[_], Key, Value] extends CollectionReader[F, Key, Value] with CollectionWriter[F, Key, Value]
+
+trait CollectionReader[F[_], Key, Value] {
+
+  def get(id: Key): F[Option[Value]]
+
+  def getBatch(ids: List[Key]): F[List[(Key, Option[Value])]]
+
+  def contains(id: Key): F[Boolean]
+
+  def dump: F[List[(Key, Value)]] =
+    getWithFilter((_, _) => true)
+
+  def getWithFilter(cond: (Key, Value) => Boolean): F[List[(Key, Value)]]
+
+  def getUnsafe(id: Key)(implicit monadThrow: MonadThrow[F], showKey: Show[Key]): F[Value] =
+    OptionT(get(id)).getOrElseF(monadThrow.raiseError(new NoSuchElementException(show"Element not found. id=$id")))
+}
+
+trait CollectionWriter[F[_], Key, Value] {
+  def put(id: Key, t: Value): F[Unit]
+
+  def remove(id: Key): F[Unit]
+
+  def putBatch(updates: List[(Key, Value)]): F[Unit]
+
+  def removeBatch(deletions: List[Key]): F[Unit]
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/storage/impl/LevelDbCollection.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/storage/impl/LevelDbCollection.scala
@@ -1,0 +1,180 @@
+package io.constellationnetwork.metagraph_sdk.storage.impl
+
+import java.nio.file.{Files, Path}
+
+import cats.data.EitherT
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryCodec
+import io.constellationnetwork.metagraph_sdk.storage.Collection
+
+import io.circe.{Decoder, Encoder}
+import org.iq80.leveldb._
+import org.iq80.leveldb.impl.Iq80DBFactory
+
+object LevelDbCollection {
+
+  implicit private class localEncoderOps[F[_]: Sync, T: Encoder](t: T) {
+    def toJsonBytes: F[Array[Byte]] = JsonBinaryCodec.simpleJsonSerialization(t)
+  }
+
+  implicit private class localDecoderOps[F[_]: Sync](bytes: Array[Byte]) {
+    def fromJsonBytes[T: Decoder]: F[Either[Throwable, T]] = JsonBinaryCodec.simpleJsonDeserialization(bytes)
+  }
+
+  def make[F[_]: Sync, Key: Encoder: Decoder, Value: Encoder: Decoder](
+    path: Path
+  ): Resource[F, Collection[F, Key, Value]] = for {
+    ldbFactory <- Resource.eval(Sync[F].delay(Iq80DBFactory.factory: DBFactory))
+    db         <- LevelDbCollection.makeDb[F](path, ldbFactory)
+  } yield new Collection[F, Key, Value] {
+
+    def put(id: Key, t: Value): F[Unit] = for {
+      idB <- id.toJsonBytes
+      tB  <- t.toJsonBytes
+      _   <- Sync[F].blocking(db.put(idB, tB))
+    } yield ()
+
+    def remove(id: Key): F[Unit] =
+      id.toJsonBytes.flatMap { idB =>
+        Sync[F].blocking(db.delete(idB))
+      }
+
+    def get(id: Key): F[Option[Value]] =
+      id.toJsonBytes
+        .flatMap(idB => Sync[F].blocking(Option(db.get(idB))))
+        .flatMap(_.flatTraverse(_.fromJsonBytes[Value].map(_.toOption)))
+
+    def contains(id: Key): F[Boolean] =
+      id.toJsonBytes.flatMap { idB =>
+        Sync[F].blocking(db.get(idB)).map(_ != null)
+      }
+
+    def putBatch(updates: List[(Key, Value)]): F[Unit] =
+      createWriteResource.use { case (batch, wo) =>
+        for {
+          _ <- updates.traverse_ { case (id, t) =>
+            (id.toJsonBytes, t.toJsonBytes).tupled.map { case (idB, tB) => batch.put(idB, tB) }
+          }
+          _ <- Sync[F].blocking(db.write(batch, wo.sync(true)))
+        } yield ()
+      }
+
+    def removeBatch(deletions: List[Key]): F[Unit] =
+      createWriteResource.use { case (batch, wo) =>
+        for {
+          _ <- deletions.traverse_ { id =>
+            id.toJsonBytes.map(idB => batch.delete(idB))
+          }
+          _ <- Sync[F].blocking(db.write(batch, wo.sync(true)))
+        } yield ()
+      }
+
+    def getBatch(keys: List[Key]): F[List[(Key, Option[Value])]] =
+      createReadResource.use { readOptions =>
+        keys.traverse { id =>
+          id.toJsonBytes
+            .flatMap(idB => Sync[F].blocking(Option(db.get(idB, readOptions))))
+            .flatMap(_.flatTraverse(_.fromJsonBytes[Value].map(_.toOption)))
+            .map((id, _))
+        }
+      }
+
+    def getWithFilter(
+      cond: (Key, Value) => Boolean
+    ): F[List[(Key, Value)]] = loopWithConditionAndLimit(cond)
+
+    private def loopWithConditionAndLimit(
+      cond:  (Key, Value) => Boolean,
+      limit: Int = Int.MaxValue
+    ): F[List[(Key, Value)]] = {
+      def loop(
+        iter:  DBIterator,
+        buf:   List[(Key, Value)],
+        count: Int = 0
+      ): F[List[(Key, Value)]] =
+        Sync[F].tailRecM((iter, buf, count)) { case (_iter, _buf, _count) =>
+          if (!_iter.hasNext || _count >= limit) Sync[F].pure(Right(_buf))
+          else {
+            (for {
+              entry <- EitherT(Sync[F].delay(_iter.next()).attempt)
+              key   <- EitherT(entry.getKey.fromJsonBytes[Key])
+              value <- EitherT(entry.getValue.fromJsonBytes[Value])
+            } yield (key, value)).value.flatMap {
+              case Left(_) => Sync[F].pure(Right(_buf))
+              case Right((key, value)) =>
+                val newBuffer = if (cond(key, value)) _buf :+ (key, value) else _buf
+                Sync[F].pure(Left((_iter, newBuffer, _count + 1)))
+            }
+          }
+        }
+
+      createIterResource.use { case (iter, _) =>
+        loop(iter, List.empty[(Key, Value)])
+      }
+    }
+
+    private def createReadResource: Resource[F, ReadOptions] =
+      Resource.make {
+        for {
+          snapshot <- Sync[F].delay(db.getSnapshot)
+          ro = new ReadOptions().snapshot(snapshot)
+        } yield ro
+      } { ro =>
+        Sync[F].delay(ro.snapshot().close())
+      }
+
+    private def createWriteResource: Resource[F, (WriteBatch, WriteOptions)] =
+      Resource.make {
+        Sync[F].delay((db.createWriteBatch(), new WriteOptions()))
+      } { case (batch, _) =>
+        Sync[F].delay(batch.close())
+      }
+
+    private def createIterResource: Resource[F, (DBIterator, ReadOptions)] =
+      Resource.make {
+        for {
+          snapshot <- Sync[F].delay(db.getSnapshot)
+          ro = new ReadOptions().snapshot(snapshot)
+          iter <- Sync[F].delay(db.iterator(ro))
+          _    <- Sync[F].delay(iter.seekToFirst())
+        } yield (iter, ro)
+      } { case (iter, ro) =>
+        for {
+          _ <- Sync[F].delay(iter.close())
+          _ <- Sync[F].delay(ro.snapshot().close())
+        } yield ()
+      }
+  }
+
+  def makeDb[F[_]: Sync](
+    baseDirectory:   Path,
+    factory:         DBFactory,
+    createIfMissing: Boolean = true,
+    paranoidChecks:  Option[Boolean] = None,
+    blockSize:       Option[Int] = None,
+    cacheSize:       Option[Long] = None,
+    maxOpenFiles:    Option[Int] = None,
+    compressionType: Option[CompressionType] = None
+  ): Resource[F, DB] = {
+    val options = new Options
+    options.createIfMissing(createIfMissing)
+    paranoidChecks.foreach(options.paranoidChecks)
+    blockSize.foreach(options.blockSize)
+    cacheSize.foreach(options.cacheSize)
+    maxOpenFiles.foreach(options.maxOpenFiles)
+    compressionType.foreach(options.compressionType)
+
+    val dbF =
+      Sync[F].whenA(createIfMissing)(Sync[F].blocking(Files.createDirectories(baseDirectory))) >>
+      Sync[F].blocking {
+        factory.open(
+          baseDirectory.toFile,
+          options
+        )
+      }
+
+    Resource.fromAutoCloseable(dbF)
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/storage/impl/RefMapCollection.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/storage/impl/RefMapCollection.scala
@@ -1,0 +1,39 @@
+package io.constellationnetwork.metagraph_sdk.storage.impl
+
+import cats.effect.{Ref, Sync}
+import cats.implicits.toFunctorOps
+
+import io.constellationnetwork.metagraph_sdk.storage.Collection
+
+object RefMapCollection {
+
+  def make[F[_]: Sync, Key, Value]: F[Collection[F, Key, Value]] =
+    Ref.of[F, Map[Key, Value]](Map.empty).map { store =>
+      new Collection[F, Key, Value] {
+
+        override def get(id: Key): F[Option[Value]] =
+          store.get.map(_.get(id))
+
+        override def getBatch(ids: List[Key]): F[List[(Key, Option[Value])]] =
+          store.get.map(m => ids.map(id => (id, m.get(id))))
+
+        override def contains(id: Key): F[Boolean] =
+          store.get.map(_.contains(id))
+
+        override def getWithFilter(cond: (Key, Value) => Boolean): F[List[(Key, Value)]] =
+          store.get.map(_.toList.filter(cond.tupled))
+
+        override def put(id: Key, t: Value): F[Unit] =
+          store.update(_.updated(id, t))
+
+        override def remove(id: Key): F[Unit] =
+          store.update(_ - id)
+
+        override def putBatch(updates: List[(Key, Value)]): F[Unit] =
+          store.update(_ ++ updates)
+
+        override def removeBatch(deletions: List[Key]): F[Unit] =
+          store.update(_ -- deletions)
+      }
+    }
+}

--- a/src/test/scala/generators/package.scala
+++ b/src/test/scala/generators/package.scala
@@ -1,0 +1,21 @@
+import org.scalacheck.Gen
+
+package object generators {
+
+  // Key-Value pairs generator
+  val kvGen: Gen[(Int, String)] = for {
+    key   <- Gen.posNum[Int]
+    value <- Gen.alphaStr.suchThat(_.nonEmpty)
+  } yield (key, value)
+
+  // Generate a list of unique Key-Value pairs
+  def kvListGenUniqueKeys(n: Int, start: Int = 1): Gen[List[(Int, String)]] =
+    Gen.listOfN(n, Gen.alphaStr.suchThat(_.nonEmpty)).map { values =>
+      (start until start + n).toList.zip(values)
+    }
+
+  def nonEmptyStringListGen(start: Int, end: Int): Gen[List[String]] = for {
+    size <- Gen.chooseNum(start, end)
+    list <- Gen.listOfN(size, Gen.alphaStr.suchThat(_.nonEmpty))
+  } yield list
+}

--- a/src/test/scala/storage/LevelDbCollectionSuite.scala
+++ b/src/test/scala/storage/LevelDbCollectionSuite.scala
@@ -1,0 +1,118 @@
+package storage
+
+import java.io.IOException
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+import cats.data.NonEmptyList
+import cats.effect.{IO, Resource}
+
+import io.constellationnetwork.metagraph_sdk.storage.Collection
+import io.constellationnetwork.metagraph_sdk.storage.impl.LevelDbCollection
+
+import generators.kvListGenUniqueKeys
+import weaver.IOSuite
+import weaver.scalacheck.Checkers
+
+object LevelDbCollectionSuite extends IOSuite with Checkers {
+
+  // ensure tests are run serially
+  override def maxParallelism = 1
+
+  // tests share the same mutable resource
+  override type Res = Collection[IO, Int, String]
+
+  override def sharedResource: Resource[IO, Res] =
+    for {
+      randSuffix <- Resource.eval(IO(scala.util.Random.alphanumeric.take(10).mkString))
+      tmpDbFile  <- Resource.make(IO(Files.createTempDirectory(s"leveldb_${randSuffix}")))(deleteRecursively)
+      store      <- LevelDbCollection.make[IO, Int, String](tmpDbFile)
+    } yield store
+
+  private def deleteRecursively(path: Path): IO[Unit] = IO {
+    Files.walkFileTree(
+      path,
+      new SimpleFileVisitor[Path] {
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          Files.delete(file)
+          FileVisitResult.CONTINUE
+        }
+
+        override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+          Files.delete(dir)
+          FileVisitResult.CONTINUE
+        }
+      }
+    )
+  } *> IO.unit
+
+  test("put stores a value and allows it to be removed successfully") { store =>
+    for {
+      _      <- store.put(1, "A")
+      value1 <- store.get(1)
+      _      <- store.remove(1)
+      value2 <- store.get(1)
+    } yield expect(value1.contains("A") && value2.isEmpty)
+  }
+
+  test("contains confirms presence of a value after it is stored") { store =>
+    for {
+      _        <- store.put(2, "B")
+      contains <- store.contains(2)
+    } yield expect(contains)
+  }
+
+  test("getWithFilter returns only values that match the specified filter") { store =>
+    for {
+      _      <- store.putBatch(List((3, "C"), (4, "D")))
+      values <- store.getWithFilter((_, v) => v == "C")
+      expected = List((3, "C"))
+    } yield expect(values == expected)
+  }
+
+  test("getUnsafe returns a value when it exists") { store =>
+    for {
+      _     <- store.put(5, "E")
+      value <- store.getUnsafe(5)
+    } yield expect(value == "E")
+  }
+
+  test("getUnsafe throws an exception when the requested value does not exist") { store =>
+    for {
+      result <- store.getUnsafe(42).attempt
+    } yield result match {
+      case Left(e: NoSuchElementException) => expect(e.getMessage == s"Element not found. id=42")
+      case _                               => failure("Exception not caught")
+    }
+  }
+
+  test("getBatch retrieves a batch of key-value pairs and filters them correctly") { store =>
+    for {
+      _        <- store.putBatch(List((6, "F"), (7, "G")))
+      values   <- store.getBatch(List(6, 7))
+      filtered <- store.getWithFilter((_, v) => v == "F")
+    } yield expect(values.toSet == Set((6, Some("F")), (7, Some("G")))) && expect(filtered == List((6, "F")))
+  }
+
+  test("putBatch stores key-value pairs and getBatch retrieves them correctly") { store =>
+    for {
+      kvPairs <- IO.fromOption(kvListGenUniqueKeys(999, 1000).sample.map(NonEmptyList.fromListUnsafe))(
+        new RuntimeException("Failed to generate key-value list")
+      )
+      (keys, _) = kvPairs.toList.unzip
+      _      <- store.putBatch(kvPairs.toList)
+      actual <- store.getBatch(keys).map(_.flatMap { case (i, maybeStr) => maybeStr.map(str => (i, str)) })
+      expected = kvPairs.toList
+    } yield expect(actual == expected)
+  }
+
+  test("deleteBatch removes a batch of keys and confirms they no longer exist") { store =>
+    for {
+      kvPairs <- IO.fromOption(kvListGenUniqueKeys(999, 2000).sample.map(NonEmptyList.fromListUnsafe))(
+        new RuntimeException("Failed to generate key-value list")
+      )
+      (keys, _) = kvPairs.toList.unzip
+      actual <- store.getBatch(keys).map(_.flatMap { case (i, maybeStr) => maybeStr.map(str => (i, str)) })
+    } yield expect(actual.isEmpty)
+  }
+}

--- a/src/test/scala/storage/RefMapCollectionSuite.scala
+++ b/src/test/scala/storage/RefMapCollectionSuite.scala
@@ -1,0 +1,107 @@
+package storage
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.storage.Collection
+import io.constellationnetwork.metagraph_sdk.storage.impl.RefMapCollection
+
+import generators.kvListGenUniqueKeys
+import weaver._
+import weaver.scalacheck.Checkers
+
+object RefMapCollectionSuite extends SimpleIOSuite with Checkers {
+
+  private val storeIO: IO[Collection[IO, Int, String]] = RefMapCollection.make[IO, Int, String]
+
+  test("put stores values, and get retrieves them correctly") {
+    forall(kvListGenUniqueKeys(100).map(NonEmptyList.fromListUnsafe)) { kvPairs =>
+      for {
+        store  <- storeIO
+        _      <- kvPairs.traverse(pair => store.put(pair._1, pair._2))
+        actual <- kvPairs.traverse(pair => store.get(pair._1))
+        expected = kvPairs.map(_._2).toList
+      } yield expect(actual.toList.flatten == expected)
+    }
+  }
+
+  test("getBatch retrieves multiple values correctly") {
+    forall(kvListGenUniqueKeys(100).map(NonEmptyList.fromListUnsafe)) { kvPairs =>
+      for {
+        store  <- storeIO
+        _      <- kvPairs.traverse(pair => store.put(pair._1, pair._2))
+        actual <- store.getBatch(kvPairs.map(_._1).toList)
+        expected = kvPairs.map(pair => (pair._1, Some(pair._2))).toList
+      } yield expect(actual == expected)
+    }
+  }
+
+  test("remove deletes a value successfully") {
+    for {
+      store <- storeIO
+      _     <- store.put(1, "A")
+      _     <- store.remove(1)
+      value <- store.get(1)
+    } yield expect(value.isEmpty)
+  }
+
+  test("putBatch stores and removeBatch deletes a batch of values correctly") {
+    forall(kvListGenUniqueKeys(100).map(NonEmptyList.fromListUnsafe)) { kvPairs =>
+      for {
+        store              <- storeIO
+        _                  <- store.putBatch(kvPairs.toList)
+        valuesBeforeDelete <- store.getBatch(kvPairs.map(_._1).toList)
+        _                  <- store.removeBatch(kvPairs.map(_._1).toList)
+        valuesAfterDelete  <- store.getBatch(kvPairs.map(_._1).toList)
+        expectedBeforeDelete = kvPairs.map(pair => pair._1 -> Some(pair._2)).toList
+        expectedAfterDelete = kvPairs.map(pair => pair._1 -> None).toList
+      } yield expect(valuesBeforeDelete == expectedBeforeDelete).and(expect(valuesAfterDelete == expectedAfterDelete))
+    }
+  }
+
+  test("contains confirms presence of a value after storing it") {
+    for {
+      store    <- storeIO
+      _        <- store.put(1, "A")
+      contains <- store.contains(1)
+    } yield expect(contains)
+  }
+
+  test("getWithFilter retrieves only values matching the specified filter") {
+    for {
+      store  <- storeIO
+      _      <- store.put(1, "A")
+      _      <- store.put(2, "B")
+      values <- store.getWithFilter((_, v) => v == "A")
+      expected = List((1, "A"))
+    } yield expect(values == expected)
+  }
+
+  test("getUnsafe returns a value when it exists") {
+    for {
+      store <- storeIO
+      _     <- store.put(1, "A")
+      value <- store.getUnsafe(1)
+    } yield expect(value == "A")
+  }
+
+  test("getUnsafe throws an exception when the requested value does not exist") {
+    for {
+      store  <- storeIO
+      result <- store.getUnsafe(42).attempt
+    } yield result match {
+      case Left(e: NoSuchElementException) => expect(e.getMessage == s"Element not found. id=42")
+      case _                               => failure("Exception not caught")
+    }
+  }
+
+  test("dump returns all stored values") {
+    for {
+      store  <- storeIO
+      _      <- store.put(1, "A")
+      _      <- store.put(2, "B")
+      values <- store.dump
+      expected = List((1, "A"), (2, "B"))
+    } yield expect(values == expected)
+  }
+}


### PR DESCRIPTION
## Purpose
This repository extracts reusable components that are helpful for developing metagraph applications such as:
- an embedded LevelDB database for persisting data to disk
- a common metagraph service template for constructing ML0 and DL1 services
- a common metagraph routes template for constructing custom HTTP endpoints
- a checkpoint service for managing ordinal linked state (i.e. calculated state)
- a Json serialization scheme with support for Stargazer signed transactions
- a Json hashing scheme to support cross-platform hash calculations
- a queue based Daemon for handling asynchronous tasks within the metagraph application

Note: This repository is 'private' for the time being but if these components are approved I would like to transition it to a public repo with the eventual goal of publishing to maven.