### PR TITLE
feat(crypto/smt): Sparse Merkle Tree (membership + non-membership proofs) + LevelDB

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleCommitment.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleCommitment.scala
@@ -1,0 +1,98 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt
+
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+
+/**
+ * Domain-separated, Circe-encoded hash pre-images for the two materialized node kinds of the binary sparse Merkle tree.
+ *
+ * Hashing is routed through `JsonBinaryHasher[F].computeDigest(commitment.asJson, prefix)` -- EXACTLY as
+ * `MerklePatriciaCommitment` / `MerklePatriciaNode` do -- so all node hashing stays on the metakit canonical-bytes path
+ * (`std/JsonBinaryHasher`, never a hand-rolled digest). The one-byte domain-separation prefixes
+ * ([[SparseMerkleCommitment.LeafPrefix]] / [[SparseMerkleCommitment.InternalPrefix]]) keep a leaf pre-image from ever colliding with an
+ * internal-node pre-image.
+ *
+ * The third logical node kind -- an empty/default subtree -- is NOT hashed; its digest is the fixed placeholder
+ * `Hash.empty` ([[io.constellationnetwork.metagraph_sdk.crypto.smt.node.SparseMerkleNode.Empty]]). This is the Diem/JMT
+ * empty-subtree convention.
+ *
+ *   - [[SparseMerkleCommitment.Leaf]] binds the FULL 256-bit leaf `position` (= the hashed key) together with the value digest.
+ *     Binding the full position (not a depth-relative remainder) makes a leaf's digest independent of where it sits in
+ *     the tree, which is what gives the structure its order-independence and lets a verifier recompute any leaf digest
+ *     from `(position, valueDigest)` alone.
+ *   - [[SparseMerkleCommitment.Internal]] binds the two child subtree digests in fixed `(left, right)` order.
+ */
+sealed trait SparseMerkleCommitment extends Product with Serializable
+
+object SparseMerkleCommitment {
+
+  /**
+   * Domain-separation prefix prepended to a leaf pre-image. Distinct from [[InternalPrefix]] and from the MPT prefixes
+   * (this is a separate primitive with its own namespace).
+   */
+  val LeafPrefix: Array[Byte] = Array(0: Byte)
+
+  /** Domain-separation prefix prepended to an internal-node pre-image. */
+  val InternalPrefix: Array[Byte] = Array(1: Byte)
+
+  /** Leaf pre-image: the full 256-bit position (the hashed key) and the value digest. */
+  final case class Leaf(position: Hash, valueDigest: Hash) extends SparseMerkleCommitment
+
+  /** Internal-node pre-image: the two child subtree digests, fixed `(left, right)` order. */
+  final case class Internal(left: Hash, right: Hash) extends SparseMerkleCommitment
+
+  object Leaf {
+
+    implicit val leafCommitEncoder: Encoder[Leaf] =
+      Encoder.instance { c =>
+        Json.obj(
+          "position"    -> c.position.asJson,
+          "valueDigest" -> c.valueDigest.asJson
+        )
+      }
+
+    implicit val leafCommitDecoder: Decoder[Leaf] =
+      Decoder.instance { hCursor =>
+        for {
+          position    <- hCursor.downField("position").as[Hash]
+          valueDigest <- hCursor.downField("valueDigest").as[Hash]
+        } yield Leaf(position, valueDigest)
+      }
+  }
+
+  object Internal {
+
+    implicit val internalCommitEncoder: Encoder[Internal] =
+      Encoder.instance { c =>
+        Json.obj(
+          "left"  -> c.left.asJson,
+          "right" -> c.right.asJson
+        )
+      }
+
+    implicit val internalCommitDecoder: Decoder[Internal] =
+      Decoder.instance { hCursor =>
+        for {
+          left  <- hCursor.downField("left").as[Hash]
+          right <- hCursor.downField("right").as[Hash]
+        } yield Internal(left, right)
+      }
+  }
+
+  implicit val smtCommitEncoder: Encoder[SparseMerkleCommitment] = Encoder.instance {
+    case c: Leaf =>
+      Json.obj("type" -> Json.fromString("Leaf"), "contents" -> c.asJson)
+    case c: Internal =>
+      Json.obj("type" -> Json.fromString("Internal"), "contents" -> c.asJson)
+  }
+
+  implicit val smtCommitDecoder: Decoder[SparseMerkleCommitment] = Decoder.instance { cursor =>
+    cursor.downField("type").as[String].flatMap {
+      case "Leaf"     => cursor.downField("contents").as[Leaf]
+      case "Internal" => cursor.downField("contents").as[Internal]
+      case other      => Left(DecodingFailure(s"Unknown SparseMerkleCommitment type: $other", cursor.history))
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleEntry.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleEntry.scala
@@ -1,0 +1,34 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt
+
+import cats.Eq
+import cats.syntax.eq._
+
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * The verified outcome a consumer obtains from [[api.SparseMerkleVerifier.verify]], wrapped in [[Verified]] so it cannot be
+ * forged. Either the key is present with its (value-bound) bytes, or the key is proven absent -- both established
+ * against the trusted [[SparseMerkleRoot]].
+ */
+sealed trait SparseMerkleEntry extends Product with Serializable {
+  def key: Hex
+}
+
+object SparseMerkleEntry {
+
+  /**
+   * The key is present and `value` cryptographically binds to the committed leaf (`Hash.fromBytes(value)` matched the
+   * leaf's value digest during verify).
+   */
+  final case class Present(key: Hex, value: Array[Byte]) extends SparseMerkleEntry
+
+  /** The key is absent under the trusted root (verified via [[AbsenceWitness]]). */
+  final case class Absent(key: Hex) extends SparseMerkleEntry
+
+  // Structural Eq (value compared by content). For test assertions, never control flow.
+  implicit val eq: Eq[SparseMerkleEntry] = Eq.instance {
+    case (Present(k1, v1), Present(k2, v2)) => k1 === k2 && v1.sameElements(v2)
+    case (Absent(k1), Absent(k2))           => k1 === k2
+    case _                                  => false
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleHashing.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleHashing.scala
@@ -1,0 +1,90 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt
+
+import java.nio.charset.StandardCharsets
+
+import cats.MonadThrow
+
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.syntax.EncoderOps
+
+/**
+ * The single, shared source of truth for SMT positions, node digests, and path bits -- so the prover, the verifier,
+ * and the in-memory tree all compute byte-identical hashes.
+ *
+ * ==Hashing seam (the metakit adaptation)==
+ * The tessellation original routed everything through the `Hasher[F]` typeclass (Blake2b/Brotli). metakit has no such
+ * typeclass in the SMT/MPT layer; the `MerklePatriciaNode`/`MerklePatriciaCommitment` discipline is to hash CANONICAL
+ * BYTES via `std/JsonBinaryHasher` (`computeDigest = Hash.fromBytes(prefix ++ canonicalBytes)`). This object mirrors
+ * that EXACTLY:
+ *   - NODE digests ([[leafDigest]] / [[internalDigest]]) go through `JsonBinaryHasher[F].computeDigest(commitment.asJson,
+ *     prefix)`, identical to how `MerklePatriciaNode` computes its node digests.
+ *   - POSITION and the VALUE digest hash raw bytes (a key has no circe `Encoder`, a value is `Array[Byte]`); they use
+ *     `Hash.fromBytes` directly -- which is exactly the final step `JsonBinaryHasher` performs (`Hash.fromBytes(bytes)`),
+ *     so the same SHA-256-based digest the MPT uses is in force across the whole primitive.
+ *
+ * The seam is intentionally narrow ([[position]] / [[leafDigest]] / [[internalDigest]] / [[empty]]). A SNARK-friendly
+ * hash (Poseidon) can be slotted in later by swapping these four functions and the [[empty]] placeholder; nothing else
+ * in the SMT touches a digest pre-image.
+ */
+object SparseMerkleHashing {
+
+  /** Digest of an empty (default) subtree -- the all-zeros placeholder, never hashed (Diem/JMT convention). */
+  val empty: Hash = Hash.empty
+
+  /**
+   * The 256-bit position (slot) of a key: the digest of the key bytes. Hashing the key uniformizes the slot
+   * distribution. The `Hash` is a 64-char lowercase hex string (32 bytes); [[bit]] reads it big-endian, MSB-first.
+   */
+  def position[F[_]: MonadThrow](key: Hex): F[Hash] =
+    MonadThrow[F].pure(Hash.fromBytes(key.value.getBytes(StandardCharsets.UTF_8)))
+
+  /** Digest of `value` bytes, as committed in a leaf. Raw-bytes SHA-256, matching the MPT's `Hash.fromBytes` seam. */
+  def valueDigest[F[_]: MonadThrow](value: Array[Byte]): F[Hash] =
+    MonadThrow[F].pure(Hash.fromBytes(value))
+
+  /** Digest of a leaf binding the FULL position and value digest. Depth-independent (the full position is in the pre-image). */
+  def leafDigest[F[_]: MonadThrow: JsonBinaryHasher](position: Hash, valueDigest: Hash): F[Hash] =
+    JsonBinaryHasher[F].computeDigest(SparseMerkleCommitment.Leaf(position, valueDigest).asJson, SparseMerkleCommitment.LeafPrefix)
+
+  /** Digest of an internal node binding its two child subtree digests in fixed `(left, right)` order. */
+  def internalDigest[F[_]: MonadThrow: JsonBinaryHasher](left: Hash, right: Hash): F[Hash] =
+    JsonBinaryHasher[F].computeDigest(SparseMerkleCommitment.Internal(left, right).asJson, SparseMerkleCommitment.InternalPrefix)
+
+  /**
+   * Combine a child digest `cur` (on the path) with its `sibling`, given the path bit at this depth: bit `false` =>
+   * path went LEFT (cur is the left child), bit `true` => path went RIGHT. This is the per-level step both the tree
+   * builder and the verifier use.
+   */
+  def combine[F[_]: MonadThrow: JsonBinaryHasher](bit: Boolean, cur: Hash, sibling: Hash): F[Hash] =
+    if (bit) internalDigest[F](sibling, cur)
+    else internalDigest[F](cur, sibling)
+
+  /** Total number of position bits (256 -- a SHA-256 hash). */
+  val PositionBits: Int = 256
+
+  /**
+   * Bit `index` (0 = most-significant bit of the first byte) of a 32-byte position hash, read big-endian. Returns
+   * `false` (LEFT) for indices past the 256-bit space (defensive; callers never index past [[PositionBits]]).
+   */
+  def bit(position: Hash, index: Int): Boolean = {
+    val bytes = positionBytes(position)
+    val byteIdx = index / 8
+    if (byteIdx < 0 || byteIdx >= bytes.length) false
+    else {
+      val bitInByte = 7 - (index % 8) // MSB-first within the byte
+      ((bytes(byteIdx) >> bitInByte) & 1) == 1
+    }
+  }
+
+  /** Whether two positions agree on the first `prefixLen` bits (used to sanity-check an OtherLeaf shares the queried key's prefix). */
+  def sharePrefix(a: Hash, b: Hash, prefixLen: Int): Boolean =
+    (0 until prefixLen).forall(i => bit(a, i) == bit(b, i))
+
+  private def positionBytes(position: Hash): Array[Byte] =
+    // Hash.value is a hex string (64 chars for SHA-256). Decode to its 32 raw bytes; the hex string IS the canonical
+    // position encoding.
+    Hex(position.value).toBytes
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleProof.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleProof.scala
@@ -1,0 +1,155 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt
+
+import cats.Eq
+import cats.syntax.eq._
+
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe._
+import io.circe.syntax.EncoderOps
+
+/**
+ * One sibling subtree digest on the authentication path of an [[SparseMerkleProof]].
+ *
+ * Siblings are recorded TOP-DOWN (root-first): in a proof for position `P`, `siblings(i)` is the digest of the sibling
+ * of the internal node at depth `i` (i.e. the child NOT on `P`'s path, selected by the complement of bit `i` of `P`).
+ * The number of siblings equals the depth at which the proof terminates (a leaf, an other-leaf, or an empty/default
+ * subtree). A verifier folds from the deepest sibling upward (`siblings.reverse`), choosing left/right at each level by
+ * bit `i` of `P`.
+ *
+ * A sibling whose value is `Hash.empty` denotes a collapsed empty (default) subtree at that level -- kept explicit
+ * (not omitted) so the sibling list index lines up with the bit index of `P`.
+ */
+final case class SparseMerkleSibling(digest: Hash)
+
+object SparseMerkleSibling {
+  implicit val eq: Eq[SparseMerkleSibling] = Eq.by(_.digest)
+
+  implicit val encoder: Encoder[SparseMerkleSibling] = Encoder.instance(s => Json.obj("digest" -> s.digest.asJson))
+  implicit val decoder: Decoder[SparseMerkleSibling] = Decoder.instance(_.downField("digest").as[Hash].map(SparseMerkleSibling(_)))
+}
+
+/**
+ * Why a key is absent, native to the sparse Merkle tree (no separate "exclusion proof" shape -- absence is the same
+ * authentication-path fold as inclusion, differing only in what sits at the terminating slot).
+ *
+ *   - [[AbsenceWitness.Default]] -- the slot on the queried key's path is a collapsed EMPTY (default-hash) subtree:
+ *     nothing occupies it. The fold starts from `Hash.empty`.
+ *   - [[AbsenceWitness.OtherLeaf]] -- a DIFFERENT leaf occupies the position the queried key's path leads to (they
+ *     share the first `siblings.length`-bit prefix, then the descent halts at that leaf before reaching the queried
+ *     position). Carries the occupying leaf's `occupyingKey` (so the verifier recomputes its position and asserts it
+ *     differs from the queried position) and its `occupyingDataDigest` (so the verifier recomputes the occupying leaf
+ *     digest and folds it up).
+ */
+sealed trait AbsenceWitness extends Product with Serializable
+
+object AbsenceWitness {
+  case object Default extends AbsenceWitness
+  final case class OtherLeaf(occupyingKey: Hex, occupyingDataDigest: Hash) extends AbsenceWitness
+
+  implicit val eq: Eq[AbsenceWitness] = Eq.instance {
+    case (Default, Default)                     => true
+    case (OtherLeaf(k1, d1), OtherLeaf(k2, d2)) => k1 === k2 && d1 === d2
+    case _                                      => false
+  }
+
+  implicit val encoder: Encoder[AbsenceWitness] = Encoder.instance {
+    case Default =>
+      Json.obj("type" -> Json.fromString("Default"))
+    case OtherLeaf(occupyingKey, occupyingDataDigest) =>
+      Json.obj(
+        "type"                -> Json.fromString("OtherLeaf"),
+        "occupyingKey"        -> occupyingKey.asJson,
+        "occupyingDataDigest" -> occupyingDataDigest.asJson
+      )
+  }
+
+  implicit val decoder: Decoder[AbsenceWitness] = Decoder.instance { c =>
+    c.downField("type").as[String].flatMap {
+      case "Default" => Right(Default)
+      case "OtherLeaf" =>
+        for {
+          occupyingKey        <- c.downField("occupyingKey").as[Hex]
+          occupyingDataDigest <- c.downField("occupyingDataDigest").as[Hash]
+        } yield OtherLeaf(occupyingKey, occupyingDataDigest)
+      case other => Left(DecodingFailure(s"Unknown AbsenceWitness type: $other", c.history))
+    }
+  }
+}
+
+/**
+ * A native sparse-Merkle-tree proof against an [[SparseMerkleRoot]]. Sealed: a proof is EITHER inclusion OR absence -- there is
+ * no third shape, and absence is first-class.
+ *
+ * Value bytes are carried as a hex string on the wire (no circe `Encoder[Array[Byte]]` in scope; the codebase's
+ * convention is `Hex`); the round-trip is byte-exact (`Hex.fromBytes`/`Hex.toBytes`).
+ *
+ *   - [[SparseMerkleProof.Inclusion]] -- `key` is present with `value`; `valueDigest` is the value digest committed in the leaf
+ *     (= `Hash.fromBytes` of the value bytes); `siblings` is the top-down authentication path from the root to the leaf
+ *     at the key's position. The verifier (1) asserts `Hash.fromBytes(value) == valueDigest` (mandatory value-binding;
+ *     a tampered `value` fails HERE as `ValueBindingFailed`, distinctly from a tampered path which fails the root fold
+ *     as `RootMismatch`), then (2) recomputes the leaf digest from `(position, valueDigest)` and folds up to check the
+ *     root. `valueDigest` is the SMT analogue of the MPT leaf's `dataDigest`; it is carried explicitly so value-binding
+ *     is a distinguishable check.
+ *   - [[SparseMerkleProof.Absence]] -- `key` is absent; `witness` explains why ([[AbsenceWitness]]); `siblings` is the top-down
+ *     authentication path to the terminating slot.
+ */
+sealed trait SparseMerkleProof extends Product with Serializable {
+  def key: Hex
+  def siblings: List[SparseMerkleSibling]
+}
+
+object SparseMerkleProof {
+
+  final case class Inclusion(key: Hex, value: Array[Byte], valueDigest: Hash, siblings: List[SparseMerkleSibling]) extends SparseMerkleProof
+  final case class Absence(key: Hex, witness: AbsenceWitness, siblings: List[SparseMerkleSibling]) extends SparseMerkleProof
+
+  // Array[Byte] has no circe instances; encode value as a hex string, decode back byte-exactly.
+  private val valueEncoder: Encoder[Array[Byte]] = Encoder.instance(bytes => Hex.fromBytes(bytes).asJson)
+  private val valueDecoder: Decoder[Array[Byte]] = Decoder[Hex].map(_.toBytes)
+
+  // Structural Eq (value compared by content). For test assertions / dedup, never control flow.
+  implicit val eq: Eq[SparseMerkleProof] = Eq.instance {
+    case (Inclusion(k1, v1, d1, s1), Inclusion(k2, v2, d2, s2)) => k1 === k2 && v1.sameElements(v2) && d1 === d2 && s1 === s2
+    case (Absence(k1, w1, s1), Absence(k2, w2, s2))             => k1 === k2 && w1 === w2 && s1 === s2
+    case _                                                      => false
+  }
+
+  implicit val encoder: Encoder[SparseMerkleProof] = Encoder.instance {
+    case Inclusion(key, value, valueDigest, siblings) =>
+      Json.obj(
+        "type"        -> Json.fromString("Inclusion"),
+        "key"         -> key.asJson,
+        "value"       -> valueEncoder(value),
+        "valueDigest" -> valueDigest.asJson,
+        "siblings"    -> siblings.asJson
+      )
+    case Absence(key, witness, siblings) =>
+      Json.obj(
+        "type"     -> Json.fromString("Absence"),
+        "key"      -> key.asJson,
+        "witness"  -> witness.asJson,
+        "siblings" -> siblings.asJson
+      )
+  }
+
+  implicit val decoder: Decoder[SparseMerkleProof] = Decoder.instance { c =>
+    c.downField("type").as[String].flatMap {
+      case "Inclusion" =>
+        for {
+          key         <- c.downField("key").as[Hex]
+          value       <- c.downField("value").as[Array[Byte]](valueDecoder)
+          valueDigest <- c.downField("valueDigest").as[Hash]
+          siblings    <- c.downField("siblings").as[List[SparseMerkleSibling]]
+        } yield Inclusion(key, value, valueDigest, siblings)
+      case "Absence" =>
+        for {
+          key      <- c.downField("key").as[Hex]
+          witness  <- c.downField("witness").as[AbsenceWitness]
+          siblings <- c.downField("siblings").as[List[SparseMerkleSibling]]
+        } yield Absence(key, witness, siblings)
+      case other => Left(DecodingFailure(s"Unknown SparseMerkleProof type: $other", c.history))
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleProofError.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleProofError.scala
@@ -1,0 +1,64 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt
+
+import cats.Eq
+import cats.syntax.eq._
+
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * Failure modes of [[api.SparseMerkleProver.prove]] / [[api.SparseMerkleVerifier.verify]]. Sealed, exhaustive, no string-typed control
+ * flow -- the structural cause is carried, never re-derived from a message string. Extends `Throwable` so it can be
+ * raised through the `F[_]` error channel like the MPT's `MerklePatriciaProofError`.
+ *
+ *   - [[SparseMerkleProofError.ValueBindingFailed]] -- an [[SparseMerkleProof.Inclusion]]'s `Hash.fromBytes(value)` did not equal the
+ *     leaf's committed value digest (the value bytes do not bind to the committed leaf). Value-binding is MANDATORY
+ *     inside verify; there is no verify variant that skips it.
+ *   - [[SparseMerkleProofError.RootMismatch]] -- the root recomputed by folding the proof's authentication path did not equal
+ *     the trusted [[SparseMerkleRoot]]. Carries both `expected` (trusted) and `got` (recomputed).
+ *   - [[SparseMerkleProofError.MalformedProof]] -- the proof is structurally inconsistent before any root fold can be trusted:
+ *     e.g. an [[AbsenceWitness.OtherLeaf]] whose recomputed position equals the queried position (so it is not a
+ *     genuine OTHER leaf), or an authentication path deeper than the 256-bit position space. Carries the offending
+ *     `key` and a structural `reason`.
+ */
+sealed trait SparseMerkleProofError extends Throwable with Product with Serializable
+
+object SparseMerkleProofError {
+
+  final case class ValueBindingFailed(key: Hex) extends SparseMerkleProofError {
+    override def getMessage: String = s"Value bytes do not bind to the committed leaf for key: ${key.value}"
+  }
+
+  final case class RootMismatch(expected: Hash, got: Hash) extends SparseMerkleProofError {
+    override def getMessage: String =
+      s"Authentication-path fold did not reproduce the trusted root (expected ${expected.value}, got ${got.value})"
+  }
+
+  final case class MalformedProof(key: Hex, reason: MalformedReason) extends SparseMerkleProofError {
+    override def getMessage: String = s"Malformed proof for key ${key.value}: $reason"
+  }
+
+  /** Structural (non-string) reasons a proof is malformed. Closed set so control flow stays pattern-matched. */
+  sealed trait MalformedReason extends Product with Serializable
+  object MalformedReason {
+
+    /**
+     * An [[AbsenceWitness.OtherLeaf]] whose recomputed occupying position equals the queried position -- i.e. the key
+     * IS present, so the proof cannot soundly claim absence.
+     */
+    case object OtherLeafCollidesWithKey extends MalformedReason
+
+    /** The authentication path (siblings list) is longer than the 256-bit position space allows. */
+    case object PathTooDeep extends MalformedReason
+
+    implicit val eq: Eq[MalformedReason] = Eq.fromUniversalEquals
+  }
+
+  // Local Eq for test assertions / dedup, never control flow.
+  implicit val eq: Eq[SparseMerkleProofError] = Eq.instance {
+    case (ValueBindingFailed(k1), ValueBindingFailed(k2)) => k1 === k2
+    case (RootMismatch(e1, g1), RootMismatch(e2, g2))     => e1 === e2 && g1 === g2
+    case (MalformedProof(k1, r1), MalformedProof(k2, r2)) => k1 === k2 && r1 === r2
+    case _                                                => false
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleRoot.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleRoot.scala
@@ -1,0 +1,33 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt
+
+import cats.Eq
+
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+/**
+ * Root commitment of a [[SparseMerkleTree]] -- the digest of the root node.
+ *
+ * Wraps [[Hash]] exactly as `MerklePatriciaTrie`'s root digest is a `Hash`, so the two proof families read alike. The
+ * empty tree's root is [[SparseMerkleRoot.empty]] (`Hash.empty`, the all-zeros default-subtree placeholder).
+ */
+final case class SparseMerkleRoot(value: Hash)
+
+object SparseMerkleRoot {
+
+  /**
+   * Root of the empty tree: the all-zeros default-subtree placeholder (`Hash.empty`). Matches the SMT convention that
+   * a subtree with zero leaves has the default hash.
+   */
+  val empty: SparseMerkleRoot = SparseMerkleRoot(Hash.empty)
+
+  implicit val eq: Eq[SparseMerkleRoot] = Eq.by(_.value)
+
+  implicit val encoder: Encoder[SparseMerkleRoot] =
+    (root: SparseMerkleRoot) => Json.obj("value" -> root.value.asJson)
+
+  implicit val decoder: Decoder[SparseMerkleRoot] =
+    (c: HCursor) => c.downField("value").as[Hash].map(SparseMerkleRoot(_))
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleTree.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/SparseMerkleTree.scala
@@ -1,0 +1,43 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt
+
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * An immutable, additive sparse Merkle tree (the logical Jellyfish Merkle Tree core) over 256-bit key POSITIONS.
+ *
+ * This is a PARALLEL primitive -- it does NOT replace or touch the `MerklePatriciaTrie`. Hashing routes through
+ * metakit's `std/JsonBinaryHasher` (canonical-bytes -> `Hash.fromBytes`) with circe-encoded, domain-separated
+ * commitments ([[SparseMerkleCommitment]]), matching `MerklePatriciaNode`'s discipline. The hashing seam ([[SparseMerkleHashing]]) is
+ * narrow and swappable so a SNARK-friendly hash (Poseidon) can be slotted in later.
+ *
+ * The position of a key is `hash(key)` (a fixed, uniform 256-bit value), so leaf positions are uniformly distributed
+ * and the tree's structure is a pure function of the live leaf SET. Combined with the Diem/JMT empty-subtree collapse
+ * (any subtree with 0 or 1 leaf collapses to a default placeholder or to that single leaf), this gives:
+ *   - node count proportional to the number of live leaves (NOT 2^256), and
+ *   - INSERTION/REMOVAL ORDER INDEPENDENCE -- the same key-set always yields the same [[root]].
+ *
+ * All mutators return a NEW tree with structural sharing; the receiver is unchanged.
+ *
+ * @tparam F
+ *   the effect; concrete impls need `Sync: JsonBinaryHasher` (positions and node digests are computed in `F`).
+ */
+trait SparseMerkleTree[F[_]] {
+
+  /** The value bytes bound to `key`, or `None` if `key` is absent. `key` is hashed to its position internally. */
+  def get(key: Hex): F[Option[Array[Byte]]]
+
+  /** The root commitment (digest of the root node; [[SparseMerkleRoot.empty]] for the empty tree). */
+  def root: F[SparseMerkleRoot]
+
+  /** A new tree with `key` bound to `value` (upsert). Structural sharing with the receiver. */
+  def insert(key: Hex, value: Array[Byte]): F[SparseMerkleTree[F]]
+
+  /** A new tree with `key` removed (no-op if absent). Structural sharing with the receiver. */
+  def remove(key: Hex): F[SparseMerkleTree[F]]
+
+  /**
+   * A new tree with `removes` deleted then `upserts` applied (removals first, upsert-wins). Structural sharing with the
+   * receiver. The result is independent of the order entries appear in the inputs.
+   */
+  def withChanges(upserts: Map[Hex, Array[Byte]], removes: Set[Hex]): F[SparseMerkleTree[F]]
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/Verified.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/Verified.scala
@@ -1,0 +1,17 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt
+
+/**
+ * Proof that `value: A` was produced by an [[api.SparseMerkleVerifier]] and only an [[api.SparseMerkleVerifier]]. The constructor is
+ * private and the only builder ([[Verified.makeInternal]]) is `private[smt]`, so a `Verified[A]` cannot be forged
+ * outside this package.
+ *
+ * A consumer that wants verified state must hold a `Verified[SparseMerkleEntry]`, and there is no path to obtain one except
+ * through `verify` -- so an absence/inclusion proof can never be consumed unverified.
+ */
+sealed abstract case class Verified[A] private (value: A)
+
+object Verified {
+
+  /** Sole builder. `private[smt]` -- callable only by the verifier in this package. */
+  private[smt] def makeInternal[A](value: A): Verified[A] = new Verified[A](value) {}
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/api/SparseMerkleProver.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/api/SparseMerkleProver.scala
@@ -1,0 +1,37 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt.api
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleProof, SparseMerkleProofError}
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * Produces a native [[SparseMerkleProof]] for a key against a [[io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleTree]]
+ * -- INCLUSION when the key is present, ABSENCE when it is not (the caller does not pre-decide which; absence is
+ * first-class).
+ *
+ * Mirrors the `MerklePatricia*Prover` split: the prover walks the tree and emits the authentication path; verification
+ * (and the mandatory value-binding) is the [[SparseMerkleVerifier]]'s job.
+ */
+trait SparseMerkleProver[F[_]] {
+
+  /**
+   * Prove `key`'s status against the tree this prover was built for. `Right` carries an [[SparseMerkleProof.Inclusion]] or
+   * [[SparseMerkleProof.Absence]]; `Left` carries a structural [[SparseMerkleProofError]] (the in-memory prover does not fail under normal
+   * operation, but the signature keeps the error channel uniform with [[SparseMerkleVerifier]]).
+   */
+  def prove(key: Hex): F[Either[SparseMerkleProofError, SparseMerkleProof]]
+}
+
+object SparseMerkleProver {
+  def apply[F[_]](implicit prover: SparseMerkleProver[F]): SparseMerkleProver[F] = prover
+
+  /** Provides syntax extensions for more ergonomic proof generation. */
+  object syntax {
+
+    implicit class SparseMerkleKeyOps(private val key: Hex) extends AnyVal {
+
+      /** Prove this key's status (inclusion or absence) against the tree the prover was built for. */
+      def attest[F[_]](implicit P: SparseMerkleProver[F]): F[Either[SparseMerkleProofError, SparseMerkleProof]] =
+        P.prove(key)
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/api/SparseMerkleVerifier.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/api/SparseMerkleVerifier.scala
@@ -1,0 +1,122 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt.api
+
+import cats.MonadThrow
+import cats.syntax.applicative._
+import cats.syntax.apply._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt._
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+/**
+ * Verifies a native [[SparseMerkleProof]] against a trusted [[SparseMerkleRoot]], returning a [[Verified]]-gated [[SparseMerkleEntry]] (so the
+ * result cannot be consumed unverified).
+ *
+ * Verification is the SAME authentication-path fold for inclusion and absence -- they differ only in what sits at the
+ * terminating slot:
+ *   - INCLUSION: assert `Hash.fromBytes(value) == proof.valueDigest` (mandatory value-binding =>
+ *     [[SparseMerkleProofError.ValueBindingFailed]] on mismatch), recompute the leaf digest from `(position, valueDigest)`, fold
+ *     the siblings up, compare to the trusted root.
+ *   - ABSENCE/Default: fold the EMPTY placeholder (`Hash.empty`) up through the siblings, compare to the trusted root.
+ *   - ABSENCE/OtherLeaf: recompute the occupying leaf's position; assert it differs from the queried position (else it
+ *     is not a genuine other leaf => [[SparseMerkleProofError.MalformedProof]]); recompute its leaf digest from
+ *     `(occupyingPosition, occupyingDataDigest)`, fold up, compare to the trusted root. The root match also enforces the
+ *     shared-prefix relationship.
+ *
+ * Any path longer than the 256-bit position space is [[SparseMerkleProofError.MalformedProof]]; a fold that does not reproduce
+ * the trusted root is [[SparseMerkleProofError.RootMismatch]].
+ */
+trait SparseMerkleVerifier[F[_]] {
+  def verify(root: SparseMerkleRoot, proof: SparseMerkleProof): F[Either[SparseMerkleProofError, Verified[SparseMerkleEntry]]]
+}
+
+object SparseMerkleVerifier {
+
+  def apply[F[_]](implicit verifier: SparseMerkleVerifier[F]): SparseMerkleVerifier[F] = verifier
+
+  def make[F[_]: MonadThrow: JsonBinaryHasher]: SparseMerkleVerifier[F] = new SparseMerkleVerifier[F] {
+
+    def verify(root: SparseMerkleRoot, proof: SparseMerkleProof): F[Either[SparseMerkleProofError, Verified[SparseMerkleEntry]]] =
+      if (proof.siblings.length > SparseMerkleHashing.PositionBits)
+        (SparseMerkleProofError.MalformedProof(proof.key, SparseMerkleProofError.MalformedReason.PathTooDeep): SparseMerkleProofError)
+          .asLeft[Verified[SparseMerkleEntry]]
+          .pure[F]
+      else
+        proof match {
+          case SparseMerkleProof.Inclusion(key, value, valueDigest, siblings) =>
+            SparseMerkleHashing.valueDigest[F](value).flatMap { computed =>
+              if (computed != valueDigest)
+                (SparseMerkleProofError.ValueBindingFailed(key): SparseMerkleProofError).asLeft[Verified[SparseMerkleEntry]].pure[F]
+              else
+                SparseMerkleHashing.position[F](key).flatMap { pos =>
+                  SparseMerkleHashing
+                    .leafDigest[F](pos, valueDigest)
+                    .flatMap(leaf => foldUp(pos, leaf, siblings))
+                    .map(recomputed => bindRoot(root, recomputed, SparseMerkleEntry.Present(key, value)))
+                }
+            }
+
+          case SparseMerkleProof.Absence(key, AbsenceWitness.Default, siblings) =>
+            SparseMerkleHashing.position[F](key).flatMap { pos =>
+              foldUp(pos, SparseMerkleHashing.empty, siblings)
+                .map(recomputed => bindRoot(root, recomputed, SparseMerkleEntry.Absent(key)))
+            }
+
+          case SparseMerkleProof.Absence(key, AbsenceWitness.OtherLeaf(occupyingKey, occupyingDataDigest), siblings) =>
+            (SparseMerkleHashing.position[F](key), SparseMerkleHashing.position[F](occupyingKey)).tupled.flatMap {
+              case (pos, occPos) =>
+                if (occPos == pos)
+                  (SparseMerkleProofError.MalformedProof(
+                    key,
+                    SparseMerkleProofError.MalformedReason.OtherLeafCollidesWithKey
+                  ): SparseMerkleProofError)
+                    .asLeft[Verified[SparseMerkleEntry]]
+                    .pure[F]
+                else
+                  SparseMerkleHashing
+                    .leafDigest[F](occPos, occupyingDataDigest)
+                    .flatMap(leaf => foldUp(pos, leaf, siblings))
+                    .map(recomputed => bindRoot(root, recomputed, SparseMerkleEntry.Absent(key)))
+            }
+        }
+
+    /**
+     * Fold a terminating digest `start` (sitting at depth = `siblings.length`) up to the root, choosing left/right at
+     * each level by the corresponding bit of `position`. `siblings` is top-down (root-first); we consume it
+     * deepest-first.
+     */
+    private def foldUp(position: Hash, start: Hash, siblings: List[SparseMerkleSibling]): F[Hash] = {
+      val depth = siblings.length
+      // (level, sibling) pairs, deepest level first: level d-1 down to 0.
+      val indexed = siblings.reverse.zipWithIndex.map { case (sib, i) => (depth - 1 - i, sib.digest) }
+      indexed.foldLeft(start.pure[F]) {
+        case (acc, (level, sibling)) =>
+          acc.flatMap(cur => SparseMerkleHashing.combine[F](SparseMerkleHashing.bit(position, level), cur, sibling))
+      }
+    }
+
+    private def bindRoot(
+      root: SparseMerkleRoot,
+      recomputed: Hash,
+      entry: SparseMerkleEntry
+    ): Either[SparseMerkleProofError, Verified[SparseMerkleEntry]] =
+      if (recomputed == root.value) Verified.makeInternal(entry).asRight[SparseMerkleProofError]
+      else (SparseMerkleProofError.RootMismatch(root.value, recomputed): SparseMerkleProofError).asLeft[Verified[SparseMerkleEntry]]
+  }
+
+  /** Provides syntax extensions for more ergonomic verification. */
+  object syntax {
+
+    implicit class SparseMerkleProofOps(private val proof: SparseMerkleProof) extends AnyVal {
+
+      /** Verify this proof against the trusted `root`. */
+      def verifyAgainst[F[_]](root: SparseMerkleRoot)(
+        implicit V: SparseMerkleVerifier[F]
+      ): F[Either[SparseMerkleProofError, Verified[SparseMerkleEntry]]] =
+        V.verify(root, proof)
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/impl/InMemorySparseMerkleTree.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/impl/InMemorySparseMerkleTree.scala
@@ -1,0 +1,104 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt.impl
+
+import cats.effect.{Ref, Sync}
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt._
+import io.constellationnetwork.metagraph_sdk.crypto.smt.api.SparseMerkleProver
+import io.constellationnetwork.metagraph_sdk.crypto.smt.node.{SparseMerkleNode, SparseMerkleNodeOps}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * In-memory reference implementation of [[SparseMerkleTree]] -- a binary sparse Merkle tree with the Diem/JMT
+ * empty-subtree collapse.
+ *
+ * `Ref[F, SparseMerkleNode]`-backed, mirroring `InMemoryMerklePatriciaProducer`'s idiom; the mutators ([[insert]] / [[remove]] /
+ * [[withChanges]]) return a NEW tree over a FRESH `Ref` seeded with the recomputed root node, while the unchanged
+ * subtrees are shared structurally (the node ADT is immutable, so the new root reuses every untouched child). The
+ * receiver is never mutated.
+ *
+ * Positions are `hash(key)` (uniform), so node count is proportional to live leaves and the [[root]] is
+ * order-independent.
+ */
+final class InMemorySparseMerkleTree[F[_]: Sync: JsonBinaryHasher] private (rootRef: Ref[F, SparseMerkleNode]) extends SparseMerkleTree[F] {
+
+  def get(key: Hex): F[Option[Array[Byte]]] =
+    for {
+      pos  <- SparseMerkleHashing.position[F](key)
+      node <- rootRef.get
+    } yield SparseMerkleNodeOps.get(node, pos, 0)
+
+  def root: F[SparseMerkleRoot] =
+    rootRef.get.map(node => SparseMerkleRoot(node.digest))
+
+  def insert(key: Hex, value: Array[Byte]): F[SparseMerkleTree[F]] =
+    for {
+      node    <- rootRef.get
+      pos     <- SparseMerkleHashing.position[F](key)
+      vd      <- SparseMerkleHashing.valueDigest[F](value)
+      updated <- SparseMerkleNodeOps.insert[F](node, key, pos, vd, value, 0)
+      tree    <- InMemorySparseMerkleTree.fromNode[F](updated)
+    } yield tree
+
+  def remove(key: Hex): F[SparseMerkleTree[F]] =
+    for {
+      node    <- rootRef.get
+      pos     <- SparseMerkleHashing.position[F](key)
+      updated <- SparseMerkleNodeOps.remove[F](node, pos, 0)
+      tree    <- InMemorySparseMerkleTree.fromNode[F](updated)
+    } yield tree
+
+  def withChanges(upserts: Map[Hex, Array[Byte]], removes: Set[Hex]): F[SparseMerkleTree[F]] =
+    for {
+      node <- rootRef.get
+      // removals first (then upserts win). The canonical collapse invariant makes the result independent of the order
+      // within each phase.
+      afterRemoves <- removes.toList.foldLeftM(node) { (acc, key) =>
+        SparseMerkleHashing.position[F](key).flatMap(pos => SparseMerkleNodeOps.remove[F](acc, pos, 0))
+      }
+      afterUpserts <- upserts.toList.foldLeftM(afterRemoves) {
+        case (acc, (key, value)) =>
+          for {
+            pos  <- SparseMerkleHashing.position[F](key)
+            vd   <- SparseMerkleHashing.valueDigest[F](value)
+            next <- SparseMerkleNodeOps.insert[F](acc, key, pos, vd, value, 0)
+          } yield next
+      }
+      tree <- InMemorySparseMerkleTree.fromNode[F](afterUpserts)
+    } yield tree
+
+  /** A [[SparseMerkleProver]] bound to THIS tree's current root node (snapshot at call time). */
+  def prover: F[SparseMerkleProver[F]] =
+    rootRef.get.map { node =>
+      new SparseMerkleProver[F] {
+        def prove(key: Hex): F[Either[SparseMerkleProofError, SparseMerkleProof]] =
+          SparseMerkleHashing.position[F](key).flatMap(pos => SparseMerkleNodeOps.prove[F](node, key, pos))
+      }
+    }
+}
+
+object InMemorySparseMerkleTree {
+
+  /** An empty tree. */
+  def empty[F[_]: Sync: JsonBinaryHasher]: F[InMemorySparseMerkleTree[F]] =
+    fromNode[F](SparseMerkleNode.Empty)
+
+  /** A tree seeded with `initial` key->value bindings. Order-independent: any iteration order of `initial` yields the same root. */
+  def make[F[_]: Sync: JsonBinaryHasher](initial: Map[Hex, Array[Byte]] = Map.empty): F[InMemorySparseMerkleTree[F]] =
+    initial.toList
+      .foldLeftM(SparseMerkleNode.Empty: SparseMerkleNode) {
+        case (acc, (key, value)) =>
+          for {
+            pos  <- SparseMerkleHashing.position[F](key)
+            vd   <- SparseMerkleHashing.valueDigest[F](value)
+            next <- SparseMerkleNodeOps.insert[F](acc, key, pos, vd, value, 0)
+          } yield next
+      }
+      .flatMap(fromNode[F])
+
+  private def fromNode[F[_]: Sync: JsonBinaryHasher](node: SparseMerkleNode): F[InMemorySparseMerkleTree[F]] =
+    Ref.of[F, SparseMerkleNode](node).map(new InMemorySparseMerkleTree[F](_))
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/impl/LevelDbSparseMerkleTree.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/impl/LevelDbSparseMerkleTree.scala
@@ -1,0 +1,214 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt.impl
+
+import java.nio.file.Path
+import java.util.Base64
+
+import cats.effect.{Async, Ref, Resource, Sync}
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt._
+import io.constellationnetwork.metagraph_sdk.crypto.smt.api.SparseMerkleProver
+import io.constellationnetwork.metagraph_sdk.crypto.smt.node.{SparseMerkleNode, SparseMerkleNodeOps}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.metagraph_sdk.storage.Collection
+import io.constellationnetwork.metagraph_sdk.storage.impl.LevelDbCollection
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.syntax._
+import io.circe.{Decoder, Json}
+
+/**
+ * A LevelDB-backed, STATEFUL persistent sparse Merkle tree -- the persistent sibling of
+ * [[InMemorySparseMerkleTree]], mirroring `LevelDbMerklePatriciaProducer`'s store-plus-`Ref` discipline.
+ *
+ * Deliberately NOT a [[SparseMerkleTree]]: that trait's mutators must return a NEW tree (structural sharing, receiver
+ * untouched), which is incompatible with a mutable persistent store. Instead this exposes a stateful API whose mutators
+ * advance THIS store in place (returning the resulting [[SparseMerkleRoot]]), exactly as the MPT LevelDB producer advances its
+ * own state.
+ *
+ * Two backing stores are kept in lock-step on every mutation:
+ *   - `entriesStore: Collection[F, Hex, Json]` -- the authoritative persisted `key -> value` map. SMT values are
+ *     `Array[Byte]`, which has no circe `Encoder`; each is stored as a BASE64 Json STRING and decoded back on load. The
+ *     round-trip is byte-EXACT (`Base64` is a lossless bijection on byte arrays), so the rebuilt `valueDigest`
+ *     (`Hash.fromBytes(value)`) and therefore the [[root]] reproduce after a restart.
+ *   - `rootRef: Ref[F, SparseMerkleNode]` -- the live in-memory tree used to answer [[get]] / [[root]] / [[prover]], rebuilt from
+ *     the persisted entries at construction (the SMT is order-independent, so any iteration order of the persisted map
+ *     yields the same node and the same root).
+ *
+ * A `metadataStore` records the latest root digest and a monotonically increasing version on each mutation, matching the
+ * MPT producer's metadata bookkeeping.
+ */
+final class LevelDbSparseMerkleTree[F[_]: Sync: JsonBinaryHasher] private (
+  val entriesStore: Collection[F, Hex, Json],
+  metadataStore: Collection[F, String, Json],
+  rootRef: Ref[F, SparseMerkleNode],
+  versionRef: Ref[F, Long]
+) {
+
+  /** The value bytes bound to `key`, or `None` if `key` is absent. `key` is hashed to its position internally. */
+  def get(key: Hex): F[Option[Array[Byte]]] =
+    for {
+      pos  <- SparseMerkleHashing.position[F](key)
+      node <- rootRef.get
+    } yield SparseMerkleNodeOps.get(node, pos, 0)
+
+  /** The current root commitment (digest of the live root node; [[SparseMerkleRoot.empty]] for the empty tree). */
+  def root: F[SparseMerkleRoot] =
+    rootRef.get.map(node => SparseMerkleRoot(node.digest))
+
+  /** Every persisted `key -> value` binding (values decoded byte-exactly from their base64 Json form). */
+  def entries: F[Map[Hex, Array[Byte]]] =
+    entriesStore.dump.flatMap { pairs =>
+      pairs.traverse {
+        case (k, json) => LevelDbSparseMerkleTree.decodeValue[F](json).map(k -> _)
+      }
+    }.map(_.toMap)
+
+  /**
+   * Upsert `key -> value`: persist the value and advance the live root. Returns the new [[SparseMerkleRoot]]. The entriesStore and
+   * the `Ref[SparseMerkleNode]` are updated together (and the metadata root/version bumped) so the persisted map and the live
+   * tree never diverge.
+   */
+  def insert(key: Hex, value: Array[Byte]): F[SparseMerkleRoot] =
+    for {
+      _       <- entriesStore.put(key, LevelDbSparseMerkleTree.encodeValue(value))
+      node    <- rootRef.get
+      pos     <- SparseMerkleHashing.position[F](key)
+      vd      <- SparseMerkleHashing.valueDigest[F](value)
+      updated <- SparseMerkleNodeOps.insert[F](node, key, pos, vd, value, 0)
+      _       <- rootRef.set(updated)
+      result  <- commit(updated)
+    } yield result
+
+  /** Remove `key` (no-op if absent): drop it from the store and re-collapse the live root. Returns the new [[SparseMerkleRoot]]. */
+  def remove(key: Hex): F[SparseMerkleRoot] =
+    for {
+      _       <- entriesStore.remove(key)
+      node    <- rootRef.get
+      pos     <- SparseMerkleHashing.position[F](key)
+      updated <- SparseMerkleNodeOps.remove[F](node, pos, 0)
+      _       <- rootRef.set(updated)
+      result  <- commit(updated)
+    } yield result
+
+  /**
+   * Apply `removes` then `upserts` (removals first, upsert-wins) atomically against both backing stores, advancing the
+   * live root once. Independent of the order entries appear in the inputs.
+   */
+  def withChanges(upserts: Map[Hex, Array[Byte]], removes: Set[Hex]): F[SparseMerkleRoot] =
+    for {
+      _    <- entriesStore.removeBatch(removes.toList)
+      _    <- entriesStore.putBatch(upserts.toList.map { case (k, v) => k -> LevelDbSparseMerkleTree.encodeValue(v) })
+      node <- rootRef.get
+      afterRemoves <- removes.toList.foldLeftM(node) { (acc, key) =>
+        SparseMerkleHashing.position[F](key).flatMap(pos => SparseMerkleNodeOps.remove[F](acc, pos, 0))
+      }
+      afterUpserts <- upserts.toList.foldLeftM(afterRemoves) {
+        case (acc, (key, value)) =>
+          for {
+            pos  <- SparseMerkleHashing.position[F](key)
+            vd   <- SparseMerkleHashing.valueDigest[F](value)
+            next <- SparseMerkleNodeOps.insert[F](acc, key, pos, vd, value, 0)
+          } yield next
+      }
+      _      <- rootRef.set(afterUpserts)
+      result <- commit(afterUpserts)
+    } yield result
+
+  /** An [[SparseMerkleProver]] bound to THIS tree's current root node (snapshot at call time). */
+  def prover: F[SparseMerkleProver[F]] =
+    rootRef.get.map { node =>
+      new SparseMerkleProver[F] {
+        def prove(key: Hex): F[Either[SparseMerkleProofError, SparseMerkleProof]] =
+          SparseMerkleHashing.position[F](key).flatMap(pos => SparseMerkleNodeOps.prove[F](node, key, pos))
+      }
+    }
+
+  /** Record the new root digest and bump the version in the metadata store; return the new [[SparseMerkleRoot]]. */
+  private def commit(node: SparseMerkleNode): F[SparseMerkleRoot] =
+    for {
+      version <- versionRef.updateAndGet(_ + 1)
+      _       <- metadataStore.put("root", node.digest.asJson)
+      _       <- metadataStore.put("version", version.asJson)
+    } yield SparseMerkleRoot(node.digest)
+}
+
+object LevelDbSparseMerkleTree {
+
+  /** Byte-exact value encoding: `Array[Byte]` -> base64 Json string. */
+  private def encodeValue(value: Array[Byte]): Json =
+    Base64.getEncoder.encodeToString(value).asJson
+
+  /** Inverse of [[encodeValue]]: base64 Json string -> the exact original bytes. */
+  private def decodeValue[F[_]: Sync](json: Json): F[Array[Byte]] =
+    Sync[F].fromEither(
+      json.as[String](Decoder[String]).map(Base64.getDecoder.decode)
+    )
+
+  /** Rebuild the live `SparseMerkleNode` from a persisted `key -> base64-json-value` map (order-independent). */
+  private def rebuildNode[F[_]: Sync: JsonBinaryHasher](persisted: List[(Hex, Json)]): F[SparseMerkleNode] =
+    persisted.foldLeftM(SparseMerkleNode.Empty: SparseMerkleNode) {
+      case (acc, (key, json)) =>
+        for {
+          value <- decodeValue[F](json)
+          pos   <- SparseMerkleHashing.position[F](key)
+          vd    <- SparseMerkleHashing.valueDigest[F](value)
+          next  <- SparseMerkleNodeOps.insert[F](acc, key, pos, vd, value, 0)
+        } yield next
+    }
+
+  /**
+   * Open (creating if missing) a LevelDB-backed SMT at `dbPath`. If the store is empty and `initial` is non-empty, it is
+   * persisted; existing persisted entries always take precedence (mirroring `LevelDbMerklePatriciaProducer.make`). The
+   * live `SparseMerkleNode` is rebuilt from whatever entries end up persisted and seeded into the `Ref`.
+   */
+  def make[F[_]: Async: JsonBinaryHasher](
+    dbPath: Path,
+    initial: Map[Hex, Array[Byte]] = Map.empty
+  ): Resource[F, LevelDbSparseMerkleTree[F]] = for {
+    entriesStore  <- LevelDbCollection.make[F, Hex, Json](dbPath.resolve("entries"))
+    metadataStore <- LevelDbCollection.make[F, String, Json](dbPath.resolve("metadata"))
+
+    tree <- Resource.eval {
+      for {
+        existing <- entriesStore.dump
+        _ <- (existing.isEmpty && initial.nonEmpty)
+          .pure[F]
+          .ifM(
+            ifTrue = entriesStore.putBatch(initial.toList.map { case (k, v) => k -> encodeValue(v) }),
+            ifFalse = ().pure[F]
+          )
+        persisted  <- if (existing.isEmpty && initial.nonEmpty) entriesStore.dump else existing.pure[F]
+        node       <- rebuildNode[F](persisted)
+        rootRef    <- Ref.of[F, SparseMerkleNode](node)
+        versionRef <- Ref.of[F, Long](0L)
+      } yield new LevelDbSparseMerkleTree[F](entriesStore, metadataStore, rootRef, versionRef)
+    }
+  } yield tree
+
+  /**
+   * Load an existing LevelDB-backed SMT without seeding. Fails if the store is empty or absent (mirroring
+   * `LevelDbMerklePatriciaProducer.load`). The live `SparseMerkleNode` is rebuilt from the persisted entries.
+   */
+  def load[F[_]: Async: JsonBinaryHasher](
+    dbPath: Path
+  ): Resource[F, LevelDbSparseMerkleTree[F]] = for {
+    entriesStore  <- LevelDbCollection.make[F, Hex, Json](dbPath.resolve("entries"))
+    metadataStore <- LevelDbCollection.make[F, String, Json](dbPath.resolve("metadata"))
+
+    tree <- Resource.eval {
+      for {
+        persisted <- entriesStore.dump
+        _ <- persisted.isEmpty
+          .pure[F]
+          .ifM(
+            ifTrue = Sync[F].raiseError[Unit](new IllegalStateException(s"No existing data found at $dbPath")),
+            ifFalse = ().pure[F]
+          )
+        node       <- rebuildNode[F](persisted)
+        rootRef    <- Ref.of[F, SparseMerkleNode](node)
+        versionRef <- Ref.of[F, Long](0L)
+      } yield new LevelDbSparseMerkleTree[F](entriesStore, metadataStore, rootRef, versionRef)
+    }
+  } yield tree
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/node/SparseMerkleNode.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/node/SparseMerkleNode.scala
@@ -1,0 +1,60 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt.node
+
+import cats.MonadThrow
+import cats.syntax.functor._
+
+import io.constellationnetwork.metagraph_sdk.crypto.Node
+import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleHashing
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * In-memory node of the binary sparse Merkle tree (the reference impl's materialized structure). Each node caches its
+ * digest, computed at construction (no invalidation) -- exactly like `MerklePatriciaNode`, and like it extends the
+ * shared [[Node]] trait.
+ *
+ * Canonical, order-independent shape for a subtree holding leaf set `S` (all sharing the prefix down to this depth):
+ *   - `|S| == 0` => [[SparseMerkleNode.Empty]] (digest = `Hash.empty`, never hashed),
+ *   - `|S| == 1` => [[SparseMerkleNode.Leaf]] (digest binds the FULL position, so it is depth-independent),
+ *   - `|S| >= 2` => [[SparseMerkleNode.Internal]] split by bit `depth` into `(left, right)`; either child MAY be `Empty` when all
+ *     of `S` shares that bit (a "stem" of internal nodes with empty siblings until the leaves diverge -- this is the
+ *     Diem/JMT empty-subtree collapse).
+ *
+ * Because the shape is a pure function of `S` (and positions are key-hashes, hence uniform), the root digest is
+ * independent of the order keys were inserted/removed.
+ */
+sealed trait SparseMerkleNode extends Node {
+  def digest: Hash
+}
+
+object SparseMerkleNode {
+
+  /** A collapsed empty (default) subtree. */
+  case object Empty extends SparseMerkleNode {
+    val digest: Hash = SparseMerkleHashing.empty
+  }
+
+  /**
+   * A single occupied position. The original `key` (pre-image of `position`) is retained so an [[SparseMerkleNode.Leaf]] proving
+   * the ABSENCE of a DIFFERENT key can hand the verifier the genuine occupying key (which the verifier re-hashes to the
+   * committed position). `value` is retained so the in-memory tree can answer `get` and the prover can emit the value
+   * bytes.
+   */
+  final case class Leaf private (key: Hex, position: Hash, valueDigest: Hash, value: Array[Byte], digest: Hash) extends SparseMerkleNode
+
+  /** An internal node split by one bit; `left`/`right` may be [[Empty]] (stem). */
+  final case class Internal private (left: SparseMerkleNode, right: SparseMerkleNode, digest: Hash) extends SparseMerkleNode
+
+  object Leaf {
+
+    def make[F[_]: MonadThrow: JsonBinaryHasher](key: Hex, position: Hash, valueDigest: Hash, value: Array[Byte]): F[Leaf] =
+      SparseMerkleHashing.leafDigest[F](position, valueDigest).map(d => new Leaf(key, position, valueDigest, value, d))
+  }
+
+  object Internal {
+
+    def make[F[_]: MonadThrow: JsonBinaryHasher](left: SparseMerkleNode, right: SparseMerkleNode): F[Internal] =
+      SparseMerkleHashing.internalDigest[F](left.digest, right.digest).map(d => new Internal(left, right, d))
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/node/SparseMerkleNodeOps.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/smt/node/SparseMerkleNodeOps.scala
@@ -1,0 +1,158 @@
+package io.constellationnetwork.metagraph_sdk.crypto.smt.node
+
+import cats.MonadThrow
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt._
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * Pure structural operations on [[SparseMerkleNode]] trees: upsert, delete, lookup, and authentication-path proof generation.
+ * Every op preserves the canonical collapse invariant documented on [[SparseMerkleNode]], so the resulting [[SparseMerkleNode.digest]] is
+ * a pure function of the live leaf set (order-independent).
+ *
+ * These are the building blocks the in-memory [[SparseMerkleTree]] / [[api.SparseMerkleProver]] are written against; keeping
+ * them here (operating on the node directly) keeps the `Ref`-backed wrapper thin.
+ */
+object SparseMerkleNodeOps {
+
+  /**
+   * Upsert `(key -> value)` (with precomputed `position` and `valueDigest`) into the subtree rooted at `node`, which
+   * sits at `depth`.
+   */
+  def insert[F[_]: MonadThrow: JsonBinaryHasher](
+    node: SparseMerkleNode,
+    key: Hex,
+    position: Hash,
+    valueDigest: Hash,
+    value: Array[Byte],
+    depth: Int
+  ): F[SparseMerkleNode] =
+    node match {
+      case SparseMerkleNode.Empty =>
+        SparseMerkleNode.Leaf.make[F](key, position, valueDigest, value).widen
+
+      case leaf: SparseMerkleNode.Leaf =>
+        if (leaf.position == position) SparseMerkleNode.Leaf.make[F](key, position, valueDigest, value).widen
+        else mergeLeafWithNew[F](leaf, key, position, valueDigest, value, depth).widen
+
+      case internal: SparseMerkleNode.Internal =>
+        if (SparseMerkleHashing.bit(position, depth))
+          insert[F](internal.right, key, position, valueDigest, value, depth + 1)
+            .flatMap(r => SparseMerkleNode.Internal.make[F](internal.left, r).widen)
+        else
+          insert[F](internal.left, key, position, valueDigest, value, depth + 1)
+            .flatMap(l => SparseMerkleNode.Internal.make[F](l, internal.right).widen)
+    }
+
+  /**
+   * Delete `position` from the subtree rooted at `node` (at `depth`), re-collapsing stems so the result stays
+   * canonical. No-op if absent.
+   */
+  def remove[F[_]: MonadThrow: JsonBinaryHasher](node: SparseMerkleNode, position: Hash, depth: Int): F[SparseMerkleNode] =
+    node match {
+      case SparseMerkleNode.Empty => (SparseMerkleNode.Empty: SparseMerkleNode).pure[F]
+
+      case leaf: SparseMerkleNode.Leaf =>
+        if (leaf.position == position) (SparseMerkleNode.Empty: SparseMerkleNode).pure[F]
+        else (leaf: SparseMerkleNode).pure[F]
+
+      case internal: SparseMerkleNode.Internal =>
+        if (SparseMerkleHashing.bit(position, depth))
+          remove[F](internal.right, position, depth + 1).flatMap(newR => collapse[F](internal.left, newR))
+        else
+          remove[F](internal.left, position, depth + 1).flatMap(newL => collapse[F](newL, internal.right))
+    }
+
+  /** The value bytes at `position`, or `None`. */
+  def get(node: SparseMerkleNode, position: Hash, depth: Int): Option[Array[Byte]] =
+    node match {
+      case SparseMerkleNode.Empty => None
+      case leaf: SparseMerkleNode.Leaf =>
+        if (leaf.position == position) Some(leaf.value) else None
+      case internal: SparseMerkleNode.Internal =>
+        if (SparseMerkleHashing.bit(position, depth)) get(internal.right, position, depth + 1)
+        else get(internal.left, position, depth + 1)
+    }
+
+  /**
+   * Build the authentication path for `key` (already hashed to `position`) against the subtree rooted at `node`,
+   * accumulating sibling digests top-down. Returns the [[SparseMerkleProof]] the [[api.SparseMerkleVerifier]] can fold. The in-memory
+   * tree never produces a malformed proof, so this is total in the `Right` channel; the `Either` keeps the type uniform
+   * with the algebra.
+   */
+  def prove[F[_]: MonadThrow](
+    root: SparseMerkleNode,
+    key: Hex,
+    position: Hash
+  ): F[Either[SparseMerkleProofError, SparseMerkleProof]] = {
+
+    // Walk down accumulating siblings (root-first). Stops at Leaf / Empty.
+    def loop(node: SparseMerkleNode, depth: Int, acc: List[SparseMerkleSibling]): Either[SparseMerkleProofError, SparseMerkleProof] =
+      node match {
+        case SparseMerkleNode.Empty =>
+          Right(SparseMerkleProof.Absence(key, AbsenceWitness.Default, acc.reverse))
+
+        case leaf: SparseMerkleNode.Leaf =>
+          if (leaf.position == position)
+            Right(SparseMerkleProof.Inclusion(key, leaf.value, leaf.valueDigest, acc.reverse))
+          else
+            Right(
+              SparseMerkleProof.Absence(
+                key,
+                AbsenceWitness.OtherLeaf(leaf.key, leaf.valueDigest),
+                acc.reverse
+              )
+            )
+
+        case internal: SparseMerkleNode.Internal =>
+          if (SparseMerkleHashing.bit(position, depth))
+            loop(internal.right, depth + 1, SparseMerkleSibling(internal.left.digest) :: acc)
+          else
+            loop(internal.left, depth + 1, SparseMerkleSibling(internal.right.digest) :: acc)
+      }
+
+    loop(root, 0, Nil).pure[F]
+  }
+
+  /** Place two distinct-position leaves (the existing `leaf` and a new one) under a fresh internal stem starting at `depth`. */
+  private def mergeLeafWithNew[F[_]: MonadThrow: JsonBinaryHasher](
+    leaf: SparseMerkleNode.Leaf,
+    newKey: Hex,
+    newPos: Hash,
+    newVd: Hash,
+    newValue: Array[Byte],
+    depth: Int
+  ): F[SparseMerkleNode.Internal] = {
+    val existingBit = SparseMerkleHashing.bit(leaf.position, depth)
+    val newBit = SparseMerkleHashing.bit(newPos, depth)
+    if (existingBit == newBit)
+      mergeLeafWithNew[F](leaf, newKey, newPos, newVd, newValue, depth + 1).flatMap { child =>
+        if (newBit) SparseMerkleNode.Internal.make[F](SparseMerkleNode.Empty, child)
+        else SparseMerkleNode.Internal.make[F](child, SparseMerkleNode.Empty)
+      }
+    else
+      SparseMerkleNode.Leaf.make[F](newKey, newPos, newVd, newValue).flatMap { newLeaf =>
+        if (newBit) SparseMerkleNode.Internal.make[F](leaf, newLeaf) // new goes right (newBit true), existing left
+        else SparseMerkleNode.Internal.make[F](newLeaf, leaf) // new goes left, existing right
+      }
+  }
+
+  /**
+   * Re-collapse an internal node after a child changed: if exactly one leaf remains in the subtree (one child a Leaf,
+   * the other Empty), return that Leaf; otherwise keep an Internal. (A subtree that became fully Empty can only arise
+   * from removing the lone leaf, which the Leaf case above already returns as Empty -- so here at least one side is
+   * non-empty in the reachable cases; the `(Empty, Empty)` case is handled defensively.)
+   */
+  private def collapse[F[_]: MonadThrow: JsonBinaryHasher](left: SparseMerkleNode, right: SparseMerkleNode): F[SparseMerkleNode] =
+    (left, right) match {
+      case (SparseMerkleNode.Empty, r: SparseMerkleNode.Leaf) => (r: SparseMerkleNode).pure[F]
+      case (l: SparseMerkleNode.Leaf, SparseMerkleNode.Empty) => (l: SparseMerkleNode).pure[F]
+      case (SparseMerkleNode.Empty, SparseMerkleNode.Empty)   => (SparseMerkleNode.Empty: SparseMerkleNode).pure[F]
+      case _                                                  => SparseMerkleNode.Internal.make[F](left, right).widen
+    }
+}

--- a/src/test/scala/crypto/smt/LevelDbSparseMerkleTreeSuite.scala
+++ b/src/test/scala/crypto/smt/LevelDbSparseMerkleTreeSuite.scala
@@ -1,0 +1,158 @@
+package crypto.smt
+
+import java.io.IOException
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt._
+import io.constellationnetwork.metagraph_sdk.crypto.smt.api.SparseMerkleVerifier
+import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.{InMemorySparseMerkleTree, LevelDbSparseMerkleTree}
+import io.constellationnetwork.security.hex.Hex
+
+import weaver._
+
+/**
+ * Persistence + parity tests for [[LevelDbSparseMerkleTree]] -- the LevelDB-backed sibling of
+ * [[InMemorySparseMerkleTree]]. Mirrors the MPT `LevelDbMerklePatriciaProducerSuite` temp-dir / restart idiom:
+ *   - the LevelDB-built root MATCHES an in-memory tree over the same entries (the persistent variant computes
+ *     byte-identical digests),
+ *   - state SURVIVES a Resource release/reopen (root unchanged, membership proof still verifies),
+ *   - [[LevelDbSparseMerkleTree.remove]] advances the root, and
+ *   - [[LevelDbSparseMerkleTree.get]] returns the EXACT value bytes (base64 round-trip is lossless).
+ */
+object LevelDbSparseMerkleTreeSuite extends SimpleIOSuite {
+
+  /** N distinct 32-byte keys with small distinct values. */
+  private def testData(n: Int): Map[Hex, Array[Byte]] =
+    (0 until n).map { i =>
+      val key = Hex.fromBytes(Array.tabulate[Byte](32)(j => (i * 31 + j).toByte))
+      val value = s"value-$i".getBytes("UTF-8")
+      key -> value
+    }.toMap
+
+  private def tempDbPath: Resource[IO, Path] =
+    Resource.make(IO(Files.createTempDirectory("smt-leveldb-test")))(deleteRecursively)
+
+  private def deleteRecursively(path: Path): IO[Unit] = IO {
+    Files.walkFileTree(
+      path,
+      new SimpleFileVisitor[Path] {
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          Files.delete(file)
+          FileVisitResult.CONTINUE
+        }
+
+        override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+          Files.delete(dir)
+          FileVisitResult.CONTINUE
+        }
+      }
+    )
+  } *> IO.unit
+
+  test("(1) LevelDB-built root equals in-memory tree built from the same entries") {
+    tempDbPath.use { dbPath =>
+      val data = testData(8)
+      for {
+        levelDbRoot <- LevelDbSparseMerkleTree.make[IO](dbPath, data).use(_.root)
+        inMemRoot   <- InMemorySparseMerkleTree.make[IO](data).flatMap(_.root)
+      } yield expect(levelDbRoot === inMemRoot)
+    }
+  }
+
+  test("(2) state persists across Resource release: reload keeps the root and a membership proof verifies") {
+    tempDbPath.use { dbPath =>
+      val data = testData(6)
+      val (probeKey, probeValue) = (data.head._1, data.head._2)
+      val verifier = SparseMerkleVerifier.make[IO]
+
+      for {
+        // First instance: seed empty, insert all, capture the root.
+        rootBefore <- LevelDbSparseMerkleTree.make[IO](dbPath).use { tree =>
+          data.toList.traverse_ { case (k, v) => tree.insert(k, v) } >> tree.root
+        }
+
+        // Second instance: reload from disk (must NOT be empty).
+        reloaded <- LevelDbSparseMerkleTree.load[IO](dbPath).use { tree =>
+          for {
+            rootAfter <- tree.root
+            prover    <- tree.prover
+            proofE    <- prover.prove(probeKey)
+            verifiedOk <- proofE match {
+              case Right(incl @ SparseMerkleProof.Inclusion(_, _, _, _)) =>
+                verifier.verify(rootAfter, incl).map {
+                  case Right(v) =>
+                    v.value match {
+                      case SparseMerkleEntry.Present(k, value) => expect(k === probeKey) && expect(value.sameElements(probeValue))
+                      case other                               => failure(s"expected Present, got $other")
+                    }
+                  case Left(err) => failure(s"verify rejected a valid inclusion after reload: $err")
+                }
+              case Right(other) => IO.pure(failure(s"expected Inclusion for present key, got $other"))
+              case Left(err)    => IO.pure(failure(s"prove failed after reload: $err"))
+            }
+          } yield (rootAfter, verifiedOk)
+        }
+      } yield expect(reloaded._1 === rootBefore) && reloaded._2
+    }
+  }
+
+  test("(2b) load fails on an empty / absent database") {
+    tempDbPath.use { dbPath =>
+      LevelDbSparseMerkleTree.load[IO](dbPath).use(_ => IO.unit).attempt.map(r => expect(r.isLeft))
+    }
+  }
+
+  test("(3) remove updates the root") {
+    tempDbPath.use { dbPath =>
+      val data = testData(5)
+      val victim = data.head._1
+      LevelDbSparseMerkleTree.make[IO](dbPath, data).use { tree =>
+        for {
+          rootBefore <- tree.root
+          rootAfter  <- tree.remove(victim)
+          gone       <- tree.get(victim)
+          reference  <- InMemorySparseMerkleTree.make[IO](data - victim).flatMap(_.root)
+        } yield expect(rootBefore =!= rootAfter) && expect(gone.isEmpty) && expect(rootAfter === reference)
+      }
+    }
+  }
+
+  test("(4) get returns the exact value bytes") {
+    tempDbPath.use { dbPath =>
+      // Include a value with the full byte range to stress the base64 round-trip.
+      val key = Hex.fromBytes(Array.tabulate[Byte](32)(i => (i + 1).toByte))
+      val value = Array.tabulate[Byte](256)(i => i.toByte) // 0x00..0xff, all byte values
+      for {
+        // First instance: write and read back (release before reloading -- LevelDB holds an exclusive file lock).
+        fetched <- LevelDbSparseMerkleTree.make[IO](dbPath, Map(key -> value)).use(_.get(key))
+        // Second instance: the bytes survive a release/reopen round-trip on disk.
+        fromDisk <- LevelDbSparseMerkleTree.load[IO](dbPath).use(_.get(key))
+      } yield expect(fetched.exists(_.sameElements(value))) && expect(fromDisk.exists(_.sameElements(value)))
+    }
+  }
+
+  test("(5) withChanges applies removes-then-upserts and matches an in-memory tree") {
+    tempDbPath.use { dbPath =>
+      val data = testData(6)
+      val (toRemove, toKeep) = data.toList.splitAt(3)
+      val removeKeys = toRemove.map(_._1).toSet
+      val extra = Hex.fromBytes(Array.fill[Byte](32)(0x5a.toByte)) -> "extra".getBytes("UTF-8")
+      val upserts = (toKeep :+ extra).toMap
+
+      LevelDbSparseMerkleTree.make[IO](dbPath, data).use { tree =>
+        for {
+          newRoot   <- tree.withChanges(upserts, removeKeys)
+          entries   <- tree.entries
+          reference <- InMemorySparseMerkleTree.make[IO]((data -- removeKeys) ++ upserts).flatMap(_.root)
+        } yield
+          expect(newRoot === reference) &&
+          expect(removeKeys.forall(k => !entries.contains(k))) &&
+          expect(entries.contains(extra._1))
+      }
+    }
+  }
+}

--- a/src/test/scala/crypto/smt/SparseMerkleTreeSuite.scala
+++ b/src/test/scala/crypto/smt/SparseMerkleTreeSuite.scala
@@ -1,0 +1,393 @@
+package crypto.smt
+
+import cats.Show
+import cats.effect.IO
+import cats.syntax.all._
+
+import scala.util.Random
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt._
+import io.constellationnetwork.metagraph_sdk.crypto.smt.api.SparseMerkleVerifier
+import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+/**
+ * Property + unit tests for the additive Sparse Merkle Tree primitive ported from tessellation-nakamoto.
+ *
+ * Proves the two headline properties of this primitive:
+ *   - ABSENCE is native and first-class: prove an absent key, verify the absence, then show inserting it changes the
+ *     root.
+ *   - ORDER-INDEPENDENCE: the same key-set inserted/removed in any permutation yields the same root.
+ *
+ * Plus the verifier's contract bar: mandatory value-binding ([[SparseMerkleProofError.ValueBindingFailed]]) and
+ * authentication-path soundness ([[SparseMerkleProofError.RootMismatch]] / [[SparseMerkleProofError.MalformedProof]]).
+ *
+ * Uses `SimpleIOSuite` with `JsonBinaryHasher[IO]` derived implicitly -- exactly the metakit crypto/mpt suite idiom
+ * (no `Hasher`/`SecurityProvider` resource is needed, since hashing routes through `std/JsonBinaryHasher`).
+ */
+object SparseMerkleTreeSuite extends SimpleIOSuite with Checkers {
+
+  // ---- generators -------------------------------------------------------------------------------------------------------------------------
+
+  /** A 32-byte key as a 64-char hex string (any Hex works since the position is `hash(key)`; fixed-width keeps samples readable). */
+  private val keyGen: Gen[Hex] =
+    Gen.listOfN(32, Gen.chooseNum(0, 255)).map(bs => Hex.fromBytes(bs.map(_.toByte).toArray))
+
+  /** A small non-empty value. */
+  private val valueGen: Gen[Array[Byte]] =
+    Gen.choose(1, 24).flatMap(n => Gen.listOfN(n, Gen.chooseNum(0, 255)).map(_.map(_.toByte).toArray))
+
+  /** A set of entries with DISTINCT keys (1..16). */
+  final case class Entries(pairs: List[(Hex, Array[Byte])])
+
+  implicit val showEntries: Show[Entries] = Show.show(e => s"Entries(n=${e.pairs.size}, keys=${e.pairs.map(_._1.shortValue)})")
+
+  /** Entries with between `minSize` and 16 distinct keys. Over-samples keys then de-dups + takes, keeping the constraint INSIDE the generator. */
+  private def entriesGenMin(minSize: Int): Gen[Entries] = for {
+    n          <- Gen.chooseNum(minSize, 16)
+    candidates <- Gen.listOfN(n + 8, keyGen).map(_.distinctBy(_.value))
+    keys = candidates.take(n)
+    values <- Gen.listOfN(keys.size, valueGen)
+  } yield Entries(keys.zip(values))
+
+  private val entriesGen: Gen[Entries] = entriesGenMin(1)
+
+  /** Entries plus one extra key guaranteed NOT in the set (for absence tests). */
+  final case class EntriesWithAbsent(entries: Entries, absent: Hex)
+
+  implicit val showEntriesWithAbsent: Show[EntriesWithAbsent] =
+    Show.show(e => s"EntriesWithAbsent(${showEntries.show(e.entries)}, absent=${e.absent.shortValue})")
+
+  private val entriesWithAbsentGen: Gen[EntriesWithAbsent] = for {
+    entries <- entriesGen
+    absent  <- keyGen.suchThat(k => !entries.pairs.exists(_._1.value == k.value))
+  } yield EntriesWithAbsent(entries, absent)
+
+  // ---- helpers ----------------------------------------------------------------------------------------------------------------------------
+
+  private def buildInOrder(pairs: List[(Hex, Array[Byte])]): IO[SparseMerkleRoot] =
+    InMemorySparseMerkleTree.make[IO](pairs.toMap).flatMap(_.root)
+
+  // ---- (a) ORDER-INDEPENDENCE -------------------------------------------------------------------------------------------------------------
+
+  test("(a) order-independence: same key-set inserted in any permutation yields the same root") {
+    forall(entriesGen) { entries =>
+      val canonical = entries.pairs
+      val perm1 = new Random(1).shuffle(entries.pairs)
+      val perm2 = new Random(2).shuffle(entries.pairs)
+      val perm3 = entries.pairs.reverse
+
+      for {
+        r0 <- buildInOrder(canonical)
+        r1 <- buildInOrder(perm1)
+        r2 <- buildInOrder(perm2)
+        r3 <- buildInOrder(perm3)
+      } yield expect.all(r0 === r1, r0 === r2, r0 === r3)
+    }
+  }
+
+  test("(a') order-independence under interleaved remove: insert-all then remove-half in two orders agrees") {
+    forall(entriesGenMin(2)) { entries =>
+      val (toRemove, toKeep) = entries.pairs.splitAt(entries.pairs.size / 2)
+      val removeKeys = toRemove.map(_._1).toSet
+
+      for {
+        full         <- InMemorySparseMerkleTree.make[IO](entries.pairs.toMap)
+        afterRemove1 <- full.withChanges(Map.empty, removeKeys)
+        r1           <- afterRemove1.root
+
+        empty        <- InMemorySparseMerkleTree.empty[IO]
+        afterRemove2 <- empty.withChanges(entries.pairs.toMap, Set.empty).flatMap(_.withChanges(Map.empty, removeKeys))
+        r2           <- afterRemove2.root
+
+        ref <- buildInOrder(toKeep)
+      } yield expect.all(r1 === r2, r1 === ref)
+    }
+  }
+
+  test("(a'') empty tree has the default-placeholder root") {
+    for {
+      tree <- InMemorySparseMerkleTree.empty[IO]
+      r    <- tree.root
+    } yield expect(r === SparseMerkleRoot.empty)
+  }
+
+  // ---- (b) INCLUSION round-trip -----------------------------------------------------------------------------------------------------------
+
+  test("(b) inclusion round-trip: prove(present) verifies and returns the bound value") {
+    val verifier = SparseMerkleVerifier.make[IO]
+
+    forall(entriesGen) { entries =>
+      InMemorySparseMerkleTree.make[IO](entries.pairs.toMap).flatMap { tree =>
+        tree.root.flatMap { root =>
+          tree.prover.flatMap { prover =>
+            entries.pairs.traverse {
+              case (key, value) =>
+                prover.prove(key).flatMap {
+                  case Right(proof @ SparseMerkleProof.Inclusion(_, _, _, _)) =>
+                    verifier.verify(root, proof).map {
+                      case Right(verified) =>
+                        verified.value match {
+                          case SparseMerkleEntry.Present(k, v) => expect(k === key) && expect(v.sameElements(value))
+                          case other                           => failure(s"expected Present, got $other")
+                        }
+                      case Left(err) => failure(s"verify rejected a valid inclusion: $err")
+                    }
+                  case Right(other) => IO.pure(failure(s"expected Inclusion for present key, got $other"))
+                  case Left(err)    => IO.pure(failure(s"prove failed for present key: $err"))
+                }
+            }.map(_.combineAll)
+          }
+        }
+      }
+    }
+  }
+
+  // ---- (c) ABSENCE round-trip -------------------------------------------------------------------------------------------------------------
+
+  test("(c) absence round-trip: prove(absent) verifies as Absent, then inserting the key CHANGES the root") {
+    val verifier = SparseMerkleVerifier.make[IO]
+
+    forall(entriesWithAbsentGen) { ewa =>
+      InMemorySparseMerkleTree.make[IO](ewa.entries.pairs.toMap).flatMap { tree =>
+        for {
+          rootBefore <- tree.root
+          prover     <- tree.prover
+          proofE     <- prover.prove(ewa.absent)
+          absenceOk <- proofE match {
+            case Right(proof @ SparseMerkleProof.Absence(k, _, _)) =>
+              verifier.verify(rootBefore, proof).map {
+                case Right(verified) =>
+                  verified.value match {
+                    case SparseMerkleEntry.Absent(ak) => expect(ak === k) && expect(k === ewa.absent)
+                    case other                        => failure(s"expected Absent, got $other")
+                  }
+                case Left(err) => failure(s"verify rejected a valid absence: $err")
+              }
+            case Right(other) => IO.pure(failure(s"expected Absence for absent key, got $other"))
+            case Left(err)    => IO.pure(failure(s"prove failed for absent key: $err"))
+          }
+          afterInsert <- tree.insert(ewa.absent, "now-present".getBytes("UTF-8"))
+          rootAfter   <- afterInsert.root
+        } yield absenceOk && expect(rootBefore =!= rootAfter)
+      }
+    }
+  }
+
+  test("(c') absence on the EMPTY tree verifies as Default-witness Absent against the empty root") {
+    val verifier = SparseMerkleVerifier.make[IO]
+    val key = Hex.fromBytes(Array.fill[Byte](32)(7))
+
+    for {
+      tree   <- InMemorySparseMerkleTree.empty[IO]
+      root   <- tree.root
+      prover <- tree.prover
+      proofE <- prover.prove(key)
+      result <- proofE match {
+        case Right(proof @ SparseMerkleProof.Absence(_, AbsenceWitness.Default, siblings)) =>
+          verifier.verify(root, proof).map { v =>
+            expect(siblings.isEmpty) && expect(v.isRight)
+          }
+        case other => IO.pure(failure(s"expected Default-witness Absence with no siblings, got $other"))
+      }
+    } yield result
+  }
+
+  test("(c'') single-leaf tree: absence of a different key is an OtherLeaf witness that verifies") {
+    val verifier = SparseMerkleVerifier.make[IO]
+    val presentKey = Hex.fromBytes(Array.fill[Byte](32)(1))
+    val absentKey = Hex.fromBytes(Array.fill[Byte](32)(2))
+
+    for {
+      tree   <- InMemorySparseMerkleTree.make[IO](Map(presentKey -> "v".getBytes("UTF-8")))
+      root   <- tree.root
+      prover <- tree.prover
+      proofE <- prover.prove(absentKey)
+      result <- proofE match {
+        case Right(proof @ SparseMerkleProof.Absence(_, AbsenceWitness.OtherLeaf(occKey, _), _)) =>
+          verifier.verify(root, proof).map { v =>
+            expect(occKey === presentKey) && expect(v.isRight)
+          }
+        case other => IO.pure(failure(s"expected OtherLeaf Absence, got $other"))
+      }
+    } yield result
+  }
+
+  // ---- (d) VALUE-TAMPER => ValueBindingFailed ----------------------------------------------------------------------------------------------
+
+  test("(d) value-tamper: mutating the inclusion proof's value bytes => ValueBindingFailed") {
+    val verifier = SparseMerkleVerifier.make[IO]
+
+    forall(entriesGen) { entries =>
+      InMemorySparseMerkleTree.make[IO](entries.pairs.toMap).flatMap { tree =>
+        tree.root.flatMap { root =>
+          tree.prover.flatMap { prover =>
+            val (key, _) = entries.pairs.head
+            prover.prove(key).flatMap {
+              case Right(SparseMerkleProof.Inclusion(k, value, vd, siblings)) =>
+                val tampered = SparseMerkleProof.Inclusion(k, value :+ 0x7f.toByte, vd, siblings) // value no longer hashes to vd
+                verifier.verify(root, tampered).map {
+                  case Left(SparseMerkleProofError.ValueBindingFailed(bad)) => expect(bad === k)
+                  case other                                                => failure(s"expected ValueBindingFailed, got $other")
+                }
+              case other => IO.pure(failure(s"expected Inclusion, got $other"))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // ---- (e) tampered authentication path => rejection ---------------------------------------------------------------------------------------
+
+  test("(e1) wrong sibling: corrupting a sibling digest => RootMismatch") {
+    val verifier = SparseMerkleVerifier.make[IO]
+
+    forall(entriesGenMin(4)) { entries =>
+      InMemorySparseMerkleTree.make[IO](entries.pairs.toMap).flatMap { tree =>
+        tree.root.flatMap { root =>
+          tree.prover.flatMap { prover =>
+            entries.pairs.collectFirstSomeM {
+              case (key, _) =>
+                prover.prove(key).map {
+                  case Right(SparseMerkleProof.Inclusion(k, v, vd, siblings)) if siblings.nonEmpty =>
+                    val corrupted = siblings.updated(0, SparseMerkleSibling(Hash("f" * 64)))
+                    Some(SparseMerkleProof.Inclusion(k, v, vd, corrupted))
+                  case _ => None
+                }
+            }.flatMap {
+              case Some(badProof) =>
+                verifier.verify(root, badProof).map {
+                  case Left(SparseMerkleProofError.RootMismatch(_, _)) => success
+                  case other                                           => failure(s"expected RootMismatch, got $other")
+                }
+              case None => IO.pure(success) // no multi-sibling proof in this sample; nothing to corrupt
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("(e2) omitted sibling: dropping a sibling from a deep proof => RootMismatch") {
+    val verifier = SparseMerkleVerifier.make[IO]
+
+    forall(entriesGenMin(4)) { entries =>
+      InMemorySparseMerkleTree.make[IO](entries.pairs.toMap).flatMap { tree =>
+        tree.root.flatMap { root =>
+          tree.prover.flatMap { prover =>
+            entries.pairs.collectFirstSomeM {
+              case (key, _) =>
+                prover.prove(key).map {
+                  case Right(SparseMerkleProof.Inclusion(k, v, vd, siblings)) if siblings.nonEmpty =>
+                    Some(SparseMerkleProof.Inclusion(k, v, vd, siblings.drop(1)))
+                  case _ => None
+                }
+            }.flatMap {
+              case Some(badProof) =>
+                verifier.verify(root, badProof).map {
+                  case Left(SparseMerkleProofError.RootMismatch(_, _)) => success
+                  case other => failure(s"expected RootMismatch after omitted sibling, got $other")
+                }
+              case None => IO.pure(success)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("(e3) extra sibling: appending a bogus sibling => RootMismatch") {
+    val verifier = SparseMerkleVerifier.make[IO]
+
+    forall(entriesGen) { entries =>
+      InMemorySparseMerkleTree.make[IO](entries.pairs.toMap).flatMap { tree =>
+        tree.root.flatMap { root =>
+          tree.prover.flatMap { prover =>
+            val (key, _) = entries.pairs.head
+            prover.prove(key).flatMap {
+              case Right(SparseMerkleProof.Inclusion(k, v, vd, siblings)) =>
+                val withExtra = SparseMerkleProof.Inclusion(k, v, vd, siblings :+ SparseMerkleSibling(Hash.empty))
+                verifier.verify(root, withExtra).map {
+                  case Left(SparseMerkleProofError.RootMismatch(_, _)) => success
+                  case other                                           => failure(s"expected RootMismatch after extra sibling, got $other")
+                }
+              case other => IO.pure(failure(s"expected Inclusion, got $other"))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("(e4) wrong-key inclusion: an inclusion proof verified against a DIFFERENT root => rejection") {
+    val verifier = SparseMerkleVerifier.make[IO]
+    val keyA = Hex.fromBytes(Array.fill[Byte](32)(10))
+    val keyB = Hex.fromBytes(Array.fill[Byte](32)(20))
+
+    for {
+      treeA   <- InMemorySparseMerkleTree.make[IO](Map(keyA -> "a".getBytes("UTF-8")))
+      treeB   <- InMemorySparseMerkleTree.make[IO](Map(keyB -> "b".getBytes("UTF-8")))
+      rootB   <- treeB.root
+      proverA <- treeA.prover
+      proofA  <- proverA.prove(keyA)
+      result <- proofA match {
+        case Right(incl: SparseMerkleProof.Inclusion) =>
+          verifier.verify(rootB, incl).map {
+            case Left(SparseMerkleProofError.RootMismatch(_, _)) => success
+            case other                                           => failure(s"expected RootMismatch against foreign root, got $other")
+          }
+        case other => IO.pure(failure(s"expected Inclusion, got $other"))
+      }
+    } yield result
+  }
+
+  // ---- proof JSON round-trips byte-exactly --------------------------------------------------------------------------------------------------
+
+  test("proof Circe round-trip preserves inclusion + absence proofs byte-exactly") {
+    import io.circe.syntax._
+
+    forall(entriesWithAbsentGen) { ewa =>
+      InMemorySparseMerkleTree.make[IO](ewa.entries.pairs.toMap).flatMap { tree =>
+        tree.prover.flatMap { prover =>
+          val (presentKey, _) = ewa.entries.pairs.head
+          for {
+            inclE <- prover.prove(presentKey)
+            absE  <- prover.prove(ewa.absent)
+          } yield {
+            val incl = inclE.toOption.get
+            val abs = absE.toOption.get
+            val inclRound = incl.asJson.as[SparseMerkleProof]
+            val absRound = abs.asJson.as[SparseMerkleProof]
+            expect(inclRound === Right(incl)) && expect(absRound === Right(abs))
+          }
+        }
+      }
+    }
+  }
+
+  // ---- collapse invariant sanity (white-box): node count is bounded, not 2^256 ---------------------------------------------------------
+
+  test("structural: a 2-leaf tree materializes a bounded stem (no 2^256 blow-up)") {
+    val k1 = Hex.fromBytes(Array.fill[Byte](32)(0))
+    val k2 = Hex.fromBytes(Array.fill[Byte](32)(0xff.toByte))
+
+    for {
+      tree   <- InMemorySparseMerkleTree.make[IO](Map(k1 -> "a".getBytes("UTF-8"), k2 -> "b".getBytes("UTF-8")))
+      prover <- tree.prover
+      p1     <- prover.prove(k1)
+      p2     <- prover.prove(k2)
+    } yield {
+      val d1 = p1.toOption.get.siblings.size
+      val d2 = p2.toOption.get.siblings.size
+      expect(d1 > 0) && expect(d1 <= SparseMerkleHashing.PositionBits) && expect(d2 <= SparseMerkleHashing.PositionBits) && expect(
+        d1 === d2
+      )
+    }
+  }
+}


### PR DESCRIPTION
## What
A Sparse Merkle Tree (SMT) in metakit's crypto auth-dbs — a parallel primitive to the MPT, wired to `std/JsonBinaryHasher` so it inherits the same RFC 8785 canonicalization determinism.

> **Stacked on `refactor/jlvm-exact-rationals`** — review/merge that first; this diff currently includes it. (SMT and numerics touch disjoint files.)

## Changes
- core: SparseMerkleTree, **SparseMerkleHashing** (narrow, swappable seam for a future Poseidon/SNARK-friendly hash), SparseMerkleCommitment, SparseMerkleProof (Inclusion + Absence/Default/OtherLeaf), proof errors, root, entry.
- node ops (insert/remove/get/prove + Diem/JMT empty-subtree collapse — structure is a function of the live leaf set ⇒ insertion-order independent).
- api: SparseMerkleProver / SparseMerkleVerifier; impl: InMemory + **LevelDB-backed** (mirrors LevelDbMerklePatriciaProducer; values persisted base64-lossless).
- Full `SparseMerkle*` names to match `MerklePatricia*` (package stays `crypto.smt`, paralleling `crypto.mpt`). Skipped VersionedSmt + LightClientSmt.

## Tests
20/20 green (14 in-memory + 6 LevelDB) on JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
