### PR TITLE
feat: add merkle-patricia trie impl and api

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/Node.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/Node.scala
@@ -1,0 +1,27 @@
+package io.constellationnetwork.metagraph_sdk.crypto
+
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder}
+
+trait Node {
+  def digest: Hash
+}
+
+object Node {
+
+  implicit def encodeNode(implicit digestEncoder: Encoder[Hash]): Encoder[Node] =
+    Encoder.instance { node =>
+      digestEncoder(node.digest).asJson
+    }
+
+  implicit def decodeNode(implicit digestDecoder: Decoder[Hash]): Decoder[Node] =
+    Decoder.instance { hCursor =>
+      hCursor.as[Hash].map { d =>
+        new Node {
+          override def digest: Hash = d
+        }
+      }
+    }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/MerkleCommitment.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/MerkleCommitment.scala
@@ -1,0 +1,69 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle
+
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax._
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+
+sealed trait MerkleCommitment
+
+object MerkleCommitment {
+  final case class Leaf(dataDigest: Hash) extends MerkleCommitment
+  final case class Internal(leftDigest: Hash, rightDigest: Option[Hash]) extends MerkleCommitment
+
+  object Leaf {
+
+    implicit val leafCommitmentEncoder: Encoder[Leaf] = Encoder.instance { commitment =>
+      Json.obj(
+        "dataDigest" -> commitment.dataDigest.asJson
+      )
+    }
+
+    implicit val leafCommitmentDecoder: Decoder[Leaf] =
+      Decoder.instance { hCursor =>
+        for {
+          dataDigest <- hCursor.downField("dataDigest").as[Hash]
+        } yield Leaf(dataDigest)
+      }
+  }
+
+  object Internal {
+
+    implicit val internalCommitmentEncoder: Encoder[Internal] = Encoder.instance { commitment =>
+      Json.obj(
+        "leftDigest"  -> commitment.leftDigest.asJson,
+        "rightDigest" -> commitment.rightDigest.asJson
+      )
+    }
+
+    implicit val internalCommitmentDecoder: Decoder[Internal] =
+      Decoder.instance { hCursor =>
+        for {
+          leftDigest  <- hCursor.downField("leftDigest").as[Hash]
+          rightDigest <- hCursor.downField("rightDigest").as[Option[Hash]]
+        } yield Internal(leftDigest, rightDigest)
+      }
+  }
+
+  implicit val merkleCommitmentEncoder: Encoder[MerkleCommitment] = Encoder.instance {
+    case commitment: Leaf =>
+      Json.obj(
+        "type"     -> Json.fromString("Leaf"),
+        "contents" -> commitment.asJson
+      )
+
+    case commitment: Internal =>
+      Json.obj(
+        "type"     -> Json.fromString("Internal"),
+        "contents" -> commitment.asJson
+      )
+  }
+
+  implicit val merkleCommitmentDecoder: Decoder[MerkleCommitment] = Decoder.instance { cursor =>
+    cursor.downField("type").as[String].flatMap {
+      case "Leaf"     => cursor.downField("contents").as[Leaf]
+      case "Internal" => cursor.downField("contents").as[Internal]
+      case other      => Left(DecodingFailure(s"Unknown type: $other", cursor.history))
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/MerkleInclusionProof.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/MerkleInclusionProof.scala
@@ -1,0 +1,88 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle
+
+import cats.data.Validated
+import cats.syntax.either._
+
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
+
+sealed trait MerkleProofError
+case class InvalidWitness(message: String) extends MerkleProofError
+case class InvalidSide(value: Byte) extends MerkleProofError
+
+/**
+ * Proof of inclusion for a leaf in a Merkle tree
+ *
+ * @param leafDigest The digest of the leaf being proven
+ * @param witness The path from leaf to root, with sibling digests and their positions
+ */
+final case class MerkleInclusionProof private (
+  leafDigest: Hash,
+  witness:    Seq[(Hash, MerkleInclusionProof.Side)]
+)
+
+object MerkleInclusionProof {
+
+  /**
+   * Side of a Merkle tree node (left or right child)
+   */
+  sealed trait Side {
+    def value: Byte
+  }
+  case object LeftSide extends Side { val value: Byte = 0 }
+  case object RightSide extends Side { val value: Byte = 1 }
+
+  /**
+   * Create a proof with validation
+   *
+   * @param leafDigest The digest of the leaf being proven
+   * @param witness The path from leaf to root
+   * @return A validated proof or error
+   */
+  def create(
+    leafDigest: Hash,
+    witness:    Seq[(Hash, Side)]
+  ): Validated[MerkleProofError, MerkleInclusionProof] =
+    if (witness.isEmpty) {
+      Validated.invalid(InvalidWitness("Witness path cannot be empty"))
+    } else {
+      Validated.valid(new MerkleInclusionProof(leafDigest, witness))
+    }
+
+  /**
+   * Create a proof for a single leaf with no siblings
+   *
+   * @param leafDigest The digest of the single leaf
+   * @return A proof for a tree with one leaf
+   */
+  def forSingleLeaf(leafDigest: Hash): MerkleInclusionProof =
+    new MerkleInclusionProof(leafDigest, Seq())
+
+  implicit val sideEncoder: Encoder[Side] = Encoder.encodeByte.contramap(_.value)
+
+  implicit val sideDecoder: Decoder[Side] = Decoder.decodeByte.emap {
+    case 0     => Right(LeftSide)
+    case 1     => Right(RightSide)
+    case other => Left(s"Invalid side value: $other")
+  }
+
+  implicit val proofEncoder: Encoder[MerkleInclusionProof] = (mp: MerkleInclusionProof) =>
+    Json.obj(
+      "leafDigest" -> mp.leafDigest.asJson,
+      "witness" -> mp.witness.map { case (digest, side) =>
+        Json.obj(
+          "digest" -> digest.asJson,
+          "side"   -> side.asJson
+        )
+      }.asJson
+    )
+
+  implicit val proofDecoder: Decoder[MerkleInclusionProof] = (c: HCursor) =>
+    for {
+      leafDigest <- c.downField("leafDigest").as[Hash]
+      witness    <- c.downField("witness").as[Seq[(Hash, Side)]]
+      proof <- create(leafDigest, witness).toEither.leftMap(err => DecodingFailure(s"Invalid proof: $err", c.history))
+    } yield proof
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/MerkleNode.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/MerkleNode.scala
@@ -1,0 +1,98 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle
+
+import cats.MonadThrow
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import io.constellationnetwork.metagraph_sdk.crypto.Node
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax._
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+
+sealed trait MerkleNode extends Node
+
+object MerkleNode {
+  private[merkle] val LeafPrefix: Array[Byte] = Array(0: Byte)
+  private[merkle] val InternalPrefix: Array[Byte] = Array(1: Byte)
+
+  final case class Leaf private (data: Json, digest: Hash) extends MerkleNode
+  final case class Internal private (left: MerkleNode, right: Option[MerkleNode], digest: Hash) extends MerkleNode
+
+  object Leaf {
+
+    def apply[F[_]: MonadThrow: JsonBinaryHasher](data: Json): F[Leaf] = for {
+      dataDigest <- JsonBinaryHasher[F].computeDigest(data)
+      commitment <- MerkleCommitment.Leaf(dataDigest).pure[F]
+      nodeDigest <- JsonBinaryHasher[F].computeDigest(commitment.asJson, LeafPrefix)
+    } yield Leaf(data, nodeDigest)
+
+    implicit val leafNodeEncoder: Encoder[Leaf] = Encoder.instance { node =>
+      Json.obj(
+        "data"   -> node.data,
+        "digest" -> node.digest.asJson
+      )
+    }
+
+    implicit val leafNodeDecoder: Decoder[Leaf] =
+      Decoder.instance { hCursor =>
+        for {
+          data   <- hCursor.downField("data").as[Json]
+          digest <- hCursor.downField("digest").as[Hash]
+        } yield Leaf(data, digest)
+      }
+  }
+
+  object Internal {
+
+    def apply[F[_]: MonadThrow: JsonBinaryHasher](
+      left:  MerkleNode,
+      right: Option[MerkleNode]
+    ): F[Internal] = for {
+      leftDigest     <- left.digest.pure[F]
+      rightDigestOpt <- right.map(_.digest).pure[F]
+      commitment     <- MerkleCommitment.Internal(leftDigest, rightDigestOpt).pure[F]
+      nodeDigest     <- JsonBinaryHasher[F].computeDigest(commitment.asJson, InternalPrefix)
+    } yield Internal(left, right, nodeDigest)
+
+    implicit val encodeInternalNode: Encoder[Internal] = Encoder.instance { node =>
+      Json.obj(
+        "left"   -> node.left.asJson,
+        "right"  -> node.right.asJson,
+        "digest" -> node.digest.asJson
+      )
+    }
+
+    implicit val decodeInternalNode: Decoder[Internal] =
+      Decoder.instance { hCursor =>
+        for {
+          left   <- hCursor.downField("left").as[MerkleNode]
+          right  <- hCursor.downField("right").as[Option[MerkleNode]]
+          digest <- hCursor.downField("digest").as[Hash]
+        } yield new Internal(left, right, digest)
+      }
+  }
+
+  implicit val encodeMerkleNode: Encoder[MerkleNode] = Encoder.instance {
+    case leaf: Leaf =>
+      Json.obj(
+        "type"     -> Json.fromString("Leaf"),
+        "contents" -> leaf.asJson
+      )
+    case internal: Internal =>
+      Json.obj(
+        "type"     -> Json.fromString("Internal"),
+        "contents" -> internal.asJson
+      )
+  }
+
+  implicit val decodeMerkleNode: Decoder[MerkleNode] = Decoder.instance { cursor =>
+    cursor.downField("type").as[String].flatMap {
+      case "Leaf"     => cursor.downField("contents").as[Leaf]
+      case "Internal" => cursor.downField("contents").as[Internal]
+      case other      => Left(DecodingFailure(s"Unknown type: $other", cursor.history))
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/MerkleTree.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/MerkleTree.scala
@@ -1,0 +1,67 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle
+
+import cats.MonadThrow
+import cats.implicits.{toFlatMapOps, toFunctorOps, toTraverseOps}
+import cats.syntax.applicative._
+import cats.syntax.applicativeError._
+import cats.syntax.either._
+
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+final case class MerkleTree(
+  rootNode:        MerkleNode,
+  leafDigestIndex: Map[Hash, Int]
+)
+
+object MerkleTree {
+
+  implicit def merkleTreeEncoder: Encoder[MerkleTree] = (tree: MerkleTree) =>
+    Json.obj(
+      "rootNode" -> tree.rootNode.asJson,
+      "leafDigestIndex" -> tree.leafDigestIndex.toList
+        .sortBy(_._2)
+        .map { case (digest, index) =>
+          Json.obj(
+            "digest" -> digest.asJson,
+            "index"  -> index.asJson
+          )
+        }
+        .asJson
+    )
+
+  implicit def merkleTreeDecoder: Decoder[MerkleTree] = (c: HCursor) =>
+    for {
+      rootNode        <- c.downField("rootNode").as[MerkleNode]
+      leafDigestIndex <- c.downField("leafDigestIndex").as[List[(Hash, Int)]].map(_.toMap)
+    } yield MerkleTree(rootNode, leafDigestIndex)
+
+  def create[F[_]: MonadThrow: JsonBinaryHasher, A: Encoder](data: List[A]): F[MerkleTree] = {
+    def buildNodes(nodes: List[MerkleNode]): F[MerkleNode] =
+      if (nodes.isEmpty) new RuntimeException("Input list must be non-empty").raiseError
+      else {
+        MonadThrow[F].tailRecM[List[MerkleNode], MerkleNode](nodes) {
+          case singleNode :: Nil => singleNode.asRight[List[MerkleNode]].pure[F]
+          case currentNodes @ _ =>
+            currentNodes
+              .grouped(2)
+              .toList
+              .traverse[F, MerkleNode.Internal] {
+                case Seq(leftNode, rightNode) => MerkleNode.Internal(leftNode, Some(rightNode))
+                case Seq(singleNode)          => MerkleNode.Internal(singleNode, None)
+                case _                        => new RuntimeException("Unexpected input").raiseError
+              }
+              .map(_.asLeft[MerkleNode])
+        }
+      }
+
+    for {
+      leafNodes <- data.traverse(el => MerkleNode.Leaf(el.asJson))
+      rootNode  <- buildNodes(leafNodes)
+      leafDigestIndex = leafNodes.zipWithIndex.map { case (node, index) => (node.digest, index) }.toMap
+    } yield MerkleTree(rootNode, leafDigestIndex)
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/api/MerkleProducer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/api/MerkleProducer.scala
@@ -1,0 +1,125 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle.api
+
+import cats.effect.{Ref, Sync}
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.impl.{OptimizedMerkleProducer, SimpleMerkleProducer}
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.{MerkleNode, MerkleTree}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+
+/**
+ * Type class for building and modifying Merkle trees
+ */
+trait MerkleProducer[F[_]] {
+
+  /**
+   * Get current leaves in the tree
+   *
+   * @return List of leaf nodes
+   */
+  def leaves: F[List[MerkleNode.Leaf]]
+
+  /**
+   * Build a Merkle tree from current leaves
+   *
+   * @return Built Merkle tree or error
+   */
+  def build: F[Either[TreeBuildError, MerkleTree]]
+
+  /**
+   * Update a leaf at a specific index
+   *
+   * @param index Index to update
+   * @param leaf New leaf node
+   * @return Unit if successful, error if index invalid
+   */
+  def update(index: Int, leaf: MerkleNode.Leaf): F[Either[MerkleProducerError, Unit]]
+
+  /**
+   * Append leaves to the end of the tree
+   *
+   * @param leaves Leaves to append
+   */
+  def append(leaves: List[MerkleNode.Leaf]): F[Unit]
+
+  /**
+   * Prepend leaves to the start of the tree
+   *
+   * @param leaves Leaves to prepend
+   */
+  def prepend(leaves: List[MerkleNode.Leaf]): F[Unit]
+
+  /**
+   * Remove a leaf at a specific index
+   *
+   * @param index Index to remove
+   * @return Unit if successful, error if index invalid
+   */
+  def remove(index: Int): F[Either[MerkleProducerError, Unit]]
+}
+
+object MerkleProducer {
+  def apply[F[_]](implicit producer: MerkleProducer[F]): MerkleProducer[F] = producer
+
+  /**
+   * Create an optimized producer instance
+   *
+   * @param initial Initial leaf nodes
+   * @return Optimized producer with caching
+   */
+  def make[F[_]: Sync: JsonBinaryHasher](
+    initial: List[MerkleNode.Leaf]
+  ): F[MerkleProducer[F]] =
+    Ref
+      .of[F, OptimizedMerkleProducer.ProducerState](
+        OptimizedMerkleProducer.ProducerState(
+          leaves = Vector.from(initial),
+          nodeCache = Map.empty,
+          dirtyNodes = Set.empty,
+          currentRoot = None
+        )
+      )
+      .map(new OptimizedMerkleProducer[F](_))
+
+  /**
+   * Create a simple producer instance
+   *
+   * @param initial Initial leaf nodes
+   * @return Simple producer without caching
+   */
+  def simple[F[_]: Sync: JsonBinaryHasher](
+    initial: List[MerkleNode.Leaf]
+  ): F[MerkleProducer[F]] =
+    Ref
+      .of[F, Vector[MerkleNode.Leaf]](Vector.from(initial))
+      .map(new SimpleMerkleProducer[F](_))
+
+  /**
+   * Provides syntax extensions for more ergonomic tree building
+   *
+   * Import xyz.kd5ujc.accumulators.merkle.api.MerkleProducer.syntax._ to use these extensions
+   */
+  object syntax {
+
+    implicit class MerkleLeafOps(val leaves: List[MerkleNode.Leaf]) extends AnyVal {
+
+      /**
+       * Build a new Merkle tree from these leaves
+       *
+       * @return Built Merkle tree
+       */
+      def buildTree[F[_]: Sync: JsonBinaryHasher]: F[Either[TreeBuildError, MerkleTree]] =
+        make[F](leaves).flatMap(_.build)
+    }
+  }
+}
+
+sealed trait MerkleProducerError extends Throwable
+
+case class InvalidIndex(index: Int, size: Int) extends MerkleProducerError {
+  override def getMessage: String = s"Invalid index $index, size is $size"
+}
+
+case class TreeBuildError(message: String) extends MerkleProducerError {
+  override def getMessage: String = message
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/api/MerkleProver.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/api/MerkleProver.scala
@@ -1,0 +1,144 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle.api
+
+import cats.MonadThrow
+import cats.implicits.toTraverseOps
+import cats.syntax.applicative._
+import cats.syntax.either._
+import cats.syntax.functor._
+
+import scala.annotation.tailrec
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.MerkleInclusionProof.Side
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.{MerkleInclusionProof, MerkleNode, MerkleTree}
+import io.constellationnetwork.security.hash.Hash
+
+/**
+ * Type class for generating Merkle inclusion proofs
+ */
+trait MerkleProver[F[_]] {
+
+  /**
+   * Generate a proof that a leaf exists in the tree
+   *
+   * @param leaf The leaf node to prove inclusion for
+   * @return A proof of inclusion if the leaf exists
+   */
+  def attestLeaf(leaf: MerkleNode.Leaf): F[Either[MerkleProofError, MerkleInclusionProof]]
+
+  /**
+   * Generate a proof that a digest exists as a leaf in the tree
+   *
+   * @param digest The digest to prove inclusion for
+   * @return A proof of inclusion if the digest exists as a leaf
+   */
+  def attestDigest(digest: Hash): F[Either[MerkleProofError, MerkleInclusionProof]]
+
+  /**
+   * Generate a proof for a leaf at a specific index
+   *
+   * @param index The index of the leaf
+   * @return A proof of inclusion if the index is valid
+   */
+  def attestIndex(index: Int): F[Either[MerkleProofError, MerkleInclusionProof]]
+}
+
+object MerkleProver {
+  def apply[F[_]](implicit prover: MerkleProver[F]): MerkleProver[F] = prover
+
+  /**
+   * Create a prover instance from a Merkle tree
+   */
+  def make[F[_]: MonadThrow](tree: MerkleTree): MerkleProver[F] =
+    new MerkleProver[F] {
+
+      def attestLeaf(leaf: MerkleNode.Leaf): F[Either[MerkleProofError, MerkleInclusionProof]] =
+        attestDigest(leaf.digest)
+
+      def attestDigest(digest: Hash): F[Either[MerkleProofError, MerkleInclusionProof]] =
+        tree.leafDigestIndex
+          .get(digest)
+          .map(proofByIndex)
+          .getOrElse(LeafNotFound(digest).asLeft.pure[F].widen)
+
+      def attestIndex(index: Int): F[Either[MerkleProofError, MerkleInclusionProof]] =
+        proofByIndex(index)
+
+      private def proofByIndex(index: Int): F[Either[MerkleProofError, MerkleInclusionProof]] = {
+        // bitwise shift operation to calculate log2 by counting number of divisions by 2
+        @tailrec
+        def log2(n: Int, acc: Int = 0): Int =
+          if (n <= 1) acc
+          else log2(n >> 1, acc + 1)
+
+        val maxDepth = log2(tree.leafDigestIndex.size)
+
+        @tailrec
+        def loop(
+          node:  MerkleNode,
+          acc:   Seq[Option[(Hash, Side)]],
+          depth: Int
+        ): Option[(MerkleNode.Leaf, Seq[Option[(Hash, Side)]])] =
+          node match {
+            case MerkleNode.Internal(left, right, _) =>
+              if (((index >> (maxDepth - depth)) & 1) == 0) {
+                loop(left, right.map(_.digest).map((_, MerkleInclusionProof.RightSide)) +: acc, depth + 1)
+              } else {
+                loop(right.get, Some((left.digest, MerkleInclusionProof.LeftSide)) +: acc, depth + 1)
+              }
+
+            case n: MerkleNode.Leaf =>
+              Some((n, acc))
+          }
+
+        if (index < 0 || index >= tree.leafDigestIndex.size)
+          InvalidLeafIndex(index, tree.leafDigestIndex.size).asLeft[MerkleInclusionProof].pure[F].widen
+        else
+          loop(tree.rootNode, Seq(), 0)
+            .flatMap { case (leaf, witness) =>
+              witness.sequence.map(MerkleInclusionProof(leaf.digest, _))
+            }
+            .toRight[MerkleProofError](InvalidLeafIndex(index, tree.leafDigestIndex.size))
+            .pure[F]
+      }
+    }
+
+  /**
+   * Provides syntax extensions for more ergonomic proof generation
+   *
+   * Import xyz.kd5ujc.accumulators.merkle.api.MerkleProver.syntax._ to use these extensions
+   */
+  object syntax {
+
+    implicit class MerkleLeafOps(val leaf: MerkleNode.Leaf) extends AnyVal {
+
+      /**
+       * Generate a proof that this leaf exists in the tree
+       *
+       * @return A proof of inclusion if the leaf exists
+       */
+      def attestInclusion[F[_]](implicit P: MerkleProver[F]): F[Either[MerkleProofError, MerkleInclusionProof]] =
+        P.attestLeaf(leaf)
+    }
+
+    implicit class MerkleDigestOps(val digest: Hash) extends AnyVal {
+
+      /**
+       * Generate a proof that this digest exists as a leaf in the tree
+       *
+       * @return A proof of inclusion if the digest exists as a leaf
+       */
+      def attestInclusion[F[_]](implicit P: MerkleProver[F]): F[Either[MerkleProofError, MerkleInclusionProof]] =
+        P.attestDigest(digest)
+    }
+  }
+}
+
+sealed trait MerkleProofError extends Throwable
+
+case class LeafNotFound(digest: Hash) extends MerkleProofError {
+  override def getMessage: String = s"Leaf with digest ${digest.value} not found"
+}
+
+case class InvalidLeafIndex(index: Int, size: Int) extends MerkleProofError {
+  override def getMessage: String = s"Invalid leaf index $index, tree size is $size"
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/api/MerkleVerifier.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/api/MerkleVerifier.scala
@@ -1,0 +1,101 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle.api
+
+import cats.syntax.applicative._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.option._
+import cats.{Applicative, MonadThrow}
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.{MerkleCommitment, MerkleInclusionProof, MerkleNode}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+import io.constellationnetwork.security.hash.Hash
+
+/**
+ * Type class for verifying Merkle inclusion proofs
+ */
+trait MerkleVerifier[F[_]] {
+
+  /**
+   * Confirm that a Merkle inclusion proof is valid
+   *
+   * @param proof The inclusion proof to verify
+   * @return True if the proof is valid for this tree's root
+   */
+  def confirm(proof: MerkleInclusionProof): F[Boolean]
+
+  /**
+   * Confirm that a leaf exists in the tree
+   *
+   * @param leaf The leaf node to verify
+   * @param proof The inclusion proof for this leaf
+   * @return True if the leaf exists and the proof is valid
+   */
+  def confirmLeaf(leaf: MerkleNode.Leaf, proof: MerkleInclusionProof)(implicit app: Applicative[F]): F[Boolean] =
+    if (leaf.digest == proof.leafDigest) confirm(proof)
+    else false.pure[F]
+}
+
+object MerkleVerifier {
+  def apply[F[_]](implicit verifier: MerkleVerifier[F]): MerkleVerifier[F] = verifier
+
+  /**
+   * Create a verifier for a specific root digest
+   */
+  private def fromRoot[F[_]: MonadThrow](root: Hash): MerkleVerifier[F] =
+    new MerkleVerifier[F] {
+
+      def confirm(proof: MerkleInclusionProof): F[Boolean] = {
+        def combine(a: Hash, b: Hash): F[Hash] =
+          MerkleCommitment
+            .Internal(a, b.some)
+            .computePrefixDigest(MerkleNode.InternalPrefix)
+
+        proof.witness
+          .foldLeftM(proof.leafDigest) {
+            case (acc, (digest, MerkleInclusionProof.LeftSide))  => combine(digest, acc)
+            case (acc, (digest, MerkleInclusionProof.RightSide)) => combine(acc, digest)
+            case (acc, _)                                        => acc.pure[F]
+          }
+          .map(_ == root)
+      }
+    }
+
+  /**
+   * Create a verifier instance from a root
+   */
+  def make[F[_]: MonadThrow](root: Hash): MerkleVerifier[F] =
+    fromRoot(root)
+
+  /**
+   * Provides syntax extensions for more ergonomic Merkle verification
+   *
+   * Import xyz.kd5ujc.accumulators.merkle.api.MerkleVerifier.syntax._ to use these extensions
+   */
+  object syntax {
+
+    implicit class MerkleVerifierOps(val proof: MerkleInclusionProof) extends AnyVal {
+
+      /**
+       * Confirm this proof is valid
+       *
+       * @return True if the proof is valid for the tree's root
+       */
+      def confirm[F[_]](implicit V: MerkleVerifier[F]): F[Boolean] =
+        V.confirm(proof)
+    }
+
+    implicit class MerkleLeafOps(val leaf: MerkleNode.Leaf) extends AnyVal {
+
+      /**
+       * Confirm this leaf exists in the tree
+       *
+       * @param proof The inclusion proof for this leaf
+       * @return True if the leaf exists and the proof is valid
+       */
+      def confirmInclusion[F[_]](
+        proof: MerkleInclusionProof
+      )(implicit V: MerkleVerifier[F], app: Applicative[F]): F[Boolean] =
+        V.confirmLeaf(leaf, proof)
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/impl/OptimizedMerkleProducer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/impl/OptimizedMerkleProducer.scala
@@ -1,0 +1,169 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle.impl
+
+import cats.effect.{Ref, Sync}
+import cats.syntax.all._
+
+import scala.annotation.tailrec
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.api.{
+  InvalidIndex,
+  MerkleProducer,
+  MerkleProducerError,
+  TreeBuildError
+}
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.{MerkleNode, MerkleTree}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+class OptimizedMerkleProducer[F[_]: Sync: JsonBinaryHasher](
+  stateRef: Ref[F, OptimizedMerkleProducer.ProducerState]
+) extends MerkleProducer[F] {
+
+  def leaves: F[List[MerkleNode.Leaf]] =
+    stateRef.get.map(_.leaves.toList)
+
+  def build: F[Either[TreeBuildError, MerkleTree]] =
+    stateRef.get.flatMap { state =>
+      if (state.leaves.isEmpty) {
+        TreeBuildError("Cannot build tree with no leaves").asLeft[MerkleTree].pure[F]
+      } else {
+        state.currentRoot match {
+          case Some(root) if state.dirtyNodes.isEmpty => root.asRight[TreeBuildError].pure[F]
+          case _ =>
+            rebuildTree(state).flatMap { tree =>
+              stateRef
+                .update(
+                  _.copy(
+                    currentRoot = Some(tree),
+                    dirtyNodes = Set.empty
+                  )
+                )
+                .as(tree.asRight[TreeBuildError])
+            }
+        }
+      }
+    }
+
+  private def rebuildTree(state: OptimizedMerkleProducer.ProducerState): F[MerkleTree] = {
+    def getOrBuildNode(left: MerkleNode, rightOpt: Option[MerkleNode]): F[MerkleNode] =
+      state.nodeCache.get(left.digest) match {
+        case Some(cached) if !state.dirtyNodes.contains(left.digest) => cached.pure[F]
+        case _ =>
+          MerkleNode
+            .Internal(left, rightOpt)
+            .flatTap { node =>
+              stateRef.update { s =>
+                s.copy(nodeCache = s.nodeCache + (left.digest -> node))
+              }
+            }
+            .widen
+      }
+
+    def buildLevel(nodes: List[MerkleNode]): F[MerkleNode] =
+      Sync[F].tailRecM(nodes) { currentLevel =>
+        if (currentLevel.length <= 1) currentLevel.head.asRight[List[MerkleNode]].pure[F]
+        else {
+          currentLevel
+            .grouped(2)
+            .toList
+            .traverse[F, MerkleNode] {
+              case left :: right :: Nil => getOrBuildNode(left, Some(right))
+              case left :: Nil          => getOrBuildNode(left, None)
+              case _                    => new RuntimeException("Unexpected grouping").raiseError
+            }
+            .map(_.asLeft[MerkleNode])
+        }
+      }
+
+    buildLevel(state.leaves.toList).map { rootNode =>
+      MerkleTree(
+        rootNode,
+        state.leaves.zipWithIndex.map { case (leaf, idx) =>
+          (leaf.digest, idx)
+        }.toMap
+      )
+    }
+  }
+
+  def update(index: Int, leaf: MerkleNode.Leaf): F[Either[MerkleProducerError, Unit]] =
+    stateRef.get.flatMap { state =>
+      if (index < 0 || index >= state.leaves.size) {
+        InvalidIndex(index, state.leaves.size).asLeft[Unit].pure[F].widen
+      } else {
+        val dirtyPath = getPathToRoot(state, index)
+        stateRef
+          .update { s =>
+            s.copy(
+              leaves = s.leaves.updated(index, leaf),
+              dirtyNodes = s.dirtyNodes ++ dirtyPath,
+              currentRoot = None
+            )
+          }
+          .map(_.asRight[MerkleProducerError])
+      }
+    }
+
+  def append(newLeaves: List[MerkleNode.Leaf]): F[Unit] =
+    stateRef.update { state =>
+      val startIdx = state.leaves.size
+      val dirtyPath = (startIdx until startIdx + newLeaves.size).flatMap(getPathToRoot(state, _))
+      state.copy(
+        leaves = state.leaves ++ newLeaves,
+        dirtyNodes = state.dirtyNodes ++ dirtyPath,
+        currentRoot = None
+      )
+    }
+
+  def prepend(newLeaves: List[MerkleNode.Leaf]): F[Unit] =
+    stateRef.update { state =>
+      state.copy(
+        leaves = Vector.from(newLeaves) ++ state.leaves,
+        nodeCache = Map.empty,
+        dirtyNodes = Set.empty,
+        currentRoot = None
+      )
+    }
+
+  def remove(index: Int): F[Either[MerkleProducerError, Unit]] =
+    stateRef.get.flatMap { state =>
+      if (index < 0 || index >= state.leaves.size) {
+        InvalidIndex(index, state.leaves.size).asLeft[Unit].pure[F].widen
+      } else {
+        val dirtyPath = getPathToRoot(state, index)
+        stateRef
+          .update { s =>
+            s.copy(
+              leaves = s.leaves.patch(index, Vector(), 1),
+              dirtyNodes = s.dirtyNodes ++ dirtyPath,
+              currentRoot = None
+            )
+          }
+          .map(_.asRight[MerkleProducerError])
+      }
+    }
+
+  private def getPathToRoot(state: OptimizedMerkleProducer.ProducerState, index: Int): Set[Hash] = {
+    @tailrec
+    def loop(idx: Int, acc: Set[Hash]): Set[Hash] =
+      if (idx == 0) acc
+      else {
+        val parentIdx = (idx - 1) / 2
+        state.nodeCache.get(state.leaves(parentIdx).digest) match {
+          case Some(parent) => loop(parentIdx, acc + parent.digest)
+          case None         => acc
+        }
+      }
+
+    loop(index, Set.empty)
+  }
+}
+
+object OptimizedMerkleProducer {
+
+  case class ProducerState(
+    leaves:      Vector[MerkleNode.Leaf],
+    nodeCache:   Map[Hash, MerkleNode],
+    dirtyNodes:  Set[Hash],
+    currentRoot: Option[MerkleTree]
+  )
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/impl/SimpleMerkleProducer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/merkle/impl/SimpleMerkleProducer.scala
@@ -1,0 +1,49 @@
+package io.constellationnetwork.metagraph_sdk.crypto.merkle.impl
+
+import cats.effect.{Ref, Sync}
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.api.{
+  InvalidIndex,
+  MerkleProducer,
+  MerkleProducerError,
+  TreeBuildError
+}
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.{MerkleNode, MerkleTree}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+
+class SimpleMerkleProducer[F[_]: Sync: JsonBinaryHasher](
+  stateRef: Ref[F, Vector[MerkleNode.Leaf]]
+) extends MerkleProducer[F] {
+
+  override def leaves: F[List[MerkleNode.Leaf]] =
+    stateRef.get.map(_.toList)
+
+  override def build: F[Either[TreeBuildError, MerkleTree]] =
+    stateRef.get.flatMap { leaves =>
+      if (leaves.isEmpty) TreeBuildError("Cannot build tree with no leaves").asLeft[MerkleTree].pure[F]
+      else MerkleTree.create(leaves.toList).map(_.asRight[TreeBuildError])
+    }
+
+  def update(index: Int, leaf: MerkleNode.Leaf): F[Either[MerkleProducerError, Unit]] =
+    stateRef.get.flatMap { leaves =>
+      if (index < 0 || index >= leaves.size) InvalidIndex(index, leaves.size).asLeft[Unit].pure[F].widen
+      else stateRef.update(_.updated(index, leaf)).map(_.asRight[MerkleProducerError])
+    }
+
+  def append(newLeaves: List[MerkleNode.Leaf]): F[Unit] =
+    stateRef.update { leaves =>
+      leaves.appendedAll(newLeaves)
+    }
+
+  def prepend(newLeaves: List[MerkleNode.Leaf]): F[Unit] =
+    stateRef.update { leaves =>
+      leaves.prependedAll(newLeaves)
+    }
+
+  def remove(index: Int): F[Either[MerkleProducerError, Unit]] =
+    stateRef.get.flatMap { leaves =>
+      if (index < 0 || index >= leaves.size) InvalidIndex(index, leaves.size).asLeft[Unit].pure[F].widen
+      else stateRef.update(_.patch(index, Vector(), 1)).map(_.asRight[MerkleProducerError])
+    }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/FixedPath.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/FixedPath.scala
@@ -1,0 +1,99 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt
+
+//package xyz.kd5ujc.accumulators.mpt
+//
+//import cats.data.Validated
+//import cats.syntax.either._
+//import cats.syntax.traverse._
+//import cats.instances.list._
+//
+//import xyz.kd5ujc.hash.{Digest, l256, l512}
+//
+//import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
+//import io.circe.syntax._
+//
+//sealed trait FixedPathError
+//case class InvalidPathLength(actual: Int, expected: Int) extends FixedPathError
+//case class InvalidNibbles(errors: List[InvalidNibble]) extends FixedPathError
+//
+///** A path in a Merkle Patricia Trie with a fixed length
+//  */
+//sealed trait FixedPath {
+//  def nibbles: Seq[Nibble]
+//  def startsWith(prefix: Seq[Nibble]): Boolean = nibbles.startsWith(prefix)
+//  def drop(n: Int): Seq[Nibble] = nibbles.drop(n)
+//  def head: Nibble = nibbles.head
+//  def tail: Seq[Nibble] = nibbles.tail
+//  override def toString: String = nibbles.mkString
+//}
+//
+//object FixedPath {
+//  private val Size256: Int = 32 // 256 bits = 32 bytes
+//  private val Size512: Int = 64 // 512 bits = 64 bytes
+//
+//  case class Path256(override val nibbles: Seq[Nibble]) extends FixedPath
+//  case class Path512(override val nibbles: Seq[Nibble]) extends FixedPath
+//
+//  /** Create a path from a digest
+//    */
+//  def fromDigest(digest: Digest): FixedPath = digest match {
+//    case d: l256 => Path256(Nibble(d))
+//    case d: l512 => Path512(Nibble(d))
+//  }
+//
+//  /** Create a path from a sequence of nibbles with validation
+//    */
+//  def fromNibbles(nibbles: Seq[Nibble]): Validated[FixedPathError, FixedPath] = {
+//    val size256 = Size256 * 2
+//    val size512 = Size512 * 2
+//    if (nibbles.length == size256)
+//      Validated.valid(Path256(nibbles))
+//    else if (nibbles.length == size512)
+//      Validated.valid(Path512(nibbles))
+//    else
+//      Validated.invalid(InvalidPathLength(nibbles.length, InvalidPathLength(nibbles.length, size256).toString))
+//  }
+//
+//  /** Create a path from a hex string with validation
+//    */
+//  def fromHexString(hex: String): Validated[FixedPathError, FixedPath] = {
+//    import cats.instances.either._
+//    import cats.instances.list._
+//    import cats.syntax.either._
+//
+//    val validatedNibbles = hex.toList.traverse(c => Nibble.validated(c).toEither)
+//    validatedNibbles.fold(
+//      errors => Validated.invalid(InvalidNibbles(errors)),
+//      nibbles => fromNibbles(nibbles)
+//    )
+//  }
+//
+//  implicit val fixedPathEncoder: Encoder[FixedPath] = {
+//    case Path256(nib) => Json.obj(
+//      "type" -> "256".asJson,
+//      "nibbles" -> Json.fromValues(nib.map(n => Json.fromString(n.toString)))
+//    )
+//    case Path512(nib) => Json.obj(
+//      "type" -> "512".asJson,
+//      "nibbles" -> Json.fromValues(nib.map(n => Json.fromString(n.toString)))
+//    )
+//  }
+//
+//  implicit val fixedPathDecoder: Decoder[FixedPath] = (c: HCursor) =>
+//    for {
+//      pathType <- c.downField("type").as[String]
+//      nibbles <- c.downField("nibbles").as[List[String]].flatMap { hexStrings =>
+//        hexStrings.traverse(s =>
+//          Nibble.validated(s.charAt(0))
+//            .toEither
+//            .leftMap(err => DecodingFailure(err.toString, c.history))
+//        )
+//      }
+//      path <- fromNibbles(nibbles).toEither.leftMap(err => DecodingFailure(err.toString, c.history))
+//      _ <- pathType match {
+//        case "256" if !path.isInstanceOf[Path256] => Left(DecodingFailure("Expected Path256", c.history))
+//        case "512" if !path.isInstanceOf[Path512] => Left(DecodingFailure("Expected Path512", c.history))
+//        case _ => Right(())
+//      }
+//    } yield path
+//}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaCommitment.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaCommitment.scala
@@ -1,0 +1,96 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt
+
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+
+sealed trait MerklePatriciaCommitment
+
+object MerklePatriciaCommitment {
+  final case class Leaf(remaining: Seq[Nibble], dataDigest: Hash) extends MerklePatriciaCommitment
+  final case class Branch(pathsDigest: Map[Nibble, Hash]) extends MerklePatriciaCommitment
+  final case class Extension(shared: Seq[Nibble], childDigest: Hash) extends MerklePatriciaCommitment
+
+  object Leaf {
+
+    implicit val leafCommitEncoder: Encoder[Leaf] =
+      Encoder.instance { node =>
+        Json.obj(
+          "remaining"  -> node.remaining.asJson(Nibble.nibbleSeqEncoder),
+          "dataDigest" -> node.dataDigest.asJson
+        )
+      }
+
+    implicit val leafCommitDecoder: Decoder[Leaf] =
+      Decoder.instance { hCursor =>
+        for {
+          remaining  <- hCursor.downField("remaining").as[Seq[Nibble]](Nibble.nibbleSeqDecoder)
+          dataDigest <- hCursor.downField("dataDigest").as[Hash]
+        } yield Leaf(remaining, dataDigest)
+      }
+  }
+
+  object Branch {
+
+    implicit val branchCommitEncoder: Encoder[Branch] =
+      Encoder.instance { node =>
+        Json.obj(
+          "pathsDigest" -> node.pathsDigest.asJson
+        )
+      }
+
+    implicit val branchCommitDecoder: Decoder[Branch] =
+      Decoder.instance { hCursor =>
+        for {
+          pathsDigest <- hCursor.downField("pathsDigest").as[Map[Nibble, Hash]]
+        } yield Branch(pathsDigest)
+      }
+  }
+
+  object Extension {
+
+    implicit val extensionCommitEncoder: Encoder[Extension] =
+      Encoder.instance { node =>
+        Json.obj(
+          "shared"      -> node.shared.asJson(Nibble.nibbleSeqEncoder),
+          "childDigest" -> node.childDigest.asJson
+        )
+      }
+
+    implicit val extensionCommitDecoder: Decoder[Extension] =
+      Decoder.instance { hCursor =>
+        for {
+          shared      <- hCursor.downField("shared").as[Seq[Nibble]](Nibble.nibbleSeqDecoder)
+          childDigest <- hCursor.downField("childDigest").as[Hash]
+        } yield Extension(shared, childDigest)
+      }
+  }
+
+  implicit val mpCommitEncoder: Encoder[MerklePatriciaCommitment] = Encoder.instance {
+    case commit: Leaf =>
+      Json.obj(
+        "type"     -> Json.fromString("Leaf"),
+        "contents" -> commit.asJson
+      )
+    case commit: Extension =>
+      Json.obj(
+        "type"     -> Json.fromString("Extension"),
+        "contents" -> commit.asJson
+      )
+    case commit: Branch =>
+      Json.obj(
+        "type"     -> Json.fromString("Branch"),
+        "contents" -> commit.asJson
+      )
+  }
+
+  implicit val mpCommitDecoder: Decoder[MerklePatriciaCommitment] = Decoder.instance { cursor =>
+    cursor.downField("type").as[String].flatMap {
+      case "Leaf"      => cursor.downField("contents").as[Leaf]
+      case "Branch"    => cursor.downField("contents").as[Branch]
+      case "Extension" => cursor.downField("contents").as[Extension]
+      case other       => Left(DecodingFailure(s"Unknown type: $other", cursor.history))
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaInclusionProof.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaInclusionProof.scala
@@ -1,0 +1,26 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt
+
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+final case class MerklePatriciaInclusionProof(
+  path:    Hash,
+  witness: List[MerklePatriciaCommitment]
+)
+
+object MerklePatriciaInclusionProof {
+
+  implicit val mpInclusionProofEncoder: Encoder[MerklePatriciaInclusionProof] = (proof: MerklePatriciaInclusionProof) =>
+    Json.obj(
+      "path"    -> proof.path.asJson,
+      "witness" -> proof.witness.asJson
+    )
+
+  implicit val mpInclusionProofDecoder: Decoder[MerklePatriciaInclusionProof] = (c: HCursor) =>
+    for {
+      path    <- c.downField("path").as[Hash]
+      witness <- c.downField("witness").as[List[MerklePatriciaCommitment]]
+    } yield MerklePatriciaInclusionProof(path, witness)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaNode.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaNode.scala
@@ -1,0 +1,132 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt
+
+import cats.MonadThrow
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import io.constellationnetwork.metagraph_sdk.crypto.Node
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaCommitment.Extension.extensionCommitEncoder
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryCodec.derive
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+
+sealed trait MerklePatriciaNode extends Node
+
+object MerklePatriciaNode {
+  private[mpt] val LeafPrefix: Array[Byte] = Array(0: Byte)
+  private[mpt] val BranchPrefix: Array[Byte] = Array(1: Byte)
+  private[mpt] val ExtensionPrefix: Array[Byte] = Array(2: Byte)
+
+  final case class Leaf private (remaining: Seq[Nibble], data: Json, digest: Hash) extends MerklePatriciaNode
+  final case class Branch private (paths: Map[Nibble, MerklePatriciaNode], digest: Hash) extends MerklePatriciaNode
+  final case class Extension private (shared: Seq[Nibble], child: Branch, digest: Hash) extends MerklePatriciaNode
+
+  object Leaf {
+
+    def apply[F[_]: MonadThrow: JsonBinaryHasher](remaining: Seq[Nibble], data: Json): F[Leaf] = for {
+      dataDigest <- JsonBinaryHasher[F].computeDigest(data)
+      commitment <- MerklePatriciaCommitment.Leaf(remaining, dataDigest).pure[F]
+      nodeDigest <- JsonBinaryHasher[F].computeDigest(commitment.asJson, LeafPrefix)
+    } yield Leaf(remaining, data, nodeDigest)
+
+    implicit val leafNodeEncoder: Encoder[Leaf] =
+      Encoder.instance { node =>
+        Json.obj(
+          "remaining" -> node.remaining.asJson(Nibble.nibbleSeqEncoder),
+          "data"      -> node.data.asJson,
+          "digest"    -> node.digest.asJson
+        )
+      }
+
+    implicit val leafNodeDecoder: Decoder[Leaf] =
+      Decoder.instance { hCursor =>
+        for {
+          remaining <- hCursor.downField("remaining").as[Seq[Nibble]](Nibble.nibbleSeqDecoder)
+          data      <- hCursor.downField("data").as[Json]
+          digest    <- hCursor.downField("digest").as[Hash]
+        } yield new Leaf(remaining, data, digest)
+      }
+  }
+
+  object Branch {
+
+    def apply[F[_]: MonadThrow: JsonBinaryHasher](paths: Map[Nibble, MerklePatriciaNode]): F[Branch] = for {
+      pathDigests <- paths.toSeq.sortBy(_._1.value).map { case (k, v) => k -> v.digest }.toMap.pure[F]
+      commitment  <- MerklePatriciaCommitment.Branch(pathDigests).pure[F]
+      nodeDigest  <- JsonBinaryHasher[F].computeDigest(commitment.asJson, BranchPrefix)
+    } yield Branch(paths, nodeDigest)
+
+    implicit val encodeBranchNode: Encoder[Branch] =
+      Encoder.instance { node =>
+        Json.obj(
+          "paths"  -> node.paths.toSeq.sortBy(_._1.value).toMap.asJson,
+          "digest" -> node.digest.asJson
+        )
+      }
+
+    implicit val decodeBranchNode: Decoder[Branch] =
+      Decoder.instance { hCursor =>
+        for {
+          children <- hCursor.downField("paths").as[Map[Nibble, MerklePatriciaNode]]
+          digest   <- hCursor.downField("digest").as[Hash]
+        } yield new Branch(children, digest)
+      }
+  }
+
+  object Extension {
+
+    def apply[F[_]: MonadThrow: JsonBinaryHasher](shared: Seq[Nibble], child: Branch): F[Extension] = for {
+      commitment <- MerklePatriciaCommitment.Extension(shared, child.digest).pure[F]
+      nodeDigest <- JsonBinaryHasher[F].computeDigest(commitment, ExtensionPrefix)
+    } yield Extension(shared, child, nodeDigest)
+
+    implicit val encodeExtensionNode: Encoder[Extension] =
+      Encoder.instance { node =>
+        Json.obj(
+          "shared" -> node.shared.asJson(Nibble.nibbleSeqEncoder),
+          "child"  -> (node.child: MerklePatriciaNode).asJson,
+          "digest" -> node.digest.asJson
+        )
+      }
+
+    implicit val decodeExtensionNode: Decoder[Extension] =
+      Decoder.instance { hCursor =>
+        for {
+          shared <- hCursor.downField("shared").as[Seq[Nibble]](Nibble.nibbleSeqDecoder)
+          child  <- hCursor.downField("child").downField("contents").as[Branch]
+          digest <- hCursor.downField("digest").as[Hash]
+        } yield new Extension(shared, child, digest)
+      }
+  }
+
+  implicit val encodeMptNode: Encoder[MerklePatriciaNode] = Encoder.instance {
+    case node: Leaf =>
+      Json.obj(
+        "type"     -> Json.fromString("Leaf"),
+        "contents" -> node.asJson
+      )
+    case node: Extension =>
+      Json.obj(
+        "type"     -> Json.fromString("Extension"),
+        "contents" -> node.asJson
+      )
+    case node: Branch =>
+      Json.obj(
+        "type"     -> Json.fromString("Branch"),
+        "contents" -> node.asJson
+      )
+  }
+
+  implicit val decodeMptNode: Decoder[MerklePatriciaNode] = Decoder.instance { cursor =>
+    cursor.downField("type").as[String].flatMap {
+      case "Leaf"      => cursor.downField("contents").as[Leaf]
+      case "Extension" => cursor.downField("contents").as[Extension]
+      case "Branch"    => cursor.downField("contents").as[Branch]
+      case other       => Left(DecodingFailure(s"Unknown type: $other", cursor.history))
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaTrie.scala
@@ -1,0 +1,81 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt
+
+import cats.MonadThrow
+
+import scala.annotation.tailrec
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{MerklePatriciaError, MerklePatriciaProducer}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+final case class MerklePatriciaTrie(rootNode: MerklePatriciaNode)
+
+object MerklePatriciaTrie {
+
+  implicit val merkleTreeEncoder: Encoder[MerklePatriciaTrie] =
+    (tree: MerklePatriciaTrie) => Json.obj("rootNode" -> tree.rootNode.asJson)
+
+  implicit val merkleTreeDecoder: Decoder[MerklePatriciaTrie] = (c: HCursor) =>
+    c.downField("rootNode").as[MerklePatriciaNode].map(MerklePatriciaTrie(_))
+
+  /**
+   * Create a new MerklePatriciaTrie from a map of data using the optimized producer
+   */
+  def make[F[_]: JsonBinaryHasher: MonadThrow, A: Encoder](data: Map[Hash, A]): F[MerklePatriciaTrie] =
+    MerklePatriciaProducer
+      .make[F]
+      .create(data)
+
+  /**
+   * Create a new MerklePatriciaTrie from a map of data using the simple producer
+   */
+  def simple[F[_]: JsonBinaryHasher: MonadThrow, A: Encoder](data: Map[Hash, A]): F[MerklePatriciaTrie] =
+    MerklePatriciaProducer
+      .simple[F]
+      .create(data)
+
+  /**
+   * Create a new MerklePatriciaTrie from a map of data (uses simple producer for backward compatibility)
+   */
+  def create[F[_]: JsonBinaryHasher: MonadThrow, A: Encoder](data: Map[Hash, A]): F[MerklePatriciaTrie] =
+    simple(data)
+
+  /**
+   * Insert new data into an existing MerklePatriciaTrie (uses simple producer for backward compatibility)
+   */
+  def insert[F[_]: JsonBinaryHasher: MonadThrow, A: Encoder](
+    current: MerklePatriciaTrie,
+    data:    Map[Hash, A]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    MerklePatriciaProducer
+      .simple[F]
+      .insert(current, data)
+
+  /**
+   * Remove data from an existing MerklePatriciaTrie (uses simple producer for backward compatibility)
+   */
+  def remove[F[_]: JsonBinaryHasher: MonadThrow](
+    current: MerklePatriciaTrie,
+    data:    List[Hash]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    MerklePatriciaProducer
+      .simple[F]
+      .remove(current, data)
+
+  def collectLeafNodes(trie: MerklePatriciaTrie): List[MerklePatriciaNode.Leaf] = {
+
+    @tailrec
+    def traverse(nodes: List[MerklePatriciaNode], acc: List[MerklePatriciaNode.Leaf]): List[MerklePatriciaNode.Leaf] =
+      nodes match {
+        case Nil                                               => acc
+        case (head: MerklePatriciaNode.Leaf) :: tail           => traverse(tail, head :: acc)
+        case MerklePatriciaNode.Branch(paths, _) :: tail       => traverse(paths.values.toList ++ tail, acc)
+        case MerklePatriciaNode.Extension(_, child, _) :: tail => traverse(child :: tail, acc)
+      }
+
+    traverse(List(trie.rootNode), List()).reverse
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/Nibble.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/Nibble.scala
@@ -1,0 +1,99 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt
+
+import cats.data.Validated
+import cats.implicits.toTraverseOps
+import cats.syntax.bifunctor._
+
+import scala.collection.immutable.ArraySeq
+
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe._
+import io.circe.syntax.EncoderOps
+
+class Nibble private (val value: Byte) extends AnyVal {
+
+  override def toString: String = {
+    val hexChars = "0123456789abcdef".toCharArray
+    "" + hexChars(value & 0x0f)
+  }
+}
+
+object Nibble {
+  val empty: Nibble = new Nibble(0: Byte)
+
+  private val hexChars: Array[Char] = "0123456789abcdef".toCharArray
+
+  def apply(digest: Hash): Seq[Nibble] =
+    digest.value.view.map(unsafe).to(ArraySeq)
+
+  def apply(bytes: Array[Byte]): Seq[Nibble] =
+    bytes.view.flatMap(apply).to(ArraySeq)
+
+  def apply(byte: Byte): Seq[Nibble] =
+    Seq(
+      Nibble.unsafe((byte >> 4 & 0x0f).toByte),
+      Nibble.unsafe((byte & 0x0f).toByte)
+    )
+
+  def fromHexString(hexString: String): Either[InvalidNibble, Seq[Nibble]] =
+    hexString.toList.traverse(validated(_).toEither).map(_.to(ArraySeq))
+
+  def unsafe(byte: Byte): Nibble = new Nibble(byte)
+
+  def unsafe(char: Char): Nibble = char match {
+    case c if c >= '0' && c <= '9' => Nibble.unsafe((c - '0').toByte)
+    case c if c >= 'a' && c <= 'f' => Nibble.unsafe((c - 'a' + 10).toByte)
+    case c if c >= 'A' && c <= 'F' => Nibble.unsafe((c - 'A' + 10).toByte)
+    case _                         => throw new IllegalArgumentException("Invalid character: " + char)
+  }
+
+  def toBytes(nibbles: Seq[Nibble]): Array[Byte] =
+    nibbles
+      .grouped(2)
+      .collect { case Seq(high, low) =>
+        ((high.value << 4) | (low.value & 0x0f)).toByte
+      }
+      .toArray
+
+  def validated(byte: Byte): Validated[InvalidNibble, Nibble] =
+    if (byte >= 0 && byte <= 15) Validated.valid(new Nibble(byte))
+    else Validated.invalid(ByteOutOfRange)
+
+  def validated(c: Char): Validated[InvalidNibble, Nibble] = c match {
+    case c if c >= '0' && c <= '9' => Validated.valid(Nibble.unsafe((c - '0').toByte))
+    case c if c >= 'a' && c <= 'f' => Validated.valid(Nibble.unsafe((c - 'a' + 10).toByte))
+    case c if c >= 'A' && c <= 'F' => Validated.valid(Nibble.unsafe((c - 'A' + 10).toByte))
+    case _                         => Validated.invalid(CharOutOfRange)
+  }
+
+  def commonPrefix(a: Seq[Nibble], b: Seq[Nibble]): Seq[Nibble] =
+    a.zip(b)
+      .takeWhile(Function.tupled(_.value == _.value))
+      .map(_._1)
+
+  implicit val nibbleEncoder: Encoder[Nibble] = (a: Nibble) => Json.fromString("" + hexChars(a.value & 0x0f))
+
+  implicit val nibbleDecoder: Decoder[Nibble] = (c: HCursor) =>
+    c.as[String].flatMap { res =>
+      if (res.length == 1) validated(res.charAt(0)).toEither.leftMap(err => DecodingFailure(err.toString, c.history))
+      else Left(DecodingFailure("Nibble string must be of length 1", c.history))
+    }
+
+  implicit val nibbleSeqEncoder: Encoder[Seq[Nibble]] =
+    (seq: Seq[Nibble]) => seq.map(a => hexChars(a.value & 0x0f)).mkString("").asJson
+
+  implicit val nibbleSeqDecoder: Decoder[Seq[Nibble]] = (c: HCursor) =>
+    c.as[String].flatMap { res =>
+      res.toList.traverse(validated(_).toEither.leftMap(err => DecodingFailure(err.toString, c.history)))
+    }
+
+  implicit val nibbleKeyEncoder: KeyEncoder[Nibble] = (key: Nibble) => "" + hexChars(key.value & 0x0f)
+
+  implicit val nibbleKeyDecoder: KeyDecoder[Nibble] = (key: String) =>
+    if (key.length == 1) validated(key.charAt(0)).toOption else None
+}
+
+sealed trait InvalidNibble extends Throwable
+case object ByteOutOfRange extends InvalidNibble
+case object CharOutOfRange extends InvalidNibble

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaProducer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaProducer.scala
@@ -1,0 +1,38 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt.api
+
+import cats.MonadThrow
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaTrie
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.impl.{
+  OptimizedMerklePatriciaProducer,
+  SimpleMerklePatriciaProducer
+}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.Encoder
+
+trait MerklePatriciaProducer[F[_]] {
+  def create[A: Encoder](data: Map[Hash, A]): F[MerklePatriciaTrie]
+
+  def insert[A: Encoder](
+    current: MerklePatriciaTrie,
+    data:    Map[Hash, A]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]]
+
+  def remove(current: MerklePatriciaTrie, data: List[Hash]): F[Either[MerklePatriciaError, MerklePatriciaTrie]]
+}
+
+object MerklePatriciaProducer {
+  def apply[F[_]](implicit producer: MerklePatriciaProducer[F]): MerklePatriciaProducer[F] = producer
+
+  def make[F[_]: JsonBinaryHasher: MonadThrow]: MerklePatriciaProducer[F] =
+    new OptimizedMerklePatriciaProducer[F]
+
+  def simple[F[_]: JsonBinaryHasher: MonadThrow]: MerklePatriciaProducer[F] =
+    new SimpleMerklePatriciaProducer[F]
+}
+
+sealed trait MerklePatriciaError extends Throwable
+case class InvalidData(message: String) extends MerklePatriciaError
+case class OperationError(message: String) extends MerklePatriciaError

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaProver.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaProver.scala
@@ -1,0 +1,167 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt.api
+
+import cats.MonadThrow
+import cats.syntax.applicativeError._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{
+  MerklePatriciaCommitment,
+  MerklePatriciaInclusionProof,
+  MerklePatriciaNode,
+  MerklePatriciaTrie,
+  Nibble
+}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+/**
+ * Type class for generating Merkle Patricia Trie inclusion proofs
+ */
+// Interface for MerklePatriciaProver
+trait MerklePatriciaProver[F[_]] {
+
+  /**
+   * Generate a proof that a path exists in the trie
+   *
+   * @param path The path to prove inclusion for
+   * @return A proof of inclusion if the path exists, or an error
+   */
+  def attestPath(path: String): F[Either[MerklePatriciaProofError, MerklePatriciaInclusionProof]]
+
+  /**
+   * Generate a proof that a digest exists in the trie
+   *
+   * @param digest The digest to prove inclusion for
+   * @return A proof of inclusion if the digest exists, or an error
+   */
+  def attestDigest(digest: Hash): F[Either[MerklePatriciaProofError, MerklePatriciaInclusionProof]]
+}
+
+object MerklePatriciaProver {
+  def apply[F[_]](implicit prover: MerklePatriciaProver[F]): MerklePatriciaProver[F] = prover
+
+  /**
+   * Create a prover instance from a Merkle Patricia Trie
+   */
+  def make[F[_]: MonadThrow](
+    trie: MerklePatriciaTrie
+  )(implicit producer: JsonBinaryHasher[F]): MerklePatriciaProver[F] =
+    new MerklePatriciaProver[F] {
+
+      def attestPath(path: String): F[Either[MerklePatriciaProofError, MerklePatriciaInclusionProof]] =
+        JsonBinaryHasher[F]
+          .computeDigest(path)
+          .flatMap(digest => attestDigest(digest))
+          .handleError(e => ProofGenerationError(e.getMessage).asLeft[MerklePatriciaInclusionProof])
+
+      def attestDigest(digest: Hash): F[Either[MerklePatriciaProofError, MerklePatriciaInclusionProof]] = {
+        type Continue = (MerklePatriciaNode, Seq[Nibble], List[MerklePatriciaCommitment])
+        type Return = Either[MerklePatriciaProofError, List[MerklePatriciaCommitment]]
+
+        MonadThrow[F]
+          .tailRecM[Continue, Return]((trie.rootNode, Nibble(digest), List.empty[MerklePatriciaCommitment])) {
+            case (currentNode, remainingPath, acc) =>
+              currentNode match {
+                case leaf: MerklePatriciaNode.Leaf if leaf.remaining == remainingPath =>
+                  JsonBinaryHasher[F]
+                    .computeDigest(leaf.data)
+                    .map(dataDigest => MerklePatriciaCommitment.Leaf(leaf.remaining, dataDigest) :: acc)
+                    .map(commitments => commitments.asRight[MerklePatriciaProofError])
+                    .map(_.asRight[Continue])
+                    .handleError(e =>
+                      ProofGenerationError(e.getMessage).asLeft[List[MerklePatriciaCommitment]].asRight[Continue]
+                    )
+
+                case extension: MerklePatriciaNode.Extension if remainingPath.startsWith(extension.shared) =>
+                  MonadThrow[F].pure(
+                    (
+                      extension.child,
+                      remainingPath.drop(extension.shared.length),
+                      MerklePatriciaCommitment.Extension(extension.shared, extension.child.digest) :: acc
+                    ).asLeft[Return]
+                  )
+
+                case branch: MerklePatriciaNode.Branch if remainingPath.nonEmpty =>
+                  branch.paths.get(remainingPath.head) match {
+                    case Some(child) =>
+                      MonadThrow[F].pure(
+                        (
+                          child,
+                          remainingPath.tail,
+                          MerklePatriciaCommitment.Branch(
+                            branch.paths.toSeq.sortBy(_._1.value).map { case (k, v) => k -> v.digest }.toMap
+                          ) :: acc
+                        ).asLeft[Return]
+                      )
+
+                    case None =>
+                      MonadThrow[F].pure(
+                        PathNotFound(s"Path not found: ${digest.toString}")
+                          .asLeft[List[MerklePatriciaCommitment]]
+                          .asRight[Continue]
+                      )
+                  }
+
+                case _ =>
+                  MonadThrow[F].pure(
+                    InvalidNodeType(s"Unexpected node type encountered for path: ${digest.toString}")
+                      .asLeft[List[MerklePatriciaCommitment]]
+                      .asRight[Continue]
+                  )
+              }
+          }
+          .map(_.map(commitments => MerklePatriciaInclusionProof(digest, commitments)))
+          .handleError(e => ProofGenerationError(e.getMessage).asLeft[MerklePatriciaInclusionProof])
+      }
+    }
+
+  /**
+   * Provides syntax extensions for more ergonomic proof generation
+   *
+   * Import xyz.kd5ujc.accumulators.mpt.api.MerklePatriciaProver.syntax._ to use these extensions
+   */
+  object syntax {
+
+    implicit class MerklePatriciaPathOps(val path: String) extends AnyVal {
+
+      /**
+       * Generate a proof that this path exists in the trie
+       *
+       * @return A proof of inclusion if the path exists
+       */
+      def attestInclusion[F[_]](implicit
+        P: MerklePatriciaProver[F]
+      ): F[Either[MerklePatriciaProofError, MerklePatriciaInclusionProof]] =
+        P.attestPath(path)
+    }
+
+    implicit class MerklePatriciaDigestOps(val digest: Hash) extends AnyVal {
+
+      /**
+       * Generate a proof that this digest exists in the trie
+       *
+       * @return A proof of inclusion if the digest exists
+       */
+      def attestInclusion[F[_]](implicit
+        P: MerklePatriciaProver[F]
+      ): F[Either[MerklePatriciaProofError, MerklePatriciaInclusionProof]] =
+        P.attestDigest(digest)
+    }
+  }
+}
+
+sealed trait MerklePatriciaProofError extends Throwable
+
+case class PathNotFound(path: String) extends MerklePatriciaProofError {
+  override def getMessage: String = s"Path not found: $path"
+}
+
+case class InvalidNodeType(message: String) extends MerklePatriciaProofError {
+  override def getMessage: String = message
+}
+
+case class ProofGenerationError(message: String) extends MerklePatriciaProofError {
+  override def getMessage: String = message
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaVerifier.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaVerifier.scala
@@ -1,0 +1,188 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt.api
+
+import cats.MonadThrow
+import cats.syntax.applicativeError._
+import cats.syntax.either._
+import cats.syntax.functor._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{
+  MerklePatriciaCommitment,
+  MerklePatriciaInclusionProof,
+  MerklePatriciaNode,
+  Nibble
+}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+
+trait MerklePatriciaVerifier[F[_]] {
+
+  /**
+   * Confirm that a Merkle Patricia inclusion proof is valid
+   *
+   * @param proof The inclusion proof to verify
+   * @return Success if the proof is valid, error otherwise
+   */
+  def confirm(proof: MerklePatriciaInclusionProof): F[Either[MerklePatriciaVerificationError, Unit]]
+
+  /**
+   * Confirm that a path exists in the trie
+   *
+   * @param path The path to verify
+   * @param proof The inclusion proof for this path
+   * @return Success if the path exists and proof is valid
+   */
+  def confirmPath(path: String, proof: MerklePatriciaInclusionProof): F[Either[MerklePatriciaVerificationError, Unit]]
+}
+
+object MerklePatriciaVerifier {
+  def apply[F[_]](implicit verifier: MerklePatriciaVerifier[F]): MerklePatriciaVerifier[F] = verifier
+
+  /**
+   * Create a verifier for a specific root digest
+   */
+  def make[F[_]: MonadThrow](root: Hash)(implicit producer: JsonBinaryHasher[F]): MerklePatriciaVerifier[F] =
+    new MerklePatriciaVerifier[F] {
+
+      def confirm(proof: MerklePatriciaInclusionProof): F[Either[MerklePatriciaVerificationError, Unit]] = {
+        type Continue = (List[MerklePatriciaCommitment], Hash, Seq[Nibble])
+        type Return = Either[MerklePatriciaVerificationError, Unit]
+
+        def verifyLeaf(
+          nodeCommit:    MerklePatriciaCommitment.Leaf,
+          currentDigest: Hash,
+          remainingPath: Seq[Nibble]
+        ): F[Either[Continue, Return]] =
+          JsonBinaryHasher[F]
+            .computeDigest(nodeCommit.asJson, MerklePatriciaNode.LeafPrefix)
+            .map { digest =>
+              if (digest == currentDigest && remainingPath == nodeCommit.remaining)
+                ().asRight[MerklePatriciaVerificationError].asRight[Continue]
+              else InvalidNodeCommitment("Invalid leaf commitment or path mismatch").asLeft[Unit].asRight[Continue]
+            }
+            .handleError(e =>
+              InvalidNodeCommitment(s"Hash computation error: ${e.getMessage}").asLeft[Unit].asRight[Continue]
+            )
+
+        def verifyExtension(
+          nodeCommit:    MerklePatriciaCommitment.Extension,
+          tail:          List[MerklePatriciaCommitment],
+          currentDigest: Hash,
+          remainingPath: Seq[Nibble]
+        ): F[Either[Continue, Return]] =
+          JsonBinaryHasher[F]
+            .computeDigest(nodeCommit.asJson, MerklePatriciaNode.ExtensionPrefix)
+            .map { digest =>
+              if (digest == currentDigest)
+                (tail, nodeCommit.childDigest, remainingPath.drop(nodeCommit.shared.length)).asLeft[Return]
+              else InvalidNodeCommitment("Invalid extension commitment").asLeft[Unit].asRight[Continue]
+            }
+            .handleError(e =>
+              InvalidNodeCommitment(s"Hash computation error: ${e.getMessage}").asLeft[Unit].asRight[Continue]
+            )
+
+        def verifyBranch(
+          nodeCommit:    MerklePatriciaCommitment.Branch,
+          tail:          List[MerklePatriciaCommitment],
+          currentDigest: Hash,
+          remainingPath: Seq[Nibble]
+        ): F[Either[Continue, Return]] =
+          nodeCommit.pathsDigest.get(remainingPath.head) match {
+            case Some(childDigest) =>
+              JsonBinaryHasher[F]
+                .computeDigest(nodeCommit.asJson, MerklePatriciaNode.BranchPrefix)
+                .map { digest =>
+                  if (digest == currentDigest)
+                    (tail, childDigest, remainingPath.tail).asLeft[Return]
+                  else
+                    InvalidNodeCommitment("Invalid branch commitment").asLeft[Unit].asRight[Continue]
+                }
+                .handleError(e =>
+                  InvalidNodeCommitment(s"Hash computation error: ${e.getMessage}").asLeft[Unit].asRight[Continue]
+                )
+
+            case None =>
+              MonadThrow[F].pure(
+                InvalidPath(s"Path not found in branch: ${remainingPath.head}").asLeft[Unit].asRight[Continue]
+              )
+          }
+
+        // Main verification logic using helper functions
+        MonadThrow[F]
+          .tailRecM[Continue, Return]((proof.witness.reverse, root, Nibble(proof.path))) {
+            case (commitments, currentDigest, remainingPath) =>
+              commitments match {
+                case (nodeCommit: MerklePatriciaCommitment.Leaf) :: Nil =>
+                  verifyLeaf(nodeCommit, currentDigest, remainingPath)
+
+                case (nodeCommit: MerklePatriciaCommitment.Extension) :: tail =>
+                  verifyExtension(nodeCommit, tail, currentDigest, remainingPath)
+
+                case (nodeCommit: MerklePatriciaCommitment.Branch) :: tail =>
+                  verifyBranch(nodeCommit, tail, currentDigest, remainingPath)
+
+                case _ =>
+                  MonadThrow[F].pure(
+                    InvalidWitness("Invalid witness structure").asLeft[Unit].asRight[Continue]
+                  )
+              }
+          }
+          .handleError(e => InvalidWitness(s"Verification failed with error: ${e.getMessage}").asLeft[Unit])
+      }
+
+      def confirmPath(
+        path:  String,
+        proof: MerklePatriciaInclusionProof
+      ): F[Either[MerklePatriciaVerificationError, Unit]] =
+        if (proof.path.value == path) confirm(proof)
+        else MonadThrow[F].pure(InvalidPath(s"Path mismatch: expected $path but got ${proof.path}").asLeft[Unit])
+    }
+
+  /**
+   * Provides syntax extensions for more ergonomic Merkle Patricia verification
+   *
+   * Import xyz.kd5ujc.accumulators.mpt.api.MerklePatriciaVerifier.syntax._ to use these extensions
+   */
+  object syntax {
+
+    implicit class MerklePatriciaProofOps(val proof: MerklePatriciaInclusionProof) extends AnyVal {
+
+      /**
+       * Confirm this proof is valid
+       *
+       * @return Success if the proof is valid
+       */
+      def confirm[F[_]](implicit V: MerklePatriciaVerifier[F]): F[Either[MerklePatriciaVerificationError, Unit]] =
+        V.confirm(proof)
+    }
+
+    implicit class MerklePatriciaPathOps(val path: String) extends AnyVal {
+
+      /**
+       * Confirm this path exists in the trie
+       *
+       * @param proof The inclusion proof for this path
+       * @return Success if the path exists and proof is valid
+       */
+      def confirmInclusion[F[_]](proof: MerklePatriciaInclusionProof)(implicit
+        V: MerklePatriciaVerifier[F]
+      ): F[Either[MerklePatriciaVerificationError, Unit]] =
+        V.confirmPath(path, proof)
+    }
+  }
+}
+
+sealed trait MerklePatriciaVerificationError extends Throwable
+
+case class InvalidWitness(message: String) extends MerklePatriciaVerificationError {
+  override def getMessage: String = message
+}
+
+case class InvalidPath(message: String) extends MerklePatriciaVerificationError {
+  override def getMessage: String = message
+}
+
+case class InvalidNodeCommitment(message: String) extends MerklePatriciaVerificationError {
+  override def getMessage: String = message
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/impl/OptimizedMerklePatriciaProducer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/impl/OptimizedMerklePatriciaProducer.scala
@@ -1,0 +1,516 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt.impl
+
+import cats.MonadThrow
+import cats.data.NonEmptyList
+import cats.syntax.all._
+
+import scala.collection.immutable.ArraySeq
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{
+  MerklePatriciaError,
+  MerklePatriciaProducer,
+  OperationError
+}
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaNode, MerklePatriciaTrie, Nibble}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+class OptimizedMerklePatriciaProducer[F[_]: JsonBinaryHasher: MonadThrow] extends MerklePatriciaProducer[F] {
+
+  /**
+   * Create a new Merkle Patricia Trie from a map of data.
+   * Optimizations:
+   * - Use NonEmptyList to avoid empty data check
+   * - Batch node creation with traverse
+   * - More efficient folding with sortBy to help locality
+   */
+  def create[A: Encoder](data: Map[Hash, A]): F[MerklePatriciaTrie] =
+    NonEmptyList.fromList(data.toList) match {
+      case Some(nel) =>
+        val (hPath, hData) = nel.head
+
+        for {
+          initialNode <- MerklePatriciaNode.Leaf[F](Nibble(hPath), hData.asJson)
+          sortedTail = nel.tail.sortBy(_._1.value.length)
+
+          resultNode <- sortedTail.foldM[F, MerklePatriciaNode](initialNode) { case (acc, (path, value)) =>
+            insertEncoded(acc, Nibble(path), value.asJson).flatMap {
+              case Left(err)    => err.raiseError[F, MerklePatriciaNode]
+              case Right(value) => value.pure[F]
+            }
+          }
+        } yield MerklePatriciaTrie(resultNode)
+
+      case None => new RuntimeException("Empty data provided").raiseError
+    }
+
+  /**
+   * Insert new data into an existing Merkle Patricia Trie.
+   * Optimizations:
+   * - Early return for empty data case
+   * - Partition inserts into batches for potentially parallel processing
+   * - Use NonEmptyList to avoid empty checks
+   */
+  def insert[A: Encoder](
+    current: MerklePatriciaTrie,
+    data:    Map[Hash, A]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    if (data.isEmpty) {
+      // Fast path for empty data
+      current.asRight[MerklePatriciaError].pure[F]
+    } else {
+      // Group inserts by path prefix to improve locality for inserts in similar branches
+      val batchSize = 100 // Configurable batch size
+      val dataList = data.toList
+
+      // Process in batches to avoid stack overflows for large inputs
+      dataList
+        .grouped(batchSize)
+        .toList
+        .foldM[F, Either[MerklePatriciaError, MerklePatriciaTrie]](current.asRight[MerklePatriciaError]) {
+          case (Right(acc), batch) =>
+            insertBatch(acc, batch)
+          case (Left(err), _) =>
+            err.asLeft[MerklePatriciaTrie].pure[F]
+        }
+        .handleError(e => OperationError(e.getMessage).asLeft[MerklePatriciaTrie])
+    }
+
+  /**
+   * Process a batch of inserts efficiently
+   */
+  private def insertBatch[A: Encoder](
+    current: MerklePatriciaTrie,
+    data:    List[(Hash, A)]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    data
+      .foldM[F, Either[MerklePatriciaError, MerklePatriciaNode]](current.rootNode.asRight[MerklePatriciaError]) {
+        case (Right(acc), (path, value)) => insertEncoded(acc, Nibble(path), value.asJson)
+        case (Left(err), _)              => err.asLeft[MerklePatriciaNode].pure[F]
+      }
+      .map(_.map(MerklePatriciaTrie(_)))
+
+  /**
+   * Remove data from a Merkle Patricia Trie.
+   * Optimizations:
+   * - Early return for empty data case
+   * - Batched processing for large removals
+   * - Use NonEmptyList to avoid empty checks
+   */
+  def remove(current: MerklePatriciaTrie, data: List[Hash]): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    if (data.isEmpty) {
+      // Fast path for empty data
+      current.asRight[MerklePatriciaError].pure[F]
+    } else {
+      // Process in batches to avoid stack overflows for large inputs
+      val batchSize = 100 // Configurable batch size
+
+      data
+        .grouped(batchSize)
+        .toList
+        .foldM[F, Either[MerklePatriciaError, MerklePatriciaTrie]](current.asRight[MerklePatriciaError]) {
+          case (Right(acc), batch) =>
+            removeBatch(acc, batch)
+          case (Left(err), _) =>
+            err.asLeft[MerklePatriciaTrie].pure[F]
+        }
+        .handleError(e => OperationError(e.getMessage).asLeft[MerklePatriciaTrie])
+    }
+
+  /**
+   * Process a batch of removals efficiently
+   */
+  private def removeBatch(
+    current: MerklePatriciaTrie,
+    paths:   List[Hash]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    paths
+      .foldM[F, Either[MerklePatriciaError, MerklePatriciaNode]](current.rootNode.asRight[MerklePatriciaError]) {
+        case (Right(acc), path) => removeEncoded(acc, Nibble(path))
+        case (Left(err), _)     => err.asLeft[MerklePatriciaNode].pure[F]
+      }
+      .map(_.map(MerklePatriciaTrie(_)))
+
+  // InsertState stays the same
+  sealed private trait InsertState
+
+  private case class InsertContinue(
+    currentNode:  MerklePatriciaNode,
+    key:          Seq[Nibble],
+    updateParent: MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+  ) extends InsertState
+  private case class InsertDone(node: Either[MerklePatriciaError, MerklePatriciaNode]) extends InsertState
+
+  /**
+   * Insert a value with the given path into the trie.
+   * Optimizations:
+   * - Add path length hint for optimization
+   * - More efficient error handling
+   * - Reduce allocations with cached empty values
+   */
+  private def insertEncoded(
+    currentNode: MerklePatriciaNode,
+    path:        Seq[Nibble],
+    data:        Json
+  ): F[Either[MerklePatriciaError, MerklePatriciaNode]] = {
+    // Helper functions to reduce code duplication
+
+    // Efficiently create branch with two nodes
+    def createBranchWithTwoNodes(
+      firstNibble:  Nibble,
+      firstNode:    MerklePatriciaNode,
+      secondNibble: Nibble,
+      secondNode:   MerklePatriciaNode
+    ): F[MerklePatriciaNode] =
+      MerklePatriciaNode
+        .Branch[F](
+          Map[Nibble, MerklePatriciaNode](
+            firstNibble  -> firstNode,
+            secondNibble -> secondNode
+          )
+        )
+        .widen
+
+    // Create a leaf or branch with optional extension based on prefix
+    def createNodeWithPrefix(
+      prefix:       Seq[Nibble],
+      node:         MerklePatriciaNode,
+      updateParent: MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+    ): F[Either[MerklePatriciaError, MerklePatriciaNode]] =
+      (if (prefix.nonEmpty) {
+         node match {
+           case branch: MerklePatriciaNode.Branch =>
+             MerklePatriciaNode.Extension[F](prefix, branch)
+           case _ =>
+             MonadThrow[F].raiseError[MerklePatriciaNode](
+               new IllegalStateException("Only branch nodes can be extended")
+             )
+         }
+       } else {
+         node.pure[F]
+       })
+        .flatMap(updateParent)
+        .handleError(e => OperationError(e.getMessage).asLeft[MerklePatriciaNode])
+
+    def insertForLeafNode(
+      leafNode:     MerklePatriciaNode.Leaf,
+      key:          Seq[Nibble],
+      updateParent: MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+    ): F[Either[InsertState, Either[MerklePatriciaError, MerklePatriciaNode]]] =
+      if (leafNode.remaining == key) {
+        // Replace leaf with new data
+        MerklePatriciaNode
+          .Leaf[F](key, data)
+          .flatMap(updateParent)
+          .map(_.asRight[InsertState])
+          .handleError(e => OperationError(e.getMessage).asLeft[MerklePatriciaNode].asRight[InsertState])
+      } else {
+        // Split into common prefix + branch with two leaves
+        val commonPrefix = Nibble.commonPrefix(leafNode.remaining, key)
+        val leafRemaining = leafNode.remaining.drop(commonPrefix.length)
+        val keyRemaining = key.drop(commonPrefix.length)
+
+        (for {
+          // Create two leaf nodes
+          existingLeaf <- MerklePatriciaNode.Leaf[F](leafRemaining.tail, leafNode.data)
+          newLeaf      <- MerklePatriciaNode.Leaf[F](keyRemaining.tail, data)
+
+          // Create branch with two paths
+          branchNode <- createBranchWithTwoNodes(
+            leafRemaining.head,
+            existingLeaf,
+            keyRemaining.head,
+            newLeaf
+          )
+
+          // Add extension node if needed and update parent
+          result <- createNodeWithPrefix(commonPrefix, branchNode, updateParent)
+        } yield InsertDone(result).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]])
+          .handleError(e => InsertDone(OperationError(e.getMessage).asLeft[MerklePatriciaNode]).asLeft)
+          .widen
+      }
+
+    def insertForExtensionNode(
+      extensionNode: MerklePatriciaNode.Extension,
+      key:           Seq[Nibble],
+      updateParent:  MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+    ): F[Either[InsertState, Either[MerklePatriciaError, MerklePatriciaNode]]] = {
+      val commonPrefix = Nibble.commonPrefix(extensionNode.shared, key)
+      val sharedRemaining = extensionNode.shared.drop(commonPrefix.length)
+      val keyRemaining = key.drop(commonPrefix.length)
+
+      if (key.isEmpty) {
+        InsertDone(OperationError("Key exhausted at extension node").asLeft)
+          .asLeft[Either[MerklePatriciaError, MerklePatriciaNode]]
+          .pure[F]
+          .widen
+      } else if (sharedRemaining.isEmpty) {
+        // Continue with child node
+        (InsertContinue(
+          extensionNode.child,
+          keyRemaining,
+          {
+            case branch: MerklePatriciaNode.Branch =>
+              MerklePatriciaNode
+                .Extension[F](extensionNode.shared, branch)
+                .flatMap(updateParent)
+                .handleError(e => OperationError(e.getMessage).asLeft)
+            case _ =>
+              OperationError("Unexpected node type while creating extension node")
+                .asLeft[MerklePatriciaNode]
+                .pure[F]
+                .widen
+          }
+        ): InsertState).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]].pure[F]
+      } else {
+        // Split extension node
+        (for {
+          newExtension <- MerklePatriciaNode.Extension[F](sharedRemaining.tail, extensionNode.child)
+          newLeaf      <- MerklePatriciaNode.Leaf[F](keyRemaining.tail, data)
+
+          // Create branch with two paths
+          branchNode <- createBranchWithTwoNodes(
+            sharedRemaining.head,
+            newExtension,
+            keyRemaining.head,
+            newLeaf
+          )
+
+          // Add extension node if needed and update parent
+          result <- createNodeWithPrefix(commonPrefix, branchNode, updateParent)
+        } yield InsertDone(result).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]])
+          .handleError(e => InsertDone(OperationError(e.getMessage).asLeft[MerklePatriciaNode]).asLeft)
+          .widen
+      }
+    }
+
+    def insertForBranchNode(
+      branchNode:   MerklePatriciaNode.Branch,
+      key:          Seq[Nibble],
+      updateParent: MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+    ): F[Either[InsertState, Either[MerklePatriciaError, MerklePatriciaNode]]] =
+      if (key.isEmpty) {
+        InsertDone(OperationError("Key exhausted at branch node").asLeft)
+          .asLeft[Either[MerklePatriciaError, MerklePatriciaNode]]
+          .pure[F]
+          .widen
+      } else {
+        val nibble = key.head
+        val keyRemaining = key.tail
+
+        branchNode.paths.get(nibble) match {
+          case Some(childNode) =>
+            // Continue with child node
+            (InsertContinue(
+              childNode,
+              keyRemaining,
+              (updatedChild: MerklePatriciaNode) =>
+                MerklePatriciaNode
+                  .Branch[F](branchNode.paths + (nibble -> updatedChild))
+                  .flatMap(updateParent)
+                  .handleError(e => OperationError(e.getMessage).asLeft)
+            ): InsertState).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]].pure[F]
+
+          case None =>
+            // Add new path to branch
+            (for {
+              newLeaf       <- MerklePatriciaNode.Leaf[F](keyRemaining, data)
+              updatedBranch <- MerklePatriciaNode.Branch[F](branchNode.paths + (nibble -> newLeaf))
+              result        <- updateParent(updatedBranch)
+            } yield result.asRight[InsertState])
+              .handleError(e => InsertDone(OperationError(e.getMessage).asLeft[MerklePatriciaNode]).asLeft)
+        }
+      }
+
+    def step(state: InsertState): F[Either[InsertState, Either[MerklePatriciaError, MerklePatriciaNode]]] =
+      state match {
+        case InsertContinue(currentNode, key, updateParent) =>
+          currentNode match {
+            case node: MerklePatriciaNode.Leaf      => insertForLeafNode(node, key, updateParent)
+            case node: MerklePatriciaNode.Extension => insertForExtensionNode(node, key, updateParent)
+            case node: MerklePatriciaNode.Branch    => insertForBranchNode(node, key, updateParent)
+          }
+        case InsertDone(node) => node.asRight[InsertState].pure[F]
+      }
+
+    val initialState: InsertState = InsertContinue(
+      currentNode,
+      path,
+      node => node.asRight[MerklePatriciaError].pure[F]
+    )
+
+    initialState.tailRecM[F, Either[MerklePatriciaError, MerklePatriciaNode]](step)
+  }
+
+  // RemoveState stays the same
+  sealed private trait RemoveState
+
+  private case class RemoveContinue(
+    currentNode:  MerklePatriciaNode,
+    key:          Seq[Nibble],
+    updateParent: Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+  ) extends RemoveState
+  private case class RemoveDone(nodeOpt: Either[MerklePatriciaError, Option[MerklePatriciaNode]]) extends RemoveState
+
+  /**
+   * Remove a value with the given path from the trie.
+   * Optimizations:
+   * - Cache common operations
+   * - Reduce allocations
+   * - Improve error handling
+   */
+  private def removeEncoded(
+    currentNode: MerklePatriciaNode,
+    path:        Seq[Nibble]
+  ): F[Either[MerklePatriciaError, MerklePatriciaNode]] = {
+    // Helper functions for common node operations
+    def handleSingleRemainingChild(
+      remainingNibble: Nibble,
+      onlyChild:       MerklePatriciaNode,
+      updateParent:    Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+    ): F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]] =
+      onlyChild match {
+        case leafNode: MerklePatriciaNode.Leaf =>
+          MerklePatriciaNode
+            .Leaf[F](ArraySeq(remainingNibble) ++ leafNode.remaining, leafNode.data)
+            .flatMap(node => updateParent(Some(node)))
+            .handleError(e => OperationError(e.getMessage).asLeft)
+
+        case extensionNode: MerklePatriciaNode.Extension =>
+          MerklePatriciaNode
+            .Extension[F](ArraySeq(remainingNibble) ++ extensionNode.shared, extensionNode.child)
+            .flatMap(node => updateParent(Some(node)))
+            .handleError(e => OperationError(e.getMessage).asLeft)
+
+        case branchNode: MerklePatriciaNode.Branch =>
+          MerklePatriciaNode
+            .Extension[F](ArraySeq(remainingNibble), branchNode)
+            .flatMap(node => updateParent(Some(node)))
+            .handleError(e => OperationError(e.getMessage).asLeft)
+      }
+
+    def removeForLeafNode(
+      leafNode:     MerklePatriciaNode.Leaf,
+      key:          Seq[Nibble],
+      updateParent: Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+    ): F[Either[RemoveState, Either[MerklePatriciaError, Option[MerklePatriciaNode]]]] =
+      if (leafNode.remaining == key) updateParent(None).map(_.asRight)
+      else leafNode.some.asRight[MerklePatriciaError].asRight[RemoveState].pure[F].widen
+
+    def removeForExtensionNode(
+      extensionNode: MerklePatriciaNode.Extension,
+      key:           Seq[Nibble],
+      updateParent:  Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+    ): F[Either[RemoveState, Either[MerklePatriciaError, Option[MerklePatriciaNode]]]] = {
+      val commonPrefix = Nibble.commonPrefix(extensionNode.shared, key)
+
+      if (commonPrefix.length == extensionNode.shared.length) {
+        RemoveContinue(
+          extensionNode.child,
+          key.drop(commonPrefix.length),
+          {
+            case Some(updatedChild) =>
+              updatedChild match {
+                case childBranch: MerklePatriciaNode.Branch =>
+                  MerklePatriciaNode
+                    .Extension[F](extensionNode.shared, childBranch)
+                    .flatMap(node => updateParent(Some(node)))
+                    .handleError(e => OperationError(e.getMessage).asLeft)
+
+                case childLeaf: MerklePatriciaNode.Leaf =>
+                  MerklePatriciaNode
+                    .Leaf[F](extensionNode.shared ++ childLeaf.remaining, childLeaf.data)
+                    .flatMap(node => updateParent(Some(node)))
+                    .handleError(e => OperationError(e.getMessage).asLeft)
+
+                case childExtension: MerklePatriciaNode.Extension =>
+                  MerklePatriciaNode
+                    .Extension[F](extensionNode.shared ++ childExtension.shared, childExtension.child)
+                    .flatMap(node => updateParent(Some(node)))
+                    .handleError(e => OperationError(e.getMessage).asLeft)
+              }
+
+            case None => updateParent(None)
+          }
+        ).asLeft[Either[MerklePatriciaError, Option[MerklePatriciaNode]]].pure[F].widen
+      } else {
+        extensionNode.some.asRight[MerklePatriciaError].asRight[RemoveState].pure[F].widen
+      }
+    }
+
+    def removeForBranchNode(
+      branchNode:   MerklePatriciaNode.Branch,
+      key:          Seq[Nibble],
+      updateParent: Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+    ): F[Either[RemoveState, Either[MerklePatriciaError, Option[MerklePatriciaNode]]]] =
+      if (key.nonEmpty) {
+        val nibble = key.head
+        val keyRemaining = key.tail
+
+        branchNode.paths.get(nibble) match {
+          case Some(childNode) =>
+            // Continue with child node
+            (RemoveContinue(
+              childNode,
+              keyRemaining,
+              {
+                case Some(updatedChild) =>
+                  MerklePatriciaNode
+                    .Branch[F](branchNode.paths + (nibble -> updatedChild))
+                    .flatMap(node => updateParent(Some(node)))
+                    .handleError(e => OperationError(e.getMessage).asLeft)
+
+                case None =>
+                  val updatedPaths = branchNode.paths - nibble
+
+                  updatedPaths.size match {
+                    case 0 =>
+                      updateParent(None)
+
+                    case 1 =>
+                      val (remainingNibble, onlyChild) = updatedPaths.head
+                      handleSingleRemainingChild(remainingNibble, onlyChild, updateParent)
+
+                    case _ =>
+                      MerklePatriciaNode
+                        .Branch[F](updatedPaths)
+                        .flatMap(node => updateParent(Some(node)))
+                        .handleError(e => OperationError(e.getMessage).asLeft)
+                  }
+              }
+            ): RemoveState).asLeft[Either[MerklePatriciaError, Option[MerklePatriciaNode]]].pure[F]
+
+          case None =>
+            branchNode.some.asRight[MerklePatriciaError].asRight[RemoveState].pure[F].widen
+        }
+      } else {
+        branchNode.some.asRight[MerklePatriciaError].asRight[RemoveState].pure[F].widen
+      }
+
+    def step(state: RemoveState): F[Either[RemoveState, Either[MerklePatriciaError, Option[MerklePatriciaNode]]]] =
+      state match {
+        case RemoveContinue(currentNode, key, updateParent) =>
+          currentNode match {
+            case node: MerklePatriciaNode.Leaf      => removeForLeafNode(node, key, updateParent)
+            case node: MerklePatriciaNode.Extension => removeForExtensionNode(node, key, updateParent)
+            case node: MerklePatriciaNode.Branch    => removeForBranchNode(node, key, updateParent)
+          }
+        case RemoveDone(nodeOpt) => nodeOpt.asRight[RemoveState].pure[F]
+      }
+
+    val initialState: RemoveState = RemoveContinue(
+      currentNode,
+      path,
+      nodeOpt => nodeOpt.asRight[MerklePatriciaError].pure[F]
+    )
+
+    initialState.tailRecM[F, Either[MerklePatriciaError, Option[MerklePatriciaNode]]](step).flatMap {
+      case Right(Some(newRootNode)) => newRootNode.asRight[MerklePatriciaError].pure[F]
+      case Right(None)              => MerklePatriciaNode.Branch[F](Map.empty).map(_.asRight[MerklePatriciaError])
+      case Left(err)                => err.asLeft[MerklePatriciaNode].pure[F]
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/impl/SimpleMerklePatriciaProducer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/impl/SimpleMerklePatriciaProducer.scala
@@ -1,0 +1,397 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt.impl
+
+import cats.MonadThrow
+import cats.data.NonEmptyList
+import cats.syntax.all._
+
+import scala.collection.immutable.ArraySeq
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{
+  MerklePatriciaError,
+  MerklePatriciaProducer,
+  OperationError
+}
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaNode, MerklePatriciaTrie, Nibble}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+class SimpleMerklePatriciaProducer[F[_]: JsonBinaryHasher: MonadThrow] extends MerklePatriciaProducer[F] {
+
+  def create[A: Encoder](data: Map[Hash, A]): F[MerklePatriciaTrie] =
+    NonEmptyList.fromList(data.toList) match {
+      case Some(nel) =>
+        val (hPath, hData) = nel.head
+
+        for {
+          initialNode <- MerklePatriciaNode.Leaf[F](Nibble(hPath), hData.asJson)
+          sortedTail = nel.tail.sortBy(_._1.value.length)
+
+          resultNode <- sortedTail.foldM[F, MerklePatriciaNode](initialNode) { case (acc, (path, value)) =>
+            insertEncoded(acc, Nibble(path), value.asJson).flatMap {
+              case Left(err)    => err.raiseError[F, MerklePatriciaNode]
+              case Right(value) => value.pure[F]
+            }
+          }
+        } yield MerklePatriciaTrie(resultNode)
+
+      case None => new RuntimeException("Empty data provided").raiseError
+    }
+
+  def insert[A: Encoder](
+    current: MerklePatriciaTrie,
+    data:    Map[Hash, A]
+  ): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    if (data.isEmpty) {
+      current.asRight[MerklePatriciaError].pure[F]
+    } else {
+      insertMultiple(current.rootNode, data.toList)
+        .map(_.map(MerklePatriciaTrie(_)))
+        .handleError(e => OperationError(e.getMessage).asLeft[MerklePatriciaTrie])
+    }
+
+  def remove(current: MerklePatriciaTrie, data: List[Hash]): F[Either[MerklePatriciaError, MerklePatriciaTrie]] =
+    if (data.isEmpty) {
+      current.asRight[MerklePatriciaError].pure[F]
+    } else {
+      removeMultiple(current.rootNode, data)
+        .map(_.map(MerklePatriciaTrie(_)))
+        .handleError(e => OperationError(e.getMessage).asLeft[MerklePatriciaTrie])
+    }
+
+  private def insertMultiple[A: Encoder](
+    initialNode: MerklePatriciaNode,
+    entries:     List[(Hash, A)]
+  ): F[Either[MerklePatriciaError, MerklePatriciaNode]] =
+    entries.foldM(initialNode.asRight[MerklePatriciaError]) {
+      case (Right(acc), (path, value)) =>
+        insertEncoded(acc, Nibble(path), value.asJson)
+      case (Left(err), _) =>
+        err.asLeft[MerklePatriciaNode].pure[F]
+    }
+
+  private def removeMultiple(
+    initialNode: MerklePatriciaNode,
+    paths:       List[Hash]
+  ): F[Either[MerklePatriciaError, MerklePatriciaNode]] =
+    paths.foldM(initialNode.asRight[MerklePatriciaError]) {
+      case (Right(acc), path) =>
+        removeEncoded(acc, Nibble(path))
+      case (Left(err), _) =>
+        err.asLeft[MerklePatriciaNode].pure[F]
+    }
+
+  sealed private trait InsertState
+
+  private case class InsertContinue(
+    currentNode:  MerklePatriciaNode,
+    key:          Seq[Nibble],
+    updateParent: MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+  ) extends InsertState
+  private case class InsertDone(node: Either[MerklePatriciaError, MerklePatriciaNode]) extends InsertState
+
+  private def insertEncoded(
+    currentNode: MerklePatriciaNode,
+    path:        Seq[Nibble],
+    data:        Json
+  ): F[Either[MerklePatriciaError, MerklePatriciaNode]] = {
+    def insertForLeafNode(
+      leafNode:     MerklePatriciaNode.Leaf,
+      _key:         Seq[Nibble],
+      updateParent: MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+    ): F[Either[InsertState, Either[MerklePatriciaError, MerklePatriciaNode]]] =
+      if (leafNode.remaining == _key) {
+        for {
+          newLeaf <- MerklePatriciaNode.Leaf[F](_key, data)
+          result  <- updateParent(newLeaf)
+        } yield result.asRight[InsertState]
+      } else {
+        val commonPrefix = Nibble.commonPrefix(leafNode.remaining, _key)
+        val leafRemaining = leafNode.remaining.drop(commonPrefix.length)
+        val keyRemaining = _key.drop(commonPrefix.length)
+
+        (for {
+          existingLeaf <- MerklePatriciaNode.Leaf[F](leafRemaining.tail, leafNode.data)
+          newLeaf      <- MerklePatriciaNode.Leaf[F](keyRemaining.tail, data)
+          branchNode <- MerklePatriciaNode.Branch[F](
+            Map[Nibble, MerklePatriciaNode](
+              leafRemaining.head -> existingLeaf,
+              keyRemaining.head  -> newLeaf
+            )
+          )
+          resultNode <-
+            if (commonPrefix.nonEmpty) MerklePatriciaNode.Extension[F](commonPrefix, branchNode)
+            else branchNode.pure[F]
+          updatedNode <- updateParent(resultNode)
+        } yield InsertDone(updatedNode).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]]).handleError { e =>
+          InsertDone(OperationError(e.getMessage).asLeft[MerklePatriciaNode]).asLeft
+        }.widen
+      }
+
+    def insertForExtensionNode(
+      extensionNode: MerklePatriciaNode.Extension,
+      _key:          Seq[Nibble],
+      updateParent:  MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+    ): F[Either[InsertState, Either[MerklePatriciaError, MerklePatriciaNode]]] = {
+      val commonPrefix = Nibble.commonPrefix(extensionNode.shared, _key)
+      val sharedRemaining = extensionNode.shared.drop(commonPrefix.length)
+      val keyRemaining = _key.drop(commonPrefix.length)
+
+      if (_key.isEmpty) {
+        InsertDone(OperationError("Key exhausted at extension node").asLeft)
+          .asLeft[Either[MerklePatriciaError, MerklePatriciaNode]]
+          .pure[F]
+          .widen
+      } else if (sharedRemaining.isEmpty) {
+        (InsertContinue(
+          extensionNode.child,
+          keyRemaining,
+          {
+            case branch: MerklePatriciaNode.Branch =>
+              MerklePatriciaNode
+                .Extension[F](extensionNode.shared, branch)
+                .flatMap(ext => updateParent(ext))
+                .handleError(e => OperationError(e.getMessage).asLeft)
+            case _ =>
+              OperationError("Unexpected node type while creating extension node")
+                .asLeft[MerklePatriciaNode]
+                .pure[F]
+                .widen
+          }
+        ): InsertState).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]].pure[F]
+      } else {
+        (for {
+          newExtension <- MerklePatriciaNode.Extension[F](sharedRemaining.tail, extensionNode.child)
+          newLeaf      <- MerklePatriciaNode.Leaf[F](keyRemaining.tail, data)
+          branchNode <- MerklePatriciaNode.Branch[F](
+            Map(
+              sharedRemaining.head -> newExtension,
+              keyRemaining.head    -> newLeaf
+            )
+          )
+          resultNode <-
+            if (commonPrefix.nonEmpty) MerklePatriciaNode.Extension[F](commonPrefix, branchNode)
+            else branchNode.pure[F]
+          updatedNode <- updateParent(resultNode)
+        } yield InsertDone(updatedNode).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]]).handleError { e =>
+          InsertDone(OperationError(e.getMessage).asLeft[MerklePatriciaNode]).asLeft
+        }.widen
+      }
+    }
+
+    def insertForBranchNode(
+      branchNode:   MerklePatriciaNode.Branch,
+      _key:         Seq[Nibble],
+      updateParent: MerklePatriciaNode => F[Either[MerklePatriciaError, MerklePatriciaNode]]
+    ): F[Either[InsertState, Either[MerklePatriciaError, MerklePatriciaNode]]] =
+      if (_key.isEmpty) {
+        InsertDone(OperationError("Key exhausted at branch node").asLeft)
+          .asLeft[Either[MerklePatriciaError, MerklePatriciaNode]]
+          .pure[F]
+          .widen
+      } else {
+        val nibble = _key.head
+        val keyRemaining = _key.tail
+
+        branchNode.paths.get(nibble) match {
+          case Some(childNode) =>
+            (InsertContinue(
+              childNode,
+              keyRemaining,
+              (updatedChild: MerklePatriciaNode) =>
+                MerklePatriciaNode
+                  .Branch[F](branchNode.paths + (nibble -> updatedChild))
+                  .flatMap(updateParent)
+                  .handleError(e => OperationError(e.getMessage).asLeft)
+            ): InsertState).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]].pure[F]
+
+          case None =>
+            (for {
+              newLeaf       <- MerklePatriciaNode.Leaf[F](keyRemaining, data)
+              updatedBranch <- MerklePatriciaNode.Branch[F](branchNode.paths + (nibble -> newLeaf))
+              result        <- updateParent(updatedBranch)
+            } yield result.asRight[InsertState]).handleError { e =>
+              InsertDone(OperationError(e.getMessage).asLeft[MerklePatriciaNode]).asLeft
+            }
+        }
+      }
+
+    def step(state: InsertState): F[Either[InsertState, Either[MerklePatriciaError, MerklePatriciaNode]]] =
+      state match {
+        case InsertContinue(currentNode, key, updateParent) =>
+          currentNode match {
+            case node: MerklePatriciaNode.Leaf      => insertForLeafNode(node, key, updateParent)
+            case node: MerklePatriciaNode.Extension => insertForExtensionNode(node, key, updateParent)
+            case node: MerklePatriciaNode.Branch    => insertForBranchNode(node, key, updateParent)
+          }
+        case InsertDone(node) => node.asRight[InsertState].pure[F]
+      }
+
+    val initialState: InsertState = InsertContinue(
+      currentNode,
+      path,
+      node => node.asRight[MerklePatriciaError].pure[F]
+    )
+
+    initialState.tailRecM[F, Either[MerklePatriciaError, MerklePatriciaNode]](step)
+  }
+
+  sealed private trait RemoveState
+
+  private case class RemoveContinue(
+    currentNode:  MerklePatriciaNode,
+    key:          Seq[Nibble],
+    updateParent: Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+  ) extends RemoveState
+  private case class RemoveDone(nodeOpt: Either[MerklePatriciaError, Option[MerklePatriciaNode]]) extends RemoveState
+
+  private def removeEncoded(
+    currentNode: MerklePatriciaNode,
+    path:        Seq[Nibble]
+  ): F[Either[MerklePatriciaError, MerklePatriciaNode]] = {
+    def removeForLeafNode(
+      leafNode:     MerklePatriciaNode.Leaf,
+      _key:         Seq[Nibble],
+      updateParent: Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+    ): F[Either[RemoveState, Either[MerklePatriciaError, Option[MerklePatriciaNode]]]] =
+      if (leafNode.remaining == _key) {
+        updateParent(None).map(_.asRight)
+      } else {
+        leafNode.some.asRight[MerklePatriciaError].asRight[RemoveState].pure[F].widen
+      }
+
+    def removeForExtensionNode(
+      extensionNode: MerklePatriciaNode.Extension,
+      _key:          Seq[Nibble],
+      updateParent:  Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+    ): F[Either[RemoveState, Either[MerklePatriciaError, Option[MerklePatriciaNode]]]] = {
+      val commonPrefix = Nibble.commonPrefix(extensionNode.shared, _key)
+
+      if (commonPrefix.length == extensionNode.shared.length) {
+        (RemoveContinue(
+          extensionNode.child,
+          _key.drop(commonPrefix.length),
+          {
+            case Some(updatedChild) =>
+              updatedChild match {
+                case childBranch: MerklePatriciaNode.Branch =>
+                  MerklePatriciaNode
+                    .Extension[F](extensionNode.shared, childBranch)
+                    .flatMap(node => updateParent(Some(node)))
+                    .handleError(e => OperationError(e.getMessage).asLeft)
+
+                case childLeaf: MerklePatriciaNode.Leaf =>
+                  MerklePatriciaNode
+                    .Leaf[F](extensionNode.shared ++ childLeaf.remaining, childLeaf.data)
+                    .flatMap(node => updateParent(Some(node)))
+                    .handleError(e => OperationError(e.getMessage).asLeft)
+
+                case childExtension: MerklePatriciaNode.Extension =>
+                  MerklePatriciaNode
+                    .Extension[F](extensionNode.shared ++ childExtension.shared, childExtension.child)
+                    .flatMap(node => updateParent(Some(node)))
+                    .handleError(e => OperationError(e.getMessage).asLeft)
+              }
+
+            case None => updateParent(None)
+          }
+        ): RemoveState).asLeft[Either[MerklePatriciaError, Option[MerklePatriciaNode]]].pure[F]
+      } else {
+        extensionNode.some.asRight[MerklePatriciaError].asRight[RemoveState].pure[F].widen
+      }
+    }
+
+    def removeForBranchNode(
+      branchNode:   MerklePatriciaNode.Branch,
+      _key:         Seq[Nibble],
+      updateParent: Option[MerklePatriciaNode] => F[Either[MerklePatriciaError, Option[MerklePatriciaNode]]]
+    ): F[Either[RemoveState, Either[MerklePatriciaError, Option[MerklePatriciaNode]]]] =
+      if (_key.nonEmpty) {
+        val nibble = _key.head
+        val keyRemaining = _key.tail
+
+        branchNode.paths.get(nibble) match {
+          case Some(childNode) =>
+            RemoveContinue(
+              childNode,
+              keyRemaining,
+              {
+                case Some(updatedChild) =>
+                  MerklePatriciaNode
+                    .Branch[F](branchNode.paths + (nibble -> updatedChild))
+                    .flatMap(node => updateParent(Some(node)))
+                    .handleError(e => OperationError(e.getMessage).asLeft)
+                case None =>
+                  val updatedPaths = branchNode.paths - nibble
+
+                  updatedPaths.size match {
+                    case 0 =>
+                      updateParent(None)
+
+                    case 1 =>
+                      val (remainingNibble, onlyChild) = updatedPaths.head
+                      onlyChild match {
+                        case leafNode: MerklePatriciaNode.Leaf =>
+                          MerklePatriciaNode
+                            .Leaf[F](ArraySeq(remainingNibble) ++ leafNode.remaining, leafNode.data)
+                            .flatMap(node => updateParent(Some(node)))
+                            .handleError(e => OperationError(e.getMessage).asLeft)
+
+                        case extensionNode: MerklePatriciaNode.Extension =>
+                          MerklePatriciaNode
+                            .Extension[F](ArraySeq(remainingNibble) ++ extensionNode.shared, extensionNode.child)
+                            .flatMap(node => updateParent(Some(node)))
+                            .handleError(e => OperationError(e.getMessage).asLeft)
+
+                        case branchNode: MerklePatriciaNode.Branch =>
+                          MerklePatriciaNode
+                            .Extension[F](ArraySeq(remainingNibble), branchNode)
+                            .flatMap(node => updateParent(Some(node)))
+                            .handleError(e => OperationError(e.getMessage).asLeft)
+                      }
+
+                    case _ =>
+                      MerklePatriciaNode
+                        .Branch[F](updatedPaths)
+                        .flatMap(node => updateParent(Some(node)))
+                        .handleError(e => OperationError(e.getMessage).asLeft)
+                  }
+              }
+            ).asLeft[Either[MerklePatriciaError, Option[MerklePatriciaNode]]].pure[F].widen
+
+          case None => branchNode.some.asRight[MerklePatriciaError].asRight[RemoveState].pure[F].widen
+        }
+      } else branchNode.some.asRight[MerklePatriciaError].asRight[RemoveState].pure[F].widen
+
+    def step(state: RemoveState): F[Either[RemoveState, Either[MerklePatriciaError, Option[MerklePatriciaNode]]]] =
+      state match {
+        case RemoveContinue(currentNode, key, updateParent) =>
+          currentNode match {
+            case node: MerklePatriciaNode.Leaf      => removeForLeafNode(node, key, updateParent)
+            case node: MerklePatriciaNode.Extension => removeForExtensionNode(node, key, updateParent)
+            case node: MerklePatriciaNode.Branch    => removeForBranchNode(node, key, updateParent)
+          }
+        case RemoveDone(nodeOpt) => nodeOpt.asRight[RemoveState].pure[F]
+      }
+
+    val initialState: RemoveState = RemoveContinue(
+      currentNode,
+      path,
+      nodeOpt => nodeOpt.asRight[MerklePatriciaError].pure[F]
+    )
+
+    initialState.tailRecM[F, Either[MerklePatriciaError, Option[MerklePatriciaNode]]](step).flatMap {
+      case Right(Some(newRootNode)) => newRootNode.asRight[MerklePatriciaError].pure[F]
+      case Right(None)              => MerklePatriciaNode.Branch[F](Map.empty).map(_.asRight[MerklePatriciaError])
+      case Left(err)                => err.asLeft[MerklePatriciaNode].pure[F]
+    }
+  }
+}
+
+object SimpleMerklePatriciaProducer {
+
+  def apply[F[_]: JsonBinaryHasher: MonadThrow]: SimpleMerklePatriciaProducer[F] =
+    new SimpleMerklePatriciaProducer[F]
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/JsonLogicValue.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/JsonLogicValue.scala
@@ -147,11 +147,11 @@ object CoercedValue {
   @tailrec
   def coerceToPrimitive(value: JsonLogicValue): Either[JsonLogicException, CoercedValue] =
     value match {
-      case NullValue           => CoercedNull.asRight
-      case BoolValue(b)        => CoercedBool(b).asRight
-      case IntValue(i)         => CoercedInt(i).asRight
-      case FloatValue(d)       => CoercedFloat(d).asRight
-      case StrValue(s)         =>
+      case NullValue     => CoercedNull.asRight
+      case BoolValue(b)  => CoercedBool(b).asRight
+      case IntValue(i)   => CoercedInt(i).asRight
+      case FloatValue(d) => CoercedFloat(d).asRight
+      case StrValue(s)   =>
         // JavaScript semantics: empty string coerces to 0, numeric strings coerce to their numeric value
         if (s.isEmpty) CoercedInt(0).asRight
         else s.toIntOption.fold[CoercedValue](CoercedString(s))(i => CoercedInt(i)).asRight
@@ -171,16 +171,16 @@ object CoercedValue {
     }
 
   private def safeParseBigInt(s: String): Option[BigInt] =
-    try {
+    try
       Some(BigInt(s))
-    } catch {
+    catch {
       case _: NumberFormatException => None
     }
 
   private def safeParseBigDecimal(s: String): Option[BigDecimal] =
-    try {
+    try
       Some(BigDecimal(s))
-    } catch {
+    catch {
       case _: NumberFormatException => None
     }
 

--- a/src/test/scala/crypto/merkle/MerkleProducerSuite.scala
+++ b/src/test/scala/crypto/merkle/MerkleProducerSuite.scala
@@ -1,0 +1,96 @@
+package crypto.merkle
+
+import cats.effect.IO
+import cats.implicits.toTraverseOps
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.MerkleNode
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.api.{MerkleProducer, TreeBuildError}
+
+import io.circe.syntax.EncoderOps
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object MerkleProducerSuite extends SimpleIOSuite with Checkers {
+
+  test("Building with no leaves throws an error") {
+    for {
+      producer <- MerkleProducer.make[IO](List())
+      outcome  <- producer.build
+    } yield outcome match {
+      case Left(TreeBuildError(message)) => expect(message == "Cannot build tree with no leaves")
+      case Left(_)                       => failure("Unexpected error type")
+      case Right(_)                      => failure("Expecting error but got successful result")
+    }
+  }
+
+  test("Building a tree with non-empty list is successful") {
+    forall(Gen.listOf(Gen.alphaNumStr).suchThat(_.nonEmpty)) { strings =>
+      for {
+        leaves        <- strings.map(_.asJson).traverse(MerkleNode.Leaf(_))
+        producer      <- MerkleProducer.make[IO](leaves)
+        outcomeEither <- producer.build
+        outcome       <- IO.fromEither(outcomeEither)
+      } yield expect(outcome.rootNode.digest.value.nonEmpty)
+    }
+  }
+
+  test("Appending a value should result in a new tree") {
+    for {
+      leaves        <- List("one", "two", "three", "four").map(_.asJson).traverse(MerkleNode.Leaf(_))
+      newLeaf       <- List("five").map(_.asJson).traverse(MerkleNode.Leaf(_))
+      producer      <- MerkleProducer.make[IO](leaves)
+      oldTreeEither <- producer.build
+      oldTree       <- IO.fromEither(oldTreeEither)
+      _             <- producer.append(newLeaf)
+      newTreeEither <- producer.build
+      newTree       <- IO.fromEither(newTreeEither)
+      newLeaves     <- producer.leaves.map(_.map(_.data))
+    } yield expect(newTree.rootNode.digest.asJson != oldTree.rootNode.asJson) &&
+    expect.same(newLeaves, List("one", "two", "three", "four", "five").map(_.asJson))
+  }
+
+  test("Prepending a value should result in a new tree") {
+    for {
+      leaves        <- List("one", "two", "three", "four").map(_.asJson).traverse(MerkleNode.Leaf(_))
+      newLeaf       <- List("five").map(_.asJson).traverse(MerkleNode.Leaf(_))
+      producer      <- MerkleProducer.make[IO](leaves)
+      oldTreeEither <- producer.build
+      oldTree       <- IO.fromEither(oldTreeEither)
+      _             <- producer.prepend(newLeaf)
+      newTreeEither <- producer.build
+      newTree       <- IO.fromEither(newTreeEither)
+      newLeaves     <- producer.leaves.map(_.map(_.data))
+    } yield expect(newTree.rootNode.digest.asJson != oldTree.rootNode.asJson) &&
+    expect.same(newLeaves, List("five", "one", "two", "three", "four").map(_.asJson))
+  }
+
+  test("Updating a value should result in a new tree") {
+    for {
+      leaves        <- List("one", "two", "three", "four").map(_.asJson).traverse(MerkleNode.Leaf(_))
+      newLeaf       <- MerkleNode.Leaf("five".asJson)
+      producer      <- MerkleProducer.make[IO](leaves)
+      oldTreeEither <- producer.build
+      oldTree       <- IO.fromEither(oldTreeEither)
+      _             <- producer.update(0, newLeaf).flatMap(IO.fromEither)
+      newTreeEither <- producer.build
+      newTree       <- IO.fromEither(newTreeEither)
+      newLeaves     <- producer.leaves.map(_.map(_.data))
+    } yield expect(newTree.rootNode.digest.asJson != oldTree.rootNode.asJson) &&
+    expect.same(newLeaves, List("five", "two", "three", "four").map(_.asJson))
+  }
+
+  test("Removing a value should result in a new tree") {
+    for {
+      leaves        <- List("one", "two", "three", "four").map(_.asJson).traverse(MerkleNode.Leaf(_))
+      producer      <- MerkleProducer.make[IO](leaves)
+      oldTreeEither <- producer.build
+      oldTree       <- IO.fromEither(oldTreeEither)
+      _             <- producer.remove(0).flatMap(IO.fromEither)
+      newTreeEither <- producer.build
+      newTree       <- IO.fromEither(newTreeEither)
+      newLeaves     <- producer.leaves.map(_.map(_.data))
+    } yield expect(newTree.rootNode.digest.asJson != oldTree.rootNode.asJson) &&
+    expect.same(newLeaves, List("two", "three", "four").map(_.asJson))
+  }
+}

--- a/src/test/scala/crypto/merkle/MerkleProverSuite.scala
+++ b/src/test/scala/crypto/merkle/MerkleProverSuite.scala
@@ -1,0 +1,61 @@
+package crypto.merkle
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.api.MerkleProver
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.{MerkleNode, MerkleTree}
+
+import io.circe.syntax.EncoderOps
+import shared.Generators.nonEmptyStringListGen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object MerkleProverSuite extends SimpleIOSuite with Checkers {
+
+  test("Creating a proof is successful using a Leaf of the tree") {
+    forall(nonEmptyStringListGen(1, 100)) { strings =>
+      for {
+        leaves <- strings.map(_.asJson).traverse(MerkleNode.Leaf(_))
+        tree   <- MerkleTree.create[IO, String](strings)
+        prover = MerkleProver.make[IO](tree)
+        proofEither <- prover.attestLeaf(leaves.head)
+        proof       <- IO.fromEither(proofEither)
+      } yield expect(proof.leafDigest == leaves.head.digest)
+    }
+  }
+
+  test("Creating a proof is successful using a digest of a leaf of the tree") {
+    forall(nonEmptyStringListGen(1, 100)) { strings =>
+      for {
+        leaves <- strings.map(_.asJson).traverse(MerkleNode.Leaf(_))
+        tree   <- MerkleTree.create[IO, String](strings)
+        prover = MerkleProver.make[IO](tree)
+        proofEither <- prover.attestDigest(leaves.head.digest)
+        proof       <- IO.fromEither(proofEither)
+      } yield expect(proof.leafDigest == leaves.head.digest)
+    }
+  }
+
+  test("Creating a proof fails when using a Leaf NOT in the tree") {
+    forall(nonEmptyStringListGen(2, 100)) { strings =>
+      for {
+        leaves <- strings.map(_.asJson).traverse(MerkleNode.Leaf(_))
+        tree   <- MerkleTree.create[IO, String](strings.tail)
+        prover = MerkleProver.make[IO](tree)
+        proofEither <- prover.attestLeaf(leaves.head)
+      } yield expect(proofEither.isLeft)
+    }
+  }
+
+  test("Creating a proof fails when using a digest of a leaf NOT in the tree") {
+    forall(nonEmptyStringListGen(2, 100)) { strings =>
+      for {
+        leaves <- strings.map(_.asJson).traverse(MerkleNode.Leaf(_))
+        tree   <- MerkleTree.create[IO, String](strings.tail)
+        prover = MerkleProver.make[IO](tree)
+        proofEither <- prover.attestDigest(leaves.head.digest)
+      } yield expect(proofEither.isLeft)
+    }
+  }
+}

--- a/src/test/scala/crypto/merkle/MerkleTreeSuite.scala
+++ b/src/test/scala/crypto/merkle/MerkleTreeSuite.scala
@@ -1,0 +1,86 @@
+package crypto.merkle
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.MerkleTree
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object MerkleTreeSuite extends SimpleIOSuite with Checkers {
+
+  test("ensure root of MerkleTree is non-empty for list of non-empty strings") {
+    forall(Gen.nonEmptyListOf(Gen.alphaStr.suchThat(_.nonEmpty))) { strings =>
+      for {
+        merkleTree <- MerkleTree.create[IO, String](strings)
+      } yield expect(merkleTree.rootNode.digest.value.nonEmpty)
+    }
+  }
+
+  test("the same list of strings produces MerkleTrees with the same root") {
+    forall(Gen.nonEmptyListOf(Gen.alphaStr.suchThat(_.nonEmpty))) { strings =>
+      for {
+        merkleTree1 <- MerkleTree.create[IO, String](strings)
+        merkleTree2 <- MerkleTree.create[IO, String](strings)
+      } yield expect.same(merkleTree1.asJson, merkleTree2.asJson)
+    }
+  }
+
+  test("different lists of strings produce MerkleTrees with different roots") {
+    val distinctNonEmptyLists: Gen[(List[String], List[String])] = for {
+      list1 <- Gen.nonEmptyListOf(Gen.alphaStr.suchThat(_.nonEmpty))
+      list2 <- Gen.nonEmptyListOf(Gen.alphaStr.suchThat(_.nonEmpty)).suchThat(_ != list1)
+    } yield (list1, list2)
+
+    forall(distinctNonEmptyLists) { case (strings1, strings2) =>
+      for {
+        merkleTree1 <- MerkleTree.create[IO, String](strings1)
+        merkleTree2 <- MerkleTree.create[IO, String](strings2)
+      } yield expect(merkleTree1.asJson != merkleTree2.asJson)
+    }
+  }
+
+  // to replicate behavior in another environment, make sure to use a hash function that allows for incremental updating
+  // ------------------------------------------
+  // NodeJS example (using blake2b, similar for sha256)
+  // ------------------------------------------
+  //  const blake = require('blakejs');
+  //
+  //  function computeHash(data, prefix) {
+  //    const context = blake.blake2bInit(32, null);
+  //    blake.blake2bUpdate(context, prefix);
+  //    blake.blake2bUpdate(context, data);
+  //    return Buffer.from(blake.blake2bFinal(context))
+  //  }
+  //
+  //  const leafPrefix = Buffer.from([0x00]);
+  //  const internalPrefix = Buffer.from([0x01]);
+  //
+  //  const left = { "a": 1 };
+  //  const leftBinary = Buffer.from(JSON.stringify(left));
+  //  const leftDigest = computeHash(leftBinary, leafPrefix);
+  //
+  //  const right = { "b": 2 };
+  //  const rightBinary = Buffer.from(JSON.stringify(right));
+  //  const rightDigest = computeHash(rightBinary, leafPrefix);
+  //
+  //  const internalHashable = {
+  //    "leftDigest": leftDigest.toString('hex'),
+  //    "rightDigest": rightDigest.toString('hex')
+  //  };
+  //  const internalBinary = Buffer.from(JSON.stringify(internalHashable));
+  //  const internalDigest = computeHash(internalBinary, internalPrefix)
+  //
+  //  console.log(internalDigest.toString('hex'))
+
+  test("ensure root of MerkleTree matches expected value for fixed data") {
+    for {
+      tree <- MerkleTree.create[IO, Json](List(Json.obj("a" -> 1.asJson), Json.obj("b" -> 2.asJson)))
+      expectedRootHash = Hash("1f385c4a728d0e3e49cdf53203df3af57804a18aab5247fa9ddf6f943a65c159")
+    } yield expect.same(tree.rootNode.digest, expectedRootHash)
+  }
+}

--- a/src/test/scala/crypto/merkle/MerkleVerifierSuite.scala
+++ b/src/test/scala/crypto/merkle/MerkleVerifierSuite.scala
@@ -1,0 +1,43 @@
+package crypto.merkle
+
+import cats.effect.IO
+import cats.implicits.toTraverseOps
+
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.api.{MerkleProver, MerkleVerifier}
+import io.constellationnetwork.metagraph_sdk.crypto.merkle.{MerkleNode, MerkleTree}
+
+import io.circe.syntax.EncoderOps
+import shared.Generators.nonEmptyStringListGen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object MerkleVerifierSuite extends SimpleIOSuite with Checkers {
+
+  test("Check whether a valid proof is verified successfully") {
+    forall(nonEmptyStringListGen(1, 100)) { strings =>
+      for {
+        leaves <- strings.traverse(str => MerkleNode.Leaf(str.asJson))
+        tree   <- MerkleTree.create[IO, String](strings)
+        prover = MerkleProver.make[IO](tree)
+        verifier = MerkleVerifier.make[IO](tree.rootNode.digest)
+        proof   <- prover.attestLeaf(leaves.head).flatMap(IO.fromEither)
+        outcome <- verifier.confirm(proof)
+      } yield expect(outcome)
+    }
+  }
+
+  test("Check that a valid proof does NOT verify against another tree") {
+    forall(nonEmptyStringListGen(1, 100)) { strings =>
+      for {
+        leaves <- strings.traverse(str => MerkleNode.Leaf(str.asJson))
+        tree1  <- MerkleTree.create[IO, String](strings)
+        tree2  <- MerkleTree.create[IO, String](List("a", "b", "c"))
+        prover1 = MerkleProver.make[IO](tree1)
+        verifier2 = MerkleVerifier.make[IO](tree2.rootNode.digest)
+        proofEither <- prover1.attestLeaf(leaves.head)
+        proof       <- IO.fromEither(proofEither)
+        outcome     <- verifier2.confirm(proof)
+      } yield expect(!outcome)
+    }
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaProverSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaProverSuite.scala
@@ -1,0 +1,57 @@
+package crypto.mpt
+
+import cats.effect.{IO, Resource}
+import cats.syntax.applicative._
+import cats.syntax.traverse._
+
+import xyz.kd5ujc.accumulators.mpt.MerklePatriciaTrie
+import xyz.kd5ujc.accumulators.mpt.api.MerklePatriciaProver
+import xyz.kd5ujc.binary.JsonSerializer
+import xyz.kd5ujc.hash.impl.Blake2b256Hasher
+import xyz.kd5ujc.hash.l256
+
+import org.bouncycastle.util.encoders.Hex
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object MerklePatriciaProverSuite extends SimpleIOSuite with Checkers {
+
+  private val hasherResource: Resource[IO, Blake2b256Hasher[IO]] =
+    Resource.eval {
+      JsonSerializer.forSync[IO].map(implicit json2bin => new Blake2b256Hasher[IO])
+    }
+
+  private val toDigest: String => l256 = (str: String) => l256.unsafe(Hex.decode(str))
+
+  test("prover can produce an inclusion proof for a path in the trie") {
+    hasherResource.use { implicit hasher =>
+      forall(Gen.listOfN(32, Gen.long).flatMap { list =>
+        Gen.choose(0, list.size - 1).map(index => (list, index))
+      }) {
+        case (list, randomIndex) =>
+          for {
+            leafPairs   <- list.traverse(l => hasher.hash(l).map(_ -> l))
+            trie        <- MerklePatriciaTrie.create(leafPairs.toMap)
+            prover      <- MerklePatriciaProver.make(trie).pure[F]
+            proofEither <- prover.attestDigest(leafPairs(randomIndex)._1)
+            proof       <- IO.fromEither(proofEither)
+          } yield expect(proof.witness.nonEmpty)
+      }
+    }
+  }
+
+  test("prover fails to produce an inclusion proof for a path not in the trie") {
+    hasherResource.use { implicit hasher =>
+      forall(Gen.listOfN(32, Gen.long)) { list =>
+        for {
+          leafMap     <- list.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+          trie        <- MerklePatriciaTrie.create(leafMap)
+          prover      <- MerklePatriciaProver.make(trie).pure[F]
+          proofEither <- prover.attestDigest(toDigest("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+          _           <- IO.fromEither(proofEither).attempt
+        } yield expect(proofEither.isLeft)
+      }
+    }
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaProverSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaProverSuite.scala
@@ -1,57 +1,41 @@
 package crypto.mpt
 
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import cats.syntax.applicative._
 import cats.syntax.traverse._
 
-import xyz.kd5ujc.accumulators.mpt.MerklePatriciaTrie
-import xyz.kd5ujc.accumulators.mpt.api.MerklePatriciaProver
-import xyz.kd5ujc.binary.JsonSerializer
-import xyz.kd5ujc.hash.impl.Blake2b256Hasher
-import xyz.kd5ujc.hash.l256
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaTrie
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.MerklePatriciaProver
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+import io.constellationnetwork.security.hash.Hash
 
-import org.bouncycastle.util.encoders.Hex
 import org.scalacheck.Gen
 import weaver.SimpleIOSuite
 import weaver.scalacheck.Checkers
 
 object MerklePatriciaProverSuite extends SimpleIOSuite with Checkers {
 
-  private val hasherResource: Resource[IO, Blake2b256Hasher[IO]] =
-    Resource.eval {
-      JsonSerializer.forSync[IO].map(implicit json2bin => new Blake2b256Hasher[IO])
-    }
-
-  private val toDigest: String => l256 = (str: String) => l256.unsafe(Hex.decode(str))
-
   test("prover can produce an inclusion proof for a path in the trie") {
-    hasherResource.use { implicit hasher =>
-      forall(Gen.listOfN(32, Gen.long).flatMap { list =>
-        Gen.choose(0, list.size - 1).map(index => (list, index))
-      }) {
-        case (list, randomIndex) =>
-          for {
-            leafPairs   <- list.traverse(l => hasher.hash(l).map(_ -> l))
-            trie        <- MerklePatriciaTrie.create(leafPairs.toMap)
-            prover      <- MerklePatriciaProver.make(trie).pure[F]
-            proofEither <- prover.attestDigest(leafPairs(randomIndex)._1)
-            proof       <- IO.fromEither(proofEither)
-          } yield expect(proof.witness.nonEmpty)
-      }
+    forall(Gen.listOfN(32, Gen.long).flatMap { list =>
+      Gen.choose(0, list.size - 1).map(index => (list, index))
+    }) { case (list, randomIndex) =>
+      for {
+        leafPairs <- list.traverse(el => el.computeDigest.map(_ -> el))
+        trie      <- MerklePatriciaTrie.create(leafPairs.toMap)
+        prover    <- MerklePatriciaProver.make(trie).pure[F]
+        proof     <- prover.attestDigest(leafPairs(randomIndex)._1).flatMap(IO.fromEither)
+      } yield expect(proof.witness.nonEmpty)
     }
   }
 
   test("prover fails to produce an inclusion proof for a path not in the trie") {
-    hasherResource.use { implicit hasher =>
-      forall(Gen.listOfN(32, Gen.long)) { list =>
-        for {
-          leafMap     <- list.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-          trie        <- MerklePatriciaTrie.create(leafMap)
-          prover      <- MerklePatriciaProver.make(trie).pure[F]
-          proofEither <- prover.attestDigest(toDigest("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
-          _           <- IO.fromEither(proofEither).attempt
-        } yield expect(proofEither.isLeft)
-      }
+    forall(Gen.listOfN(32, Gen.long)) { list =>
+      for {
+        leafMap     <- list.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+        trie        <- MerklePatriciaTrie.create(leafMap)
+        prover      <- MerklePatriciaProver.make(trie).pure[F]
+        proofEither <- prover.attestDigest(Hash("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+      } yield expect(proofEither.isLeft)
     }
   }
 }

--- a/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
@@ -723,4 +723,26 @@ object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
       } yield MerklePatriciaTrie(ext2)
     } yield expect(trieActual == trieExpected)
   }
+
+  test("create, insert, then remove produces original root hash") {
+    val initialLeafMap = Map[Hash, String](
+      Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD1") -> "initial value 1",
+      Hash("BFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD2") -> "initial value 2"
+    )
+    
+    val insertKey = Hash("CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD3")
+    val insertValue = "inserted value"
+
+    for {
+      trie1 <- MerklePatriciaTrie.create(initialLeafMap)
+      root1 = trie1.rootNode.digest
+      
+      trie2 <- MerklePatriciaTrie.insert(trie1, Map(insertKey -> insertValue)).flatMap(IO.fromEither(_))
+      root2 = trie2.rootNode.digest
+      
+      trie3 <- MerklePatriciaTrie.remove(trie2, List(insertKey)).flatMap(IO.fromEither(_))
+      root3 = trie3.rootNode.digest
+      
+    } yield expect(root1 == root3 && root1 != root2 && root2 != root3)
+  }
 }

--- a/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
@@ -1,0 +1,709 @@
+package crypto.mpt
+
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedSet
+
+import xyz.kd5ujc.accumulators.mpt.{MerklePatriciaNode, MerklePatriciaTrie, Nibble}
+import xyz.kd5ujc.binary.JsonSerializer
+import xyz.kd5ujc.hash.impl.Blake2b256Hasher
+import xyz.kd5ujc.hash.{Digest, l256}
+
+import io.circe.syntax.EncoderOps
+import org.bouncycastle.util.encoders.Hex
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
+
+  private val hasherResource: Resource[IO, Blake2b256Hasher[IO]] =
+    Resource.eval {
+      JsonSerializer.forSync[IO].map { implicit json2bin =>
+        new Blake2b256Hasher[IO]
+      }
+    }
+
+  private val toDigest: String => l256 = (str: String) => l256.unsafe(Hex.decode(str))
+  private val toNibbleSeq: String => Seq[Nibble] = (str: String) => scala.collection.immutable.ArraySeq.from(str.map(Nibble.unsafe))
+
+  test("trie can be encoded and decoded from json") {
+    hasherResource.use { implicit hasher =>
+      forall(Gen.listOfN(32, Gen.long)) { listLong =>
+        for {
+          leafMap      <- listLong.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+          trieExpected <- MerklePatriciaTrie.create(leafMap)
+          trieActual   <- IO.fromEither(trieExpected.asJson.as[MerklePatriciaTrie])
+        } yield expect(trieExpected == trieActual)
+      }
+    }
+  }
+
+  test("root of trie is non-empty") {
+    hasherResource.use { implicit hasher =>
+      forall(Gen.listOfN(32, Gen.long)) { listLong =>
+        for {
+          leafMap <- listLong.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+          trie    <- MerklePatriciaTrie.create(leafMap)
+        } yield expect(trie.rootNode.digest.value.nonEmpty)
+      }
+    }
+  }
+
+  test("trie from create contains all values in leaves") {
+    hasherResource.use { implicit hasher =>
+      forall(Gen.listOfN(32, Gen.long)) { listLong =>
+        for {
+          leafMap    <- listLong.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+          trie       <- MerklePatriciaTrie.create(leafMap)
+          listLeaves <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie).traverse(_.data.as[Long]))
+          sortedInputSet = SortedSet.from(listLong)
+          sortedOutputSet = SortedSet.from(listLeaves)
+        } yield expect(sortedInputSet == sortedOutputSet)
+      }
+    }
+  }
+
+  test("trie from insert contains all values in leaves") {
+    val gen = for {
+      list1 <- Gen.listOfN(32, Gen.long)
+      list2 <- Gen.listOfN(32, Gen.long)
+    } yield (list1, list2)
+
+    hasherResource.use { implicit hasher =>
+      forall(gen) {
+        case (list1, list2) =>
+          for {
+            initMap    <- list1.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+            updMap     <- list2.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+            trie       <- MerklePatriciaTrie.create(initMap)
+            trie2      <- MerklePatriciaTrie.insert(trie, updMap).flatMap(IO.fromEither(_))
+            listLeaves <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie2).traverse(_.data.as[Long]))
+            sortedInputSet = SortedSet.from(list1 ++ list2)
+            sortedOutputSet = SortedSet.from(listLeaves)
+          } yield expect(sortedInputSet == sortedOutputSet)
+      }
+    }
+  }
+
+  test("trie can remove leaves") {
+    val gen = for {
+      createList <- Gen.listOfN(32, Gen.long)
+      removeList <- Gen.someOf(createList).map(_.toList)
+    } yield (createList, removeList)
+
+    hasherResource.use { implicit hasher =>
+      forall(gen) {
+        case (createList, removeList) =>
+          for {
+            createMap   <- createList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+            removePaths <- removeList.traverse(hasher.hash(_))
+            trie1       <- MerklePatriciaTrie.create(createMap)
+            trie2       <- MerklePatriciaTrie.remove(trie1, removePaths).flatMap(IO.fromEither(_))
+            listLeaves  <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie2).traverse(_.data.as[Long]))
+          } yield expect(listLeaves.forall(!removeList.contains(_)))
+      }
+    }
+  }
+
+  test("updating a trie with an existing path updates the data held by the leaf and changes the root node digest") {
+    hasherResource.use { implicit hasher =>
+      forall(Gen.long.flatMap(v1 => Gen.long.flatMap(v2 => (v1, v2))).suchThat(g => g._1 != g._2)) {
+        case (val1, val2) =>
+          for {
+            path  <- IO.fromEither(l256.from(Array.fill(32)(1: Byte)).toEither.leftMap(err => new Exception(s"${err.toString}")))
+            trie1 <- MerklePatriciaTrie.create[IO, Long](Map(path -> val1))
+            trie2 <- MerklePatriciaTrie.insert[IO, Long](trie1, Map(path -> val2)).flatMap(IO.fromEither(_))
+            (root1, data1, digest1) <- trie1.rootNode match {
+              case MerklePatriciaNode.Leaf(_, _data, _digest) => IO.pure((trie1.rootNode.digest, _data, _digest))
+              case _                                          => IO.raiseError(new Exception("unexpected root node found"))
+            }
+            (root2, data2, digest2) <- trie2.rootNode match {
+              case MerklePatriciaNode.Leaf(_, _data, _digest) => IO.pure((trie2.rootNode.digest, _data, _digest))
+              case _                                          => IO.raiseError(new Exception("unexpected root node found"))
+            }
+          } yield expect(root1 != root2 && data1 != data2 && digest1 != digest2)
+      }
+    }
+  }
+
+  test("create produces a trie with a known root digest") {
+    hasherResource.use { implicit hasher =>
+      for {
+        leafMap <- (0 to 31).toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+        trie    <- MerklePatriciaTrie.create[IO, Int](leafMap)
+      } yield expect(trie.rootNode.digest == toDigest("fddee3f51499aeb0077ef1ab2dd3756d5083a8912e9a8b83fae2d446e282fd57"))
+    }
+  }
+
+  test("create then insert produces a trie with a known root digest") {
+    hasherResource.use { implicit hasher =>
+      for {
+        leafMap   <- (0 to 31).toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+        trie      <- MerklePatriciaTrie.create[IO, Int](leafMap)
+        newLeaves <- (-31 to -0).toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+        trie2     <- MerklePatriciaTrie.insert(trie, newLeaves).flatMap(IO.fromEither(_))
+      } yield expect(trie2.rootNode.digest == toDigest("543e932b3a73fba7572d393d733b0400756e8cad163cc32303598e4ccf6395ed"))
+    }
+  }
+
+  test("create then remove produces a trie with a known root digest") {
+    hasherResource.use { implicit hasher =>
+      for {
+        leafMap   <- (0 to 31).toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+        trie      <- MerklePatriciaTrie.create[IO, Int](leafMap)
+        remLeaves <- (17 to 31).toList.traverse(l => hasher.hash(l))
+        trie2     <- MerklePatriciaTrie.remove(trie, remLeaves).flatMap(IO.fromEither(_))
+      } yield expect(trie2.rootNode.digest == toDigest("59edbf8dbc3d09a6d4657ab3978971b792318d799e97d100b6a244aa018a2ee9"))
+    }
+  }
+
+  test("create can produce a fixed simple trie with a single branch and multiple leaves") {
+    hasherResource.use { implicit hasher =>
+      for {
+        content    <- ((1 to 5) ++ (7 to 9)).pure[IO]
+        leafMap    <- content.toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
+        trieActual <- MerklePatriciaTrie.create[IO, Int](leafMap)
+        trieExpected <- for {
+          leafNodes <- leafMap.toList.traverse {
+            case (digest, data) =>
+              val path = Nibble(digest)
+              val json = data.asJson
+              MerklePatriciaNode.Leaf[IO](path.tail, json).map(leaf => Map(path.head -> leaf))
+          }
+          mergedLeafNodes = leafNodes.fold(Map.empty)(_ ++ _)
+          branchNode <- MerklePatriciaNode.Branch[IO](mergedLeafNodes)
+        } yield MerklePatriciaTrie(branchNode)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create produces a fixed complex trie with branches, extensions, and leaves") {
+    val leafMap = Map[Digest, String](
+      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD2") -> "are we done yet?",
+      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1") -> "yet another value",
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") -> "a value",
+      toDigest("1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") -> "another value"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), "a value".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), "another value".asJson)
+          leaf3 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("1"), "yet another value".asJson)
+          leaf4 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("2"), "are we done yet?".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x0f: Byte) -> leaf3,
+              Nibble.unsafe(0x0d: Byte) -> leaf4
+            )
+          )
+          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), branch1)
+          branch2 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x01: Byte) -> leaf2,
+              Nibble.unsafe(0x0a: Byte) -> ext
+            )
+          )
+        } yield MerklePatriciaTrie(branch2)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  /**
+   * For a 2-leaf trie there are two possible configurations (B = Branch, L = Leaf, E = Extension)
+   * Config A  | Config B  |
+   * ----------|-----------|
+   *     B     |     E     |
+   *    / \    |     |     |
+   *   L   L   |     B     |
+   *           |    / \    |
+   *           |   L   L   |
+   * -----------------------
+   */
+  test("create produces a 2-leaf trie in configuration A") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> leaf2
+            )
+          )
+        } yield MerklePatriciaTrie(branch1)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create produces a 2-leaf trie in configuration B") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("2"), "leaf 2".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x0a: Byte) -> leaf1,
+              Nibble.unsafe(0x0b: Byte) -> leaf2
+            )
+          )
+          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), branch1)
+        } yield MerklePatriciaTrie(ext)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  /**
+   * For a 3-leaf trie there are six possible configurations (B = Branch, L = Leaf, E = Extension)
+   * Config A  | Config B  | Config C  | Config D  | Config E  | Config F  |
+   * ----------|-----------|-----------|-----------|-----------|-----------|
+   *     B     |     E     |      B    |      E    |      B    |      E    |
+   *   / | \   |     |     |     / \   |      |    |     / \   |      |    |
+   *  L  L  L  |     B     |    B   L  |      B    |    E   L  |      B    |
+   *           |   / | \   |   / \     |     / \   |    |      |     / \   |
+   *           |  L  L  L  |  L   L    |    B   L  |    B      |    E   L  |
+   *           |           |           |   / \     |   / \     |    |      |
+   *           |           |           |  L   L    |  L   L    |    B      |
+   *           |           |           |           |           |   / \     |
+   *           |           |           |           |           |  L   L    |
+   * -----------------------------------------------------------------------
+   */
+  test("create produces a 3-leaf trie in configuration A") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> leaf2,
+              Nibble.unsafe(0x0f: Byte) -> leaf3
+            )
+          )
+        } yield MerklePatriciaTrie(branch1)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create produces a 3-leaf trie in configuration B") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x0a: Byte) -> leaf1,
+              Nibble.unsafe(0x0b: Byte) -> leaf2,
+              Nibble.unsafe(0x0c: Byte) -> leaf3
+            )
+          )
+          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), branch1)
+        } yield MerklePatriciaTrie(ext)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create produces a 3-leaf trie in configuration C") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("AAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x0a: Byte) -> leaf2,
+              Nibble.unsafe(0x0f: Byte) -> leaf3
+            )
+          )
+          branch2 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> branch1
+            )
+          )
+        } yield MerklePatriciaTrie(branch2)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create produces a 3-leaf trie in configuration D") {
+    val leafMap = Map[Digest, String](
+      toDigest("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("FFAAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("FFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x0a: Byte) -> leaf2,
+              Nibble.unsafe(0x0f: Byte) -> leaf3
+            )
+          )
+          branch2 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> branch1
+            )
+          )
+          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch2)
+        } yield MerklePatriciaTrie(ext)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create produces a 3-leaf trie in configuration E") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("AFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("AFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf2,
+              Nibble.unsafe(0x0a: Byte) -> leaf3
+            )
+          )
+          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch1)
+          branch2 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> ext
+            )
+          )
+        } yield MerklePatriciaTrie(branch2)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create produces a 3-leaf trie in configuration F") {
+    val leafMap = Map[Digest, String](
+      toDigest("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("FFAFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie.create(leafMap)
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf2,
+              Nibble.unsafe(0x0a: Byte) -> leaf3
+            )
+          )
+          ext1 <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch1)
+          branch2 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> ext1
+            )
+          )
+          ext2 <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch2)
+        } yield MerklePatriciaTrie(ext2)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create then remove produces a 3-leaf trie in configuration A") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie
+          .create(leafMap)
+          .flatMap(MerklePatriciaTrie.remove(_, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4"))))
+          .flatMap(IO.fromEither(_))
+
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> leaf2,
+              Nibble.unsafe(0x0f: Byte) -> leaf3
+            )
+          )
+        } yield MerklePatriciaTrie(branch1)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create then remove produces a 3-leaf trie in configuration B") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie
+          .create(leafMap)
+          .flatMap(trie =>
+            MerklePatriciaTrie.remove(trie, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
+          )
+          .flatMap(IO.fromEither(_))
+
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x0a: Byte) -> leaf1,
+              Nibble.unsafe(0x0b: Byte) -> leaf2,
+              Nibble.unsafe(0x0c: Byte) -> leaf3
+            )
+          )
+          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), branch1)
+        } yield MerklePatriciaTrie(ext)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create then remove produces a 3-leaf trie in configuration C") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("AAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie
+          .create(leafMap)
+          .flatMap(trie =>
+            MerklePatriciaTrie.remove(trie, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
+          )
+          .flatMap(IO.fromEither(_))
+
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x0a: Byte) -> leaf2,
+              Nibble.unsafe(0x0f: Byte) -> leaf3
+            )
+          )
+          branch2 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> branch1
+            )
+          )
+        } yield MerklePatriciaTrie(branch2)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create then remove produces a 3-leaf trie in configuration D") {
+    val leafMap = Map[Digest, String](
+      toDigest("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("FFAAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("FFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie
+          .create(leafMap)
+          .flatMap(MerklePatriciaTrie.remove(_, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4"))))
+          .flatMap(IO.fromEither(_))
+
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x0a: Byte) -> leaf2,
+              Nibble.unsafe(0x0f: Byte) -> leaf3
+            )
+          )
+          branch2 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> branch1
+            )
+          )
+          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch2)
+        } yield MerklePatriciaTrie(ext)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create then remove produces a 3-leaf trie in configuration E") {
+    val leafMap = Map[Digest, String](
+      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("AFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("AFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie
+          .create(leafMap)
+          .flatMap(MerklePatriciaTrie.remove(_, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4"))))
+          .flatMap(IO.fromEither(_))
+
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf2,
+              Nibble.unsafe(0x0a: Byte) -> leaf3
+            )
+          )
+          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch1)
+          branch2 <- MerklePatriciaNode.Branch[IO](
+            Map(
+              Nibble.unsafe(0x00: Byte) -> leaf1,
+              Nibble.unsafe(0x0a: Byte) -> ext
+            )
+          )
+        } yield MerklePatriciaTrie(branch2)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+
+  test("create then remove produces a 3-leaf trie in configuration F") {
+    val leafMap = Map[Digest, String](
+      toDigest("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      toDigest("FFAFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    )
+
+    hasherResource.use { implicit hasher =>
+      for {
+        trieActual <- MerklePatriciaTrie
+          .create(leafMap)
+          .flatMap(MerklePatriciaTrie.remove(_, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4"))))
+          .flatMap(IO.fromEither(_))
+
+        trieExpected <- for {
+          leaf1 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
+          leaf2 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
+          leaf3 <- MerklePatriciaNode
+            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
+          branch1 <- MerklePatriciaNode.Branch[IO](Map(Nibble.unsafe(0x00: Byte) -> leaf2, Nibble.unsafe(0x0a: Byte) -> leaf3))
+          ext1    <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch1)
+          branch2 <- MerklePatriciaNode.Branch[IO](Map(Nibble.unsafe(0x00: Byte) -> leaf1, Nibble.unsafe(0x0a: Byte) -> ext1))
+          ext2    <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch2)
+        } yield MerklePatriciaTrie(ext2)
+      } yield expect(trieActual == trieExpected)
+    }
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
@@ -1,67 +1,49 @@
 package crypto.mpt
 
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import cats.syntax.all._
 
 import scala.collection.immutable.SortedSet
 
-import xyz.kd5ujc.accumulators.mpt.{MerklePatriciaNode, MerklePatriciaTrie, Nibble}
-import xyz.kd5ujc.binary.JsonSerializer
-import xyz.kd5ujc.hash.impl.Blake2b256Hasher
-import xyz.kd5ujc.hash.{Digest, l256}
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaNode, MerklePatriciaTrie, Nibble}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+import io.constellationnetwork.security.hash.Hash
 
 import io.circe.syntax.EncoderOps
-import org.bouncycastle.util.encoders.Hex
 import org.scalacheck.Gen
 import weaver.SimpleIOSuite
 import weaver.scalacheck.Checkers
 
 object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
 
-  private val hasherResource: Resource[IO, Blake2b256Hasher[IO]] =
-    Resource.eval {
-      JsonSerializer.forSync[IO].map { implicit json2bin =>
-        new Blake2b256Hasher[IO]
-      }
-    }
-
-  private val toDigest: String => l256 = (str: String) => l256.unsafe(Hex.decode(str))
-  private val toNibbleSeq: String => Seq[Nibble] = (str: String) => scala.collection.immutable.ArraySeq.from(str.map(Nibble.unsafe))
-
   test("trie can be encoded and decoded from json") {
-    hasherResource.use { implicit hasher =>
-      forall(Gen.listOfN(32, Gen.long)) { listLong =>
-        for {
-          leafMap      <- listLong.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-          trieExpected <- MerklePatriciaTrie.create(leafMap)
-          trieActual   <- IO.fromEither(trieExpected.asJson.as[MerklePatriciaTrie])
-        } yield expect(trieExpected == trieActual)
-      }
+    forall(Gen.listOfN(32, Gen.long)) { listLong =>
+      for {
+        leafMap      <- listLong.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+        trieExpected <- MerklePatriciaTrie.create(leafMap)
+        trieActual   <- IO.fromEither(trieExpected.asJson.as[MerklePatriciaTrie])
+      } yield expect(trieExpected == trieActual)
     }
   }
 
   test("root of trie is non-empty") {
-    hasherResource.use { implicit hasher =>
-      forall(Gen.listOfN(32, Gen.long)) { listLong =>
-        for {
-          leafMap <- listLong.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-          trie    <- MerklePatriciaTrie.create(leafMap)
-        } yield expect(trie.rootNode.digest.value.nonEmpty)
-      }
+    forall(Gen.listOfN(32, Gen.long)) { listLong =>
+      for {
+        leafMap <- listLong.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+        trie    <- MerklePatriciaTrie.create(leafMap)
+      } yield expect(trie.rootNode.digest.value.nonEmpty)
     }
   }
 
   test("trie from create contains all values in leaves") {
-    hasherResource.use { implicit hasher =>
-      forall(Gen.listOfN(32, Gen.long)) { listLong =>
-        for {
-          leafMap    <- listLong.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-          trie       <- MerklePatriciaTrie.create(leafMap)
-          listLeaves <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie).traverse(_.data.as[Long]))
-          sortedInputSet = SortedSet.from(listLong)
-          sortedOutputSet = SortedSet.from(listLeaves)
-        } yield expect(sortedInputSet == sortedOutputSet)
-      }
+    forall(Gen.listOfN(32, Gen.long)) { listLong =>
+      for {
+        leafMap    <- listLong.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+        trie       <- MerklePatriciaTrie.create(leafMap)
+        listLeaves <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie).traverse(_.data.as[Long]))
+        sortedInputSet = SortedSet.from(listLong)
+        sortedOutputSet = SortedSet.from(listLeaves)
+      } yield expect(sortedInputSet == sortedOutputSet)
     }
   }
 
@@ -71,19 +53,16 @@ object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
       list2 <- Gen.listOfN(32, Gen.long)
     } yield (list1, list2)
 
-    hasherResource.use { implicit hasher =>
-      forall(gen) {
-        case (list1, list2) =>
-          for {
-            initMap    <- list1.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-            updMap     <- list2.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-            trie       <- MerklePatriciaTrie.create(initMap)
-            trie2      <- MerklePatriciaTrie.insert(trie, updMap).flatMap(IO.fromEither(_))
-            listLeaves <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie2).traverse(_.data.as[Long]))
-            sortedInputSet = SortedSet.from(list1 ++ list2)
-            sortedOutputSet = SortedSet.from(listLeaves)
-          } yield expect(sortedInputSet == sortedOutputSet)
-      }
+    forall(gen) { case (list1, list2) =>
+      for {
+        initMap    <- list1.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+        updMap     <- list2.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+        trie       <- MerklePatriciaTrie.create(initMap)
+        trie2      <- MerklePatriciaTrie.insert(trie, updMap).flatMap(IO.fromEither(_))
+        listLeaves <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie2).traverse(_.data.as[Long]))
+        sortedInputSet = SortedSet.from(list1 ++ list2)
+        sortedOutputSet = SortedSet.from(listLeaves)
+      } yield expect(sortedInputSet == sortedOutputSet)
     }
   }
 
@@ -93,127 +72,122 @@ object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
       removeList <- Gen.someOf(createList).map(_.toList)
     } yield (createList, removeList)
 
-    hasherResource.use { implicit hasher =>
-      forall(gen) {
-        case (createList, removeList) =>
-          for {
-            createMap   <- createList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-            removePaths <- removeList.traverse(hasher.hash(_))
-            trie1       <- MerklePatriciaTrie.create(createMap)
-            trie2       <- MerklePatriciaTrie.remove(trie1, removePaths).flatMap(IO.fromEither(_))
-            listLeaves  <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie2).traverse(_.data.as[Long]))
-          } yield expect(listLeaves.forall(!removeList.contains(_)))
-      }
+    forall(gen) { case (createList, removeList) =>
+      for {
+        createMap   <- createList.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+        removePaths <- removeList.traverse[IO, Hash](el => el.computeDigest)
+        trie1       <- MerklePatriciaTrie.create(createMap)
+        trie2       <- MerklePatriciaTrie.remove(trie1, removePaths).flatMap(IO.fromEither(_))
+        listLeaves  <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie2).traverse(_.data.as[Long]))
+      } yield expect(listLeaves.forall(!removeList.contains(_)))
     }
   }
 
   test("updating a trie with an existing path updates the data held by the leaf and changes the root node digest") {
-    hasherResource.use { implicit hasher =>
-      forall(Gen.long.flatMap(v1 => Gen.long.flatMap(v2 => (v1, v2))).suchThat(g => g._1 != g._2)) {
-        case (val1, val2) =>
-          for {
-            path  <- IO.fromEither(l256.from(Array.fill(32)(1: Byte)).toEither.leftMap(err => new Exception(s"${err.toString}")))
-            trie1 <- MerklePatriciaTrie.create[IO, Long](Map(path -> val1))
-            trie2 <- MerklePatriciaTrie.insert[IO, Long](trie1, Map(path -> val2)).flatMap(IO.fromEither(_))
-            (root1, data1, digest1) <- trie1.rootNode match {
-              case MerklePatriciaNode.Leaf(_, _data, _digest) => IO.pure((trie1.rootNode.digest, _data, _digest))
-              case _                                          => IO.raiseError(new Exception("unexpected root node found"))
-            }
-            (root2, data2, digest2) <- trie2.rootNode match {
-              case MerklePatriciaNode.Leaf(_, _data, _digest) => IO.pure((trie2.rootNode.digest, _data, _digest))
-              case _                                          => IO.raiseError(new Exception("unexpected root node found"))
-            }
-          } yield expect(root1 != root2 && data1 != data2 && digest1 != digest2)
-      }
+    forall(Gen.long.flatMap(v1 => Gen.long.flatMap(v2 => (v1, v2))).suchThat(g => g._1 != g._2)) { case (val1, val2) =>
+      for {
+        path  <- Hash(Array.fill(32)('1').mkString).pure[IO]
+        trie1 <- MerklePatriciaTrie.create[IO, Long](Map(path -> val1))
+        trie2 <- MerklePatriciaTrie.insert[IO, Long](trie1, Map(path -> val2)).flatMap(IO.fromEither(_))
+        (root1, data1, digest1) <- trie1.rootNode match {
+          case MerklePatriciaNode.Leaf(_, _data, _digest) => IO.pure((trie1.rootNode.digest, _data, _digest))
+          case _                                          => IO.raiseError(new Exception("unexpected root node found"))
+        }
+        (root2, data2, digest2) <- trie2.rootNode match {
+          case MerklePatriciaNode.Leaf(_, _data, _digest) => IO.pure((trie2.rootNode.digest, _data, _digest))
+          case _                                          => IO.raiseError(new Exception("unexpected root node found"))
+        }
+      } yield expect(root1 != root2 && data1 != data2 && digest1 != digest2)
     }
+
   }
 
   test("create produces a trie with a known root digest") {
-    hasherResource.use { implicit hasher =>
-      for {
-        leafMap <- (0 to 31).toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-        trie    <- MerklePatriciaTrie.create[IO, Int](leafMap)
-      } yield expect(trie.rootNode.digest == toDigest("fddee3f51499aeb0077ef1ab2dd3756d5083a8912e9a8b83fae2d446e282fd57"))
-    }
+    for {
+      leafMap <- (0 to 31).toList.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+      trie    <- MerklePatriciaTrie.create[IO, Int](leafMap)
+    } yield expect(trie.rootNode.digest == Hash("2c225239414a82ea1b72061de98199f90e910106b9e9896bd6df4cc74e6c39a0"))
+
   }
 
   test("create then insert produces a trie with a known root digest") {
-    hasherResource.use { implicit hasher =>
-      for {
-        leafMap   <- (0 to 31).toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-        trie      <- MerklePatriciaTrie.create[IO, Int](leafMap)
-        newLeaves <- (-31 to -0).toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-        trie2     <- MerklePatriciaTrie.insert(trie, newLeaves).flatMap(IO.fromEither(_))
-      } yield expect(trie2.rootNode.digest == toDigest("543e932b3a73fba7572d393d733b0400756e8cad163cc32303598e4ccf6395ed"))
-    }
+    for {
+      leafMap   <- (0 to 31).toList.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+      trie      <- MerklePatriciaTrie.create[IO, Int](leafMap)
+      newLeaves <- (-31 to -0).toList.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+      trie2     <- MerklePatriciaTrie.insert(trie, newLeaves).flatMap(IO.fromEither(_))
+    } yield expect(trie2.rootNode.digest == Hash("f01117b41e875b6f432e12a10b340ddd0cafa077a4b9b82aed688695adf58c45"))
   }
 
   test("create then remove produces a trie with a known root digest") {
-    hasherResource.use { implicit hasher =>
-      for {
-        leafMap   <- (0 to 31).toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-        trie      <- MerklePatriciaTrie.create[IO, Int](leafMap)
-        remLeaves <- (17 to 31).toList.traverse(l => hasher.hash(l))
-        trie2     <- MerklePatriciaTrie.remove(trie, remLeaves).flatMap(IO.fromEither(_))
-      } yield expect(trie2.rootNode.digest == toDigest("59edbf8dbc3d09a6d4657ab3978971b792318d799e97d100b6a244aa018a2ee9"))
-    }
+    for {
+      leafMap   <- (0 to 31).toList.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+      trie      <- MerklePatriciaTrie.create[IO, Int](leafMap)
+      remLeaves <- (17 to 31).toList.traverse[IO, Hash](el => el.computeDigest)
+      trie2     <- MerklePatriciaTrie.remove(trie, remLeaves).flatMap(IO.fromEither(_))
+    } yield expect(trie2.rootNode.digest == Hash("dd0c87acf3b891f2461cb9776a1e3376216b156ff0bebdb6b7c1b4c6f8ee9f35"))
   }
 
+  // this test relies on the happenstance that SHA256 hash of each (1,2,3,4,7,8,9) don't share a common prefix
   test("create can produce a fixed simple trie with a single branch and multiple leaves") {
-    hasherResource.use { implicit hasher =>
-      for {
-        content    <- ((1 to 5) ++ (7 to 9)).pure[IO]
-        leafMap    <- content.toList.traverse(l => hasher.hash(l).map(_ -> l)).map(_.toMap)
-        trieActual <- MerklePatriciaTrie.create[IO, Int](leafMap)
-        trieExpected <- for {
-          leafNodes <- leafMap.toList.traverse {
-            case (digest, data) =>
-              val path = Nibble(digest)
-              val json = data.asJson
-              MerklePatriciaNode.Leaf[IO](path.tail, json).map(leaf => Map(path.head -> leaf))
-          }
-          mergedLeafNodes = leafNodes.fold(Map.empty)(_ ++ _)
-          branchNode <- MerklePatriciaNode.Branch[IO](mergedLeafNodes)
-        } yield MerklePatriciaTrie(branchNode)
-      } yield expect(trieActual == trieExpected)
-    }
+    for {
+      content    <- List(1, 2, 3, 5, 7, 8, 9).pure[IO]
+      leafMap    <- content.traverse(el => el.computeDigest.map(_ -> el)).map(_.toMap)
+      trieActual <- MerklePatriciaTrie.create[IO, Int](leafMap)
+      trieExpected <- for {
+        leafNodes <- leafMap.toList.traverse { case (digest, data) =>
+          val path = Nibble(digest)
+          val json = data.asJson
+          MerklePatriciaNode.Leaf[IO](path.tail, json).map(leaf => Map(path.head -> leaf))
+        }
+        mergedLeafNodes = leafNodes.fold(Map.empty)(_ ++ _)
+        branchNode <- MerklePatriciaNode.Branch[IO](mergedLeafNodes)
+      } yield MerklePatriciaTrie(branchNode)
+    } yield expect(trieActual == trieExpected)
   }
 
   test("create produces a fixed complex trie with branches, extensions, and leaves") {
-    val leafMap = Map[Digest, String](
-      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD2") -> "are we done yet?",
-      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1") -> "yet another value",
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") -> "a value",
-      toDigest("1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") -> "another value"
+    val leafMap = Map[Hash, String](
+      Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD2") -> "are we done yet?",
+      Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1") -> "yet another value",
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") -> "a value",
+      Hash("1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") -> "another value"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), "a value".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), "another value".asJson)
-          leaf3 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("1"), "yet another value".asJson)
-          leaf4 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("2"), "are we done yet?".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x0f: Byte) -> leaf3,
-              Nibble.unsafe(0x0d: Byte) -> leaf4
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+        )
+        leaf2Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+        )
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("1"))
+        leaf4Rem <- IO.fromEither(Nibble.fromHexString("2"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "a value".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "another value".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "yet another value".asJson)
+        leaf4    <- MerklePatriciaNode.Leaf[IO](leaf4Rem, "are we done yet?".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x0f: Byte) -> leaf3,
+            Nibble.unsafe(0x0d: Byte) -> leaf4
           )
-          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), branch1)
-          branch2 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x01: Byte) -> leaf2,
-              Nibble.unsafe(0x0a: Byte) -> ext
-            )
+        )
+        extShared <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+        )
+        ext <- MerklePatriciaNode.Extension[IO](extShared, branch1)
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x01: Byte) -> leaf2,
+            Nibble.unsafe(0x0a: Byte) -> ext
           )
-        } yield MerklePatriciaTrie(branch2)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+      } yield MerklePatriciaTrie(branch2)
+    } yield expect(trieActual == trieExpected)
   }
 
   /**
@@ -228,52 +202,57 @@ object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
    * -----------------------
    */
   test("create produces a 2-leaf trie in configuration A") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> leaf2
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1")
+        )
+        leaf2Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2")
+        )
+        leaf1 <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2 <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> leaf2
           )
-        } yield MerklePatriciaTrie(branch1)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+      } yield MerklePatriciaTrie(branch1)
+    } yield expect(trieActual == trieExpected)
+
   }
 
   test("create produces a 2-leaf trie in configuration B") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("2"), "leaf 2".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x0a: Byte) -> leaf1,
-              Nibble.unsafe(0x0b: Byte) -> leaf2
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(Nibble.fromHexString("1"))
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("2"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x0a: Byte) -> leaf1,
+            Nibble.unsafe(0x0b: Byte) -> leaf2
           )
-          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), branch1)
-        } yield MerklePatriciaTrie(ext)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+        extRem <- IO.fromEither(Nibble.fromHexString("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+        ext    <- MerklePatriciaNode.Extension[IO](extRem, branch1)
+      } yield MerklePatriciaTrie(ext)
+    } yield expect(trieActual == trieExpected)
+
   }
 
   /**
@@ -292,418 +271,456 @@ object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
    * -----------------------------------------------------------------------
    */
   test("create produces a 3-leaf trie in configuration A") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> leaf2,
-              Nibble.unsafe(0x0f: Byte) -> leaf3
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1")
+        )
+        leaf2Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2")
+        )
+        leaf3Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3")
+        )
+        leaf1 <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2 <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3 <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> leaf2,
+            Nibble.unsafe(0x0f: Byte) -> leaf3
           )
-        } yield MerklePatriciaTrie(branch1)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+      } yield MerklePatriciaTrie(branch1)
+    } yield expect(trieActual == trieExpected)
+
   }
 
   test("create produces a 3-leaf trie in configuration B") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x0a: Byte) -> leaf1,
-              Nibble.unsafe(0x0b: Byte) -> leaf2,
-              Nibble.unsafe(0x0c: Byte) -> leaf3
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(Nibble.fromHexString("1"))
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("2"))
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("3"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x0a: Byte) -> leaf1,
+            Nibble.unsafe(0x0b: Byte) -> leaf2,
+            Nibble.unsafe(0x0c: Byte) -> leaf3
           )
-          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), branch1)
-        } yield MerklePatriciaTrie(ext)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+        extRem <- IO.fromEither(Nibble.fromHexString("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+        ext    <- MerklePatriciaNode.Extension[IO](extRem, branch1)
+      } yield MerklePatriciaTrie(ext)
+    } yield expect(trieActual == trieExpected)
   }
 
   test("create produces a 3-leaf trie in configuration C") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("AAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("AAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x0a: Byte) -> leaf2,
-              Nibble.unsafe(0x0f: Byte) -> leaf3
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1")
+        )
+        leaf2Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2")
+        )
+        leaf3Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3")
+        )
+        leaf1 <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2 <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3 <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x0a: Byte) -> leaf2,
+            Nibble.unsafe(0x0f: Byte) -> leaf3
           )
-          branch2 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> branch1
-            )
+        )
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> branch1
           )
-        } yield MerklePatriciaTrie(branch2)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+      } yield MerklePatriciaTrie(branch2)
+    } yield expect(trieActual == trieExpected)
   }
 
   test("create produces a 3-leaf trie in configuration D") {
-    val leafMap = Map[Digest, String](
-      toDigest("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("FFAAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("FFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    val leafMap = Map[Hash, String](
+      Hash("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("FFAAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("FFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x0a: Byte) -> leaf2,
-              Nibble.unsafe(0x0f: Byte) -> leaf3
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"))
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"))
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x0a: Byte) -> leaf2,
+            Nibble.unsafe(0x0f: Byte) -> leaf3
           )
-          branch2 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> branch1
-            )
+        )
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> branch1
           )
-          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch2)
-        } yield MerklePatriciaTrie(ext)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+        extRem <- IO.fromEither(Nibble.fromHexString("FF"))
+        ext    <- MerklePatriciaNode.Extension[IO](extRem, branch2)
+      } yield MerklePatriciaTrie(ext)
+    } yield expect(trieActual == trieExpected)
+
   }
 
   test("create produces a 3-leaf trie in configuration E") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("AFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("AFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("AFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("AFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf2,
-              Nibble.unsafe(0x0a: Byte) -> leaf3
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1")
+        )
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"))
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf2,
+            Nibble.unsafe(0x0a: Byte) -> leaf3
           )
-          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch1)
-          branch2 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> ext
-            )
+        )
+        extRem <- IO.fromEither(Nibble.fromHexString("FF"))
+        ext    <- MerklePatriciaNode.Extension[IO](extRem, branch1)
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> ext
           )
-        } yield MerklePatriciaTrie(branch2)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+      } yield MerklePatriciaTrie(branch2)
+    } yield expect(trieActual == trieExpected)
+
   }
 
   test("create produces a 3-leaf trie in configuration F") {
-    val leafMap = Map[Digest, String](
-      toDigest("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("FFAFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
+    val leafMap = Map[Hash, String](
+      Hash("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("FFAFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("FFAFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie.create(leafMap)
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf2,
-              Nibble.unsafe(0x0a: Byte) -> leaf3
-            )
+    for {
+      trieActual <- MerklePatriciaTrie.create(leafMap)
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"))
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"))
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf2,
+            Nibble.unsafe(0x0a: Byte) -> leaf3
           )
-          ext1 <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch1)
-          branch2 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> ext1
-            )
+        )
+        ext1Rem <- IO.fromEither(Nibble.fromHexString("FF"))
+        ext1    <- MerklePatriciaNode.Extension[IO](ext1Rem, branch1)
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> ext1
           )
-          ext2 <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch2)
-        } yield MerklePatriciaTrie(ext2)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+        ext2Rem <- IO.fromEither(Nibble.fromHexString("FF"))
+        ext2    <- MerklePatriciaNode.Extension[IO](ext2Rem, branch2)
+      } yield MerklePatriciaTrie(ext2)
+    } yield expect(trieActual == trieExpected)
+
   }
 
   test("create then remove produces a 3-leaf trie in configuration A") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
-      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie
-          .create(leafMap)
-          .flatMap(MerklePatriciaTrie.remove(_, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4"))))
-          .flatMap(IO.fromEither(_))
+    for {
+      trieActual <- MerklePatriciaTrie
+        .create(leafMap)
+        .flatMap(
+          MerklePatriciaTrie.remove(_, List(Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
+        )
+        .flatMap(IO.fromEither(_))
 
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> leaf2,
-              Nibble.unsafe(0x0f: Byte) -> leaf3
-            )
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1")
+        )
+        leaf2Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2")
+        )
+        leaf3Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3")
+        )
+        leaf1 <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2 <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3 <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> leaf2,
+            Nibble.unsafe(0x0f: Byte) -> leaf3
           )
-        } yield MerklePatriciaTrie(branch1)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+      } yield MerklePatriciaTrie(branch1)
+    } yield expect(trieActual == trieExpected)
   }
 
   test("create then remove produces a 3-leaf trie in configuration B") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
-      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie
-          .create(leafMap)
-          .flatMap(trie =>
-            MerklePatriciaTrie.remove(trie, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
-          )
-          .flatMap(IO.fromEither(_))
+    for {
+      trieActual <- MerklePatriciaTrie
+        .create(leafMap)
+        .flatMap(trie =>
+          MerklePatriciaTrie
+            .remove(trie, List(Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
+        )
+        .flatMap(IO.fromEither(_))
 
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode.Leaf[IO](toNibbleSeq("3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x0a: Byte) -> leaf1,
-              Nibble.unsafe(0x0b: Byte) -> leaf2,
-              Nibble.unsafe(0x0c: Byte) -> leaf3
-            )
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(Nibble.fromHexString("1"))
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("2"))
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("3"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x0a: Byte) -> leaf1,
+            Nibble.unsafe(0x0b: Byte) -> leaf2,
+            Nibble.unsafe(0x0c: Byte) -> leaf3
           )
-          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), branch1)
-        } yield MerklePatriciaTrie(ext)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+        extRem <- IO.fromEither(Nibble.fromHexString("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+        ext    <- MerklePatriciaNode.Extension[IO](extRem, branch1)
+      } yield MerklePatriciaTrie(ext)
+    } yield expect(trieActual == trieExpected)
   }
 
   test("create then remove produces a 3-leaf trie in configuration C") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("AAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
-      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("AAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie
-          .create(leafMap)
-          .flatMap(trie =>
-            MerklePatriciaTrie.remove(trie, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
-          )
-          .flatMap(IO.fromEither(_))
+    for {
+      trieActual <- MerklePatriciaTrie
+        .create(leafMap)
+        .flatMap(trie =>
+          MerklePatriciaTrie
+            .remove(trie, List(Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
+        )
+        .flatMap(IO.fromEither(_))
 
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x0a: Byte) -> leaf2,
-              Nibble.unsafe(0x0f: Byte) -> leaf3
-            )
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1")
+        )
+        leaf2Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2")
+        )
+        leaf3Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3")
+        )
+        leaf1 <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2 <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3 <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x0a: Byte) -> leaf2,
+            Nibble.unsafe(0x0f: Byte) -> leaf3
           )
-          branch2 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> branch1
-            )
+        )
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> branch1
           )
-        } yield MerklePatriciaTrie(branch2)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+      } yield MerklePatriciaTrie(branch2)
+    } yield expect(trieActual == trieExpected)
   }
 
   test("create then remove produces a 3-leaf trie in configuration D") {
-    val leafMap = Map[Digest, String](
-      toDigest("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("FFAAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("FFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
-      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    val leafMap = Map[Hash, String](
+      Hash("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("FFAAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("FFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie
-          .create(leafMap)
-          .flatMap(MerklePatriciaTrie.remove(_, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4"))))
-          .flatMap(IO.fromEither(_))
+    for {
+      trieActual <- MerklePatriciaTrie
+        .create(leafMap)
+        .flatMap(
+          MerklePatriciaTrie.remove(_, List(Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
+        )
+        .flatMap(IO.fromEither(_))
 
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x0a: Byte) -> leaf2,
-              Nibble.unsafe(0x0f: Byte) -> leaf3
-            )
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"))
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"))
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x0a: Byte) -> leaf2,
+            Nibble.unsafe(0x0f: Byte) -> leaf3
           )
-          branch2 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> branch1
-            )
+        )
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> branch1
           )
-          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch2)
-        } yield MerklePatriciaTrie(ext)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+        extRem <- IO.fromEither(Nibble.fromHexString("FF"))
+        ext    <- MerklePatriciaNode.Extension[IO](extRem, branch2)
+      } yield MerklePatriciaTrie(ext)
+    } yield expect(trieActual == trieExpected)
   }
 
   test("create then remove produces a 3-leaf trie in configuration E") {
-    val leafMap = Map[Digest, String](
-      toDigest("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("AFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("AFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
-      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    val leafMap = Map[Hash, String](
+      Hash("0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("AFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("AFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie
-          .create(leafMap)
-          .flatMap(MerklePatriciaTrie.remove(_, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4"))))
-          .flatMap(IO.fromEither(_))
+    for {
+      trieActual <- MerklePatriciaTrie
+        .create(leafMap)
+        .flatMap(
+          MerklePatriciaTrie.remove(_, List(Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
+        )
+        .flatMap(IO.fromEither(_))
 
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf2,
-              Nibble.unsafe(0x0a: Byte) -> leaf3
-            )
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(
+          Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1")
+        )
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"))
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf2,
+            Nibble.unsafe(0x0a: Byte) -> leaf3
           )
-          ext <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch1)
-          branch2 <- MerklePatriciaNode.Branch[IO](
-            Map(
-              Nibble.unsafe(0x00: Byte) -> leaf1,
-              Nibble.unsafe(0x0a: Byte) -> ext
-            )
+        )
+        extRem <- IO.fromEither(Nibble.fromHexString("FF"))
+        ext    <- MerklePatriciaNode.Extension[IO](extRem, branch1)
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(
+            Nibble.unsafe(0x00: Byte) -> leaf1,
+            Nibble.unsafe(0x0a: Byte) -> ext
           )
-        } yield MerklePatriciaTrie(branch2)
-      } yield expect(trieActual == trieExpected)
-    }
+        )
+      } yield MerklePatriciaTrie(branch2)
+    } yield expect(trieActual == trieExpected)
   }
 
   test("create then remove produces a 3-leaf trie in configuration F") {
-    val leafMap = Map[Digest, String](
-      toDigest("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
-      toDigest("FFAFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
-      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
-      toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
+    val leafMap = Map[Hash, String](
+      Hash("FF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1") -> "leaf 1",
+      Hash("FFAFF0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2") -> "leaf 2",
+      Hash("FFAFFAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3") -> "leaf 3",
+      Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4") -> "leaf 4"
     )
 
-    hasherResource.use { implicit hasher =>
-      for {
-        trieActual <- MerklePatriciaTrie
-          .create(leafMap)
-          .flatMap(MerklePatriciaTrie.remove(_, List(toDigest("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4"))))
-          .flatMap(IO.fromEither(_))
+    for {
+      trieActual <- MerklePatriciaTrie
+        .create(leafMap)
+        .flatMap(
+          MerklePatriciaTrie.remove(_, List(Hash("FFAFFAFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4")))
+        )
+        .flatMap(IO.fromEither(_))
 
-        trieExpected <- for {
-          leaf1 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"), "leaf 1".asJson)
-          leaf2 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"), "leaf 2".asJson)
-          leaf3 <- MerklePatriciaNode
-            .Leaf[IO](toNibbleSeq("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"), "leaf 3".asJson)
-          branch1 <- MerklePatriciaNode.Branch[IO](Map(Nibble.unsafe(0x00: Byte) -> leaf2, Nibble.unsafe(0x0a: Byte) -> leaf3))
-          ext1    <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch1)
-          branch2 <- MerklePatriciaNode.Branch[IO](Map(Nibble.unsafe(0x00: Byte) -> leaf1, Nibble.unsafe(0x0a: Byte) -> ext1))
-          ext2    <- MerklePatriciaNode.Extension[IO](toNibbleSeq("FF"), branch2)
-        } yield MerklePatriciaTrie(ext2)
-      } yield expect(trieActual == trieExpected)
-    }
+      trieExpected <- for {
+        leaf1Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA1"))
+        leaf2Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB2"))
+        leaf3Rem <- IO.fromEither(Nibble.fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC3"))
+        leaf1    <- MerklePatriciaNode.Leaf[IO](leaf1Rem, "leaf 1".asJson)
+        leaf2    <- MerklePatriciaNode.Leaf[IO](leaf2Rem, "leaf 2".asJson)
+        leaf3    <- MerklePatriciaNode.Leaf[IO](leaf3Rem, "leaf 3".asJson)
+        branch1 <- MerklePatriciaNode.Branch[IO](
+          Map(Nibble.unsafe(0x00: Byte) -> leaf2, Nibble.unsafe(0x0a: Byte) -> leaf3)
+        )
+        ext1Rem <- IO.fromEither(Nibble.fromHexString("FF"))
+        ext1    <- MerklePatriciaNode.Extension[IO](ext1Rem, branch1)
+        branch2 <- MerklePatriciaNode.Branch[IO](
+          Map(Nibble.unsafe(0x00: Byte) -> leaf1, Nibble.unsafe(0x0a: Byte) -> ext1)
+        )
+        ext2Rem <- IO.fromEither(Nibble.fromHexString("FF"))
+        ext2    <- MerklePatriciaNode.Extension[IO](ext2Rem, branch2)
+      } yield MerklePatriciaTrie(ext2)
+    } yield expect(trieActual == trieExpected)
   }
 }

--- a/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
@@ -729,20 +729,20 @@ object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
       Hash("AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD1") -> "initial value 1",
       Hash("BFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD2") -> "initial value 2"
     )
-    
+
     val insertKey = Hash("CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD3")
     val insertValue = "inserted value"
 
     for {
       trie1 <- MerklePatriciaTrie.create(initialLeafMap)
       root1 = trie1.rootNode.digest
-      
+
       trie2 <- MerklePatriciaTrie.insert(trie1, Map(insertKey -> insertValue)).flatMap(IO.fromEither(_))
       root2 = trie2.rootNode.digest
-      
+
       trie3 <- MerklePatriciaTrie.remove(trie2, List(insertKey)).flatMap(IO.fromEither(_))
       root3 = trie3.rootNode.digest
-      
+
     } yield expect(root1 == root3 && root1 != root2 && root2 != root3)
   }
 }

--- a/src/test/scala/crypto/mpt/MerklePatriciaVerifierSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaVerifierSuite.scala
@@ -1,0 +1,62 @@
+package crypto.mpt
+
+import cats.effect.{IO, Resource}
+import cats.syntax.applicative._
+import cats.syntax.traverse._
+
+import xyz.kd5ujc.accumulators.mpt.MerklePatriciaTrie
+import xyz.kd5ujc.accumulators.mpt.api.{MerklePatriciaProver, MerklePatriciaVerifier}
+import xyz.kd5ujc.binary.JsonSerializer
+import xyz.kd5ujc.hash.impl.Blake2b256Hasher
+import xyz.kd5ujc.hash.l256
+
+import org.bouncycastle.util.encoders.Hex
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+object MerklePatriciaVerifierSuite extends SimpleIOSuite with Checkers {
+
+  private val hasherResource: Resource[IO, Blake2b256Hasher[IO]] =
+    Resource.eval {
+      JsonSerializer.forSync[IO].map(implicit json2bin => new Blake2b256Hasher[IO])
+    }
+
+  private val toDigest: String => l256 = (str: String) => l256.unsafe(Hex.decode(str))
+
+  test("verifier can confirm an inclusion proof for a path in the trie") {
+    hasherResource.use { implicit hasher =>
+      forall(Gen.listOfN(32, Gen.long).flatMap { list =>
+        Gen.choose(0, list.size - 1).map(index => (list, index))
+      }) {
+        case (list, randomIndex) =>
+          for {
+            leafPairs    <- list.traverse(l => hasher.hash(l).map(_ -> l))
+            trie         <- MerklePatriciaTrie.create(leafPairs.toMap)
+            verifier     <- MerklePatriciaVerifier.make(trie.rootNode.digest).pure[F]
+            prover       <- MerklePatriciaProver.make(trie).pure[F]
+            proof        <- prover.attestDigest(leafPairs(randomIndex)._1).flatMap(IO.fromEither(_))
+            resultEither <- verifier.confirm(proof)
+          } yield expect(proof.witness.nonEmpty && resultEither.isRight)
+      }
+    }
+  }
+
+  test("verifier fails to confirm an inclusion proof for a fixed root digest") {
+    hasherResource.use { implicit hasher =>
+      forall(Gen.listOfN(32, Gen.long).flatMap { list =>
+        Gen.choose(0, list.size - 1).map(index => (list, index))
+      }) {
+        case (list, randomIndex) =>
+          for {
+            leafPairs <- list.traverse(l => hasher.hash(l).map(_ -> l))
+            trie      <- MerklePatriciaTrie.create(leafPairs.toMap)
+            verifier  <- MerklePatriciaVerifier.make(toDigest("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")).pure[F]
+            prover    <- MerklePatriciaProver.make(trie).pure[F]
+            proof     <- prover.attestDigest(leafPairs(randomIndex)._1).flatMap(IO.fromEither(_))
+            resultEither <- verifier.confirm(proof)
+          } yield expect(resultEither.isLeft)
+      }
+    }
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaVerifierSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaVerifierSuite.scala
@@ -1,62 +1,49 @@
 package crypto.mpt
 
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import cats.syntax.applicative._
 import cats.syntax.traverse._
 
-import xyz.kd5ujc.accumulators.mpt.MerklePatriciaTrie
-import xyz.kd5ujc.accumulators.mpt.api.{MerklePatriciaProver, MerklePatriciaVerifier}
-import xyz.kd5ujc.binary.JsonSerializer
-import xyz.kd5ujc.hash.impl.Blake2b256Hasher
-import xyz.kd5ujc.hash.l256
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaTrie
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{MerklePatriciaProver, MerklePatriciaVerifier}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+import io.constellationnetwork.security.hash.Hash
 
-import org.bouncycastle.util.encoders.Hex
 import org.scalacheck.Gen
 import weaver.SimpleIOSuite
 import weaver.scalacheck.Checkers
 
 object MerklePatriciaVerifierSuite extends SimpleIOSuite with Checkers {
 
-  private val hasherResource: Resource[IO, Blake2b256Hasher[IO]] =
-    Resource.eval {
-      JsonSerializer.forSync[IO].map(implicit json2bin => new Blake2b256Hasher[IO])
-    }
-
-  private val toDigest: String => l256 = (str: String) => l256.unsafe(Hex.decode(str))
-
   test("verifier can confirm an inclusion proof for a path in the trie") {
-    hasherResource.use { implicit hasher =>
-      forall(Gen.listOfN(32, Gen.long).flatMap { list =>
-        Gen.choose(0, list.size - 1).map(index => (list, index))
-      }) {
-        case (list, randomIndex) =>
-          for {
-            leafPairs    <- list.traverse(l => hasher.hash(l).map(_ -> l))
-            trie         <- MerklePatriciaTrie.create(leafPairs.toMap)
-            verifier     <- MerklePatriciaVerifier.make(trie.rootNode.digest).pure[F]
-            prover       <- MerklePatriciaProver.make(trie).pure[F]
-            proof        <- prover.attestDigest(leafPairs(randomIndex)._1).flatMap(IO.fromEither(_))
-            resultEither <- verifier.confirm(proof)
-          } yield expect(proof.witness.nonEmpty && resultEither.isRight)
-      }
+    forall(Gen.listOfN(32, Gen.long).flatMap { list =>
+      Gen.choose(0, list.size - 1).map(index => (list, index))
+    }) { case (list, randomIndex) =>
+      for {
+        leafPairs    <- list.traverse(el => el.computeDigest.map(_ -> el))
+        trie         <- MerklePatriciaTrie.create(leafPairs.toMap)
+        verifier     <- MerklePatriciaVerifier.make(trie.rootNode.digest).pure[F]
+        prover       <- MerklePatriciaProver.make(trie).pure[F]
+        proof        <- prover.attestDigest(leafPairs(randomIndex)._1).flatMap(IO.fromEither(_))
+        resultEither <- verifier.confirm(proof)
+      } yield expect(proof.witness.nonEmpty && resultEither.isRight)
     }
   }
 
   test("verifier fails to confirm an inclusion proof for a fixed root digest") {
-    hasherResource.use { implicit hasher =>
-      forall(Gen.listOfN(32, Gen.long).flatMap { list =>
-        Gen.choose(0, list.size - 1).map(index => (list, index))
-      }) {
-        case (list, randomIndex) =>
-          for {
-            leafPairs <- list.traverse(l => hasher.hash(l).map(_ -> l))
-            trie      <- MerklePatriciaTrie.create(leafPairs.toMap)
-            verifier  <- MerklePatriciaVerifier.make(toDigest("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")).pure[F]
-            prover    <- MerklePatriciaProver.make(trie).pure[F]
-            proof     <- prover.attestDigest(leafPairs(randomIndex)._1).flatMap(IO.fromEither(_))
-            resultEither <- verifier.confirm(proof)
-          } yield expect(resultEither.isLeft)
-      }
+    forall(Gen.listOfN(32, Gen.long).flatMap { list =>
+      Gen.choose(0, list.size - 1).map(index => (list, index))
+    }) { case (list, randomIndex) =>
+      for {
+        leafPairs <- list.traverse(el => el.computeDigest.map(_ -> el))
+        trie      <- MerklePatriciaTrie.create(leafPairs.toMap)
+        verifier <- MerklePatriciaVerifier
+          .make(Hash("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+          .pure[F]
+        prover       <- MerklePatriciaProver.make(trie).pure[F]
+        proof        <- prover.attestDigest(leafPairs(randomIndex)._1).flatMap(IO.fromEither(_))
+        resultEither <- verifier.confirm(proof)
+      } yield expect(resultEither.isLeft)
     }
   }
 }

--- a/src/test/scala/json_logic/JsonLogicSpec.scala
+++ b/src/test/scala/json_logic/JsonLogicSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.IO
 import io.constellationnetwork.metagraph_sdk.json_logic._
 
 import io.circe.parser
-import org.scalacheck.{Arbitrary, Gen}
 import weaver.scalacheck.Checkers
 import weaver.{Expectations, SimpleIOSuite}
 
@@ -1653,7 +1652,6 @@ object JsonLogicSpec extends SimpleIOSuite with Checkers {
       staticTestRunner(expr, data, BoolValue(false))
     }
   }
-
 
   test("reduce with empty array and no initial value should return null") {
     val exprStr = """{"reduce":[[], {"+":[{"var":"current"}, {"var":"accumulator"}]}]}"""


### PR DESCRIPTION
## Summary
Adds a Merkle tree and Merkle-Patricia trie for creating cryptographic commitments to collections of data. These structures are integrated with the `JsonBinaryCodec` and `JsonBinaryHasher` to provide reproducible serde and hash guarantees for any type `T` where the corresponding Circe `Encoder[T] & Decoder[T]` instances may be found.

## Testing
- Added unit tests suites for both structures