### PR TITLE
fix: drop null values before JSON canonicalization (dev)

### DIFF
--- a/src/test/scala/shared/Generators.scala
+++ b/src/test/scala/shared/Generators.scala
@@ -34,6 +34,14 @@ object Generators {
     } yield TestDataUpdate(id, value)
   )
 
+  implicit val arbTestDataUpdateComplex: Arbitrary[TestDataUpdateComplex] = Arbitrary(
+    for {
+      id       <- Gen.stringOf(Gen.alphaNumChar)
+      value    <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
+      metadata <- Gen.option(nonEmptyAlphaStr)
+    } yield TestDataUpdateComplex(id, value, metadata)
+  )
+
   val genTestDataUpdate: Gen[TestDataUpdate] = arbTestDataUpdate.arbitrary
 
   val jsonValueGen: Gen[Json] = Gen.oneOf(

--- a/src/test/scala/shared/Models.scala
+++ b/src/test/scala/shared/Models.scala
@@ -17,4 +17,7 @@ object Models {
   @derive(encoder, decoder, show)
   case class TestDataUpdate(id: String, value: Int) extends DataUpdate
 
+  @derive(encoder, decoder, show)
+  case class TestDataUpdateComplex(id: String, value: Int, metadata: Option[String]) extends DataUpdate
+
 }


### PR DESCRIPTION
Cherry-pick of #14 targeting the `dev` branch.

## Changes
Same as #14:
- Drop null values from JSON objects before canonicalization (signature compatibility)
- Add JSON depth limit for deserialization (stack safety, default 64)
- 23 tests total

See #14 for full details.