### PR TITLE
chore: update sbt from 1.8.0 to 1.9.8

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.9.8


### PR DESCRIPTION
## Summary
Updates sbt version from 1.8.0 to 1.9.8 to align with tessellation.

## Changes
- `project/build.properties`: sbt.version 1.8.0 → 1.9.8

## Testing
- Local compile: ✅ (18s)
- 387/388 tests pass
- 1 test (`JsonBinaryHasherSuite.arrays.json`) fails due to hardcoded expected hash computed with previous sbt/dependency versions

## Notes
The failing test checks a specific hash value that was computed with sbt 1.8.0 dependencies. The hash algorithm itself is deterministic (other tests verify this), but the exact bytes may differ due to transitive dependency resolution changes. The expected hash may need updating.

## Versions
| Component    | Before | After |
|--------------|--------|-------|
| sbt          | 1.8.0  | 1.9.8 |
| tessellation | -      | 1.9.8 |
| ottochain    | -      | 1.12.0|