### PR TITLE
fix(json_logic): align `!==` and `all([])` with the JSON Logic reference

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
@@ -298,7 +298,9 @@ object JsonLogicSemantics {
             case FloatValue(l) :: FloatValue(r) :: Nil => l != r
             case ArrayValue(l) :: ArrayValue(r) :: Nil => l != r
             case MapValue(l) :: MapValue(r) :: Nil     => l != r
-            case _                                     => false
+            // `!==` is the negation of `===`: values of mismatched types are NOT strictly equal, hence strictly
+            // not-equal. Matches the JSON Logic reference / TS (`!==` === `!(===)`).
+            case _ => true
           }
           (BoolValue(boolResult): JsonLogicValue).pure[Result].asRight[JsonLogicException]
         }
@@ -756,6 +758,9 @@ object JsonLogicSemantics {
 
         args.withMetrics {
           case NullValue :: FunctionValue(_) :: Nil => (BoolValue(false): JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
+          // `all` over an EMPTY array is false (JSON Logic reference / TS), not vacuously true.
+          case ArrayValue(Nil) :: FunctionValue(_) :: Nil =>
+            (BoolValue(false): JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
           case ArrayValue(arr) :: FunctionValue(expr) :: Nil => impl(arr, expr)
           case _ => JsonLogicException(s"Unexpected input to ${AllOp.tag}, got $values").asLeft[Result[JsonLogicValue]].pure[F]
         }

--- a/src/test/scala/json_logic/JsonLogicSpec.scala
+++ b/src/test/scala/json_logic/JsonLogicSpec.scala
@@ -610,7 +610,7 @@ object JsonLogicSpec extends SimpleIOSuite with Checkers {
     }
   }
 
-  test("!== can test strict not-equal with type coercion for un-like types") {
+  test("!== is strict not-equal: un-like types are not strictly equal (=> true)") {
     val exprStr =
       """
         |{"!==" : [1, "1"]}
@@ -623,7 +623,7 @@ object JsonLogicSpec extends SimpleIOSuite with Checkers {
 
     parseTestJson(exprStr, dataStr).flatMap {
       case (expr, data) =>
-        staticTestRunner(expr, data, BoolValue(false))
+        staticTestRunner(expr, data, BoolValue(true))
     }
   }
 
@@ -2971,6 +2971,16 @@ object JsonLogicSpec extends SimpleIOSuite with Checkers {
     parseTestJson(exprStr, dataStr).flatMap {
       case (expr, data) =>
         expectError(expr, data)
+    }
+  }
+
+  test("`all` over an empty array is false (not vacuously true)") {
+    val exprStr = """{"all": [[], {">": [{"var": ""}, 0]}]}"""
+    val dataStr = """null"""
+
+    parseTestJson(exprStr, dataStr).flatMap {
+      case (expr, data) =>
+        staticTestRunner(expr, data, BoolValue(false))
     }
   }
 


### PR DESCRIPTION
## What
Fixes two latent semantic bugs surfaced by **cross-language differential testing** — the Rust JLVM port + the TypeScript impl + the shared conformance vectors all disagreed with Scala:

- **`!==`** on mismatched types returned `false`; it must be the negation of `===`, so un-like types (e.g. `[1, "1"]`) are strictly not-equal ⇒ `true`.
- **`all([])`** returned `true` (vacuous `forall`); the JSON Logic reference / TS return `false`.

## Tests
Updated the `!==` un-like-types expectation; added an `all([]) ⇒ false` regression test. json_logic suite **553/553 green**. Independent of the numerics/SMT branches (disjoint handlers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
