### PR TITLE
fix: drop null values before JSON canonicalization

### DIFF
--- a/src/test/scala/shared/Generators.scala
+++ b/src/test/scala/shared/Generators.scala
@@ -34,6 +34,14 @@ object Generators {
     } yield TestDataUpdate(id, value)
   )
 
+  implicit val arbTestDataUpdateComplex: Arbitrary[TestDataUpdateComplex] = Arbitrary(
+    for {
+      id       <- Gen.stringOf(Gen.alphaNumChar)
+      value    <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
+      metadata <- Gen.option(nonEmptyAlphaStr)
+    } yield TestDataUpdateComplex(id, value, metadata)
+  )
+
   val genTestDataUpdate: Gen[TestDataUpdate] = arbTestDataUpdate.arbitrary
 
   val jsonValueGen: Gen[Json] = Gen.oneOf(

--- a/src/test/scala/shared/Models.scala
+++ b/src/test/scala/shared/Models.scala
@@ -17,4 +17,7 @@ object Models {
   @derive(encoder, decoder, show)
   case class TestDataUpdate(id: String, value: Int) extends DataUpdate
 
+  @derive(encoder, decoder, show)
+  case class TestDataUpdateComplex(id: String, value: Int, metadata: Option[String]) extends DataUpdate
+
 }


### PR DESCRIPTION
## Problem

When Circe encodes case classes with `Option[T]` fields set to `None`, it produces `null` values in the JSON. These nulls were being preserved during canonicalization, causing **signature verification to fail** when the sender omitted the optional field entirely.

### Example

1. TypeScript SDK sends: `{"id": "test", "isFinal": false}` (no `metadata` field)
2. Scala deserializes to: `State(metadata = None)`
3. Scala re-encodes via Circe: `{"id": "test", "isFinal": false, "metadata": null}`
4. Canonicalization preserves the null
5. **Hash mismatch → signature verification fails**

## Solution

Filter out null values from JSON objects **before** canonicalization in `JsonBinaryCodec`. This ensures:

1. `Option[T] = None` produces the same canonical form as an omitted field
2. Signature hashes match between sender (field omitted) and receiver (field decoded as None, then re-encoded)

This matches the behavior of TypeScript's JSON serialization which typically omits undefined/null fields.

## Changes

- Added `dropNulls` helper function that recursively removes null values from JSON objects
- Modified `JsonBinaryCodec.derive` and `deriveDataUpdate` to apply null filtering before canonicalization
- Added 3 new tests:
  - `codec should drop null values from Option fields`
  - `codec should round-trip data with Option fields`
  - `codec with None produces same bytes as sender without field`

## Testing

All existing tests pass. New tests verify the null-dropping behavior works correctly.

```
[info] std.JsonBinaryCodecSuite
[info] + codec should drop null values from Option fields 69ms
[info] + codec should round-trip data with Option fields 146ms
[info] + codec with None produces same bytes as sender without field 67ms
[info] Passed: Total 15, Failed 0, Errors 0, Passed 15
```
