### PR TITLE
fix(mpt): deterministic roots (zero-length Extension) + batch/prefix provers + tests

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaBatchInclusionProof.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/MerklePatriciaBatchInclusionProof.scala
@@ -1,0 +1,34 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt
+
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+/**
+ * A batch inclusion proof attesting that several paths are all present in the same trie.
+ *
+ * The witness is a single, de-duplicated list of node commitments shared across all paths. A
+ * verifier reconstructs the per-path witness by walking from the root and, at each step, selecting
+ * the commitment in `witness` whose prefixed digest matches the expected child digest.
+ */
+final case class MerklePatriciaBatchInclusionProof(
+  paths: List[Hex],
+  witness: List[MerklePatriciaCommitment]
+)
+
+object MerklePatriciaBatchInclusionProof {
+
+  implicit val batchProofEncoder: Encoder[MerklePatriciaBatchInclusionProof] =
+    (proof: MerklePatriciaBatchInclusionProof) =>
+      Json.obj(
+        "paths"   -> proof.paths.asJson,
+        "witness" -> proof.witness.asJson
+      )
+
+  implicit val batchProofDecoder: Decoder[MerklePatriciaBatchInclusionProof] = (c: HCursor) =>
+    for {
+      paths   <- c.downField("paths").as[List[Hex]]
+      witness <- c.downField("witness").as[List[MerklePatriciaCommitment]]
+    } yield MerklePatriciaBatchInclusionProof(paths, witness)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/Nibble.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/Nibble.scala
@@ -87,6 +87,10 @@ object Nibble {
       .takeWhile(Function.tupled(_.value == _.value))
       .map(_._1)
 
+  /** Render a nibble sequence as a Hex string, one hex character per nibble. */
+  def toHex(nibbles: Seq[Nibble]): Hex =
+    Hex(nibbles.map(n => hexChars(n.value & 0x0f)).mkString(""))
+
   implicit val nibbleEncoder: Encoder[Nibble] = (a: Nibble) => Json.fromString("" + hexChars(a.value & 0x0f))
 
   implicit val nibbleDecoder: Decoder[Nibble] = (c: HCursor) =>

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaBatchInclusionProver.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaBatchInclusionProver.scala
@@ -1,0 +1,102 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt.api
+
+import cats.MonadThrow
+import cats.syntax.all._
+
+import scala.annotation.tailrec
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt._
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hex.Hex
+
+trait MerklePatriciaBatchInclusionProver[F[_]] {
+
+  /**
+   * Generate a single proof attesting that all of the given paths are present in the trie.
+   *
+   * @param paths The paths to prove inclusion for
+   * @return A batch proof with a de-duplicated shared witness, or an error
+   */
+  def attestPaths(paths: List[Hex]): F[Either[MerklePatriciaProofError, MerklePatriciaBatchInclusionProof]]
+}
+
+object MerklePatriciaBatchInclusionProver {
+
+  def apply[F[_]](implicit prover: MerklePatriciaBatchInclusionProver[F]): MerklePatriciaBatchInclusionProver[F] = prover
+
+  /**
+   * Create a batch prover from a Merkle Patricia Trie.
+   *
+   * Each path is attested independently via the single-path prover; the resulting per-path
+   * witnesses are concatenated and de-duplicated into one shared witness. Paths are sorted so the
+   * proof is deterministic regardless of the caller's input order.
+   */
+  def make[F[_]: MonadThrow: JsonBinaryHasher](
+    trie: MerklePatriciaTrie
+  ): MerklePatriciaBatchInclusionProver[F] =
+    new MerklePatriciaBatchInclusionProver[F] {
+
+      def attestPaths(paths: List[Hex]): F[Either[MerklePatriciaProofError, MerklePatriciaBatchInclusionProof]] = {
+
+        val singleProver = MerklePatriciaProver.make[F](trie)
+
+        def commitmentKey(commitment: MerklePatriciaCommitment): String = commitment match {
+          case MerklePatriciaCommitment.Leaf(remaining, dataDigest) =>
+            s"leaf:${remaining.mkString}:${dataDigest.value}"
+          case MerklePatriciaCommitment.Branch(pathsDigest) =>
+            s"branch:${pathsDigest.toSeq.sortBy(_._1.value).map { case (k, v) => s"${k.value}:${v.value}" }.mkString(",")}"
+          case MerklePatriciaCommitment.Extension(shared, childDigest) =>
+            s"extension:${shared.mkString}:${childDigest.value}"
+        }
+
+        def deduplicate(commitments: List[MerklePatriciaCommitment]): List[MerklePatriciaCommitment] = {
+          @tailrec
+          def loop(
+            remaining: List[MerklePatriciaCommitment],
+            seen: Set[String],
+            acc: List[MerklePatriciaCommitment]
+          ): List[MerklePatriciaCommitment] = remaining match {
+            case Nil => acc.reverse
+            case head :: tail =>
+              val key = commitmentKey(head)
+              if (seen.contains(key)) loop(tail, seen, acc)
+              else loop(tail, seen + key, head :: acc)
+          }
+
+          loop(commitments, Set.empty, List.empty)
+        }
+
+        if (paths.isEmpty)
+          (ProofGenerationError("Cannot create batch proof for empty path list"): MerklePatriciaProofError)
+            .asLeft[MerklePatriciaBatchInclusionProof]
+            .pure[F]
+        else {
+          val sortedPaths = paths.sorted(Ordering.by[Hex, String](_.value))
+
+          sortedPaths
+            .traverse(singleProver.attestPath)
+            .map { results =>
+              results.sequence.map { proofs =>
+                val deduplicated = deduplicate(proofs.flatMap(_.witness))
+                MerklePatriciaBatchInclusionProof(sortedPaths, deduplicated)
+              }
+            }
+            .handleError(e => ProofGenerationError(e.getMessage).asLeft[MerklePatriciaBatchInclusionProof])
+        }
+      }
+    }
+
+  /**
+   * Provides syntax extensions for more ergonomic batch proof generation
+   */
+  object syntax {
+
+    implicit class MerklePatriciaPathListOps(private val paths: List[Hex]) extends AnyVal {
+
+      def attestBatchInclusion[F[_]](
+        implicit P: MerklePatriciaBatchInclusionProver[F]
+      ): F[Either[MerklePatriciaProofError, MerklePatriciaBatchInclusionProof]] =
+        P.attestPaths(paths)
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaBatchInclusionVerifier.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaBatchInclusionVerifier.scala
@@ -1,0 +1,143 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt.api
+
+import cats.MonadThrow
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt._
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.syntax.EncoderOps
+
+trait MerklePatriciaBatchInclusionVerifier[F[_]] {
+
+  /**
+   * Confirm that a batch inclusion proof is valid for every path it attests.
+   *
+   * @param proof The batch proof to verify
+   * @return Success if every path verifies against the root, error otherwise
+   */
+  def confirm(proof: MerklePatriciaBatchInclusionProof): F[Either[MerklePatriciaVerificationError, Unit]]
+}
+
+object MerklePatriciaBatchInclusionVerifier {
+
+  def apply[F[_]](implicit verifier: MerklePatriciaBatchInclusionVerifier[F]): MerklePatriciaBatchInclusionVerifier[F] = verifier
+
+  def make[F[_]: MonadThrow: JsonBinaryHasher](root: Hash): MerklePatriciaBatchInclusionVerifier[F] =
+    new MerklePatriciaBatchInclusionVerifier[F] {
+
+      private val singleVerifier = MerklePatriciaVerifier.make[F](root)
+
+      def confirm(proof: MerklePatriciaBatchInclusionProof): F[Either[MerklePatriciaVerificationError, Unit]] = {
+
+        // Reconstruct the per-path witness from the shared, de-duplicated witness by walking from
+        // the root: at each step, find the commitment whose prefixed digest matches the expected
+        // child digest and whose path is consistent with the remaining nibbles. The reconstructed
+        // (leaf-first) witness is then handed to the standard single-path verifier.
+        def reconstructProof(
+          path: Hex,
+          sharedWitness: List[MerklePatriciaCommitment]
+        ): F[Either[MerklePatriciaVerificationError, Unit]] = {
+          type Continue = (Seq[Nibble], Hash, List[MerklePatriciaCommitment])
+          type Return = Either[MerklePatriciaVerificationError, List[MerklePatriciaCommitment]]
+
+          val pathNibbles = Nibble(path)
+
+          def checkCommitment(
+            commitment: MerklePatriciaCommitment,
+            expectedDigest: Hash,
+            remainingPath: Seq[Nibble]
+          ): F[Option[(MerklePatriciaCommitment, Hash, Seq[Nibble])]] =
+            commitment match {
+              case leaf: MerklePatriciaCommitment.Leaf =>
+                JsonBinaryHasher[F]
+                  .computeDigest(leaf.asJson, MerklePatriciaNode.LeafPrefix)
+                  .map { digest =>
+                    if (digest == expectedDigest && remainingPath == leaf.remaining)
+                      Some((leaf, expectedDigest, Seq.empty[Nibble]))
+                    else None
+                  }
+
+              case ext: MerklePatriciaCommitment.Extension =>
+                JsonBinaryHasher[F]
+                  .computeDigest(ext.asJson, MerklePatriciaNode.ExtensionPrefix)
+                  .map { digest =>
+                    if (digest == expectedDigest && remainingPath.startsWith(ext.shared))
+                      Some((ext, ext.childDigest, remainingPath.drop(ext.shared.length)))
+                    else None
+                  }
+
+              case branch: MerklePatriciaCommitment.Branch =>
+                JsonBinaryHasher[F]
+                  .computeDigest(branch.asJson, MerklePatriciaNode.BranchPrefix)
+                  .map { digest =>
+                    if (digest == expectedDigest && remainingPath.nonEmpty && branch.pathsDigest.contains(remainingPath.head))
+                      Some((branch, branch.pathsDigest(remainingPath.head), remainingPath.tail))
+                    else None
+                  }
+            }
+
+          def findMatchingCommitment(
+            expectedDigest: Hash,
+            remainingPath: Seq[Nibble]
+          ): F[Option[(MerklePatriciaCommitment, Hash, Seq[Nibble])]] =
+            sharedWitness
+              .traverse(checkCommitment(_, expectedDigest, remainingPath))
+              .map(_.collectFirst { case Some(result) => result })
+
+          MonadThrow[F]
+            .tailRecM[Continue, Return]((pathNibbles, root, List.empty[MerklePatriciaCommitment])) {
+              case (remainingPath, expectedDigest, acc) =>
+                if (remainingPath.isEmpty)
+                  acc.asRight[MerklePatriciaVerificationError].asRight[Continue].pure[F]
+                else
+                  findMatchingCommitment(expectedDigest, remainingPath).map {
+                    case Some((commitment: MerklePatriciaCommitment.Leaf, _, _)) =>
+                      (commitment :: acc).asRight[MerklePatriciaVerificationError].asRight[Continue]
+
+                    case Some((commitment, nextDigest, nextPath)) =>
+                      (nextPath, nextDigest, commitment :: acc).asLeft[Return]
+
+                    case None =>
+                      (InvalidWitness(
+                        s"No matching commitment for digest ${expectedDigest.value} at path ${path.value} " +
+                        s"(position ${pathNibbles.length - remainingPath.length}/${pathNibbles.length})"
+                      ): MerklePatriciaVerificationError)
+                        .asLeft[List[MerklePatriciaCommitment]]
+                        .asRight[Continue]
+                  }
+            }
+            .flatMap {
+              case Right(relevantCommitments) =>
+                singleVerifier.confirm(MerklePatriciaInclusionProof(path, relevantCommitments))
+              case Left(error) =>
+                error.asLeft[Unit].pure[F]
+            }
+        }
+
+        if (proof.paths.isEmpty)
+          (InvalidWitness("Batch proof cannot have empty paths list"): MerklePatriciaVerificationError)
+            .asLeft[Unit]
+            .pure[F]
+        else
+          proof.paths
+            .traverse(path => reconstructProof(path, proof.witness))
+            .map(_.sequence.map(_ => ()))
+            .handleError(e => InvalidWitness(s"Batch verification failed: ${e.getMessage}").asLeft[Unit])
+      }
+    }
+
+  /**
+   * Provides syntax extensions for more ergonomic batch verification
+   */
+  object syntax {
+
+    implicit class MerklePatriciaBatchInclusionProofOps(private val proof: MerklePatriciaBatchInclusionProof) extends AnyVal {
+
+      def confirm[F[_]](implicit V: MerklePatriciaBatchInclusionVerifier[F]): F[Either[MerklePatriciaVerificationError, Unit]] =
+        V.confirm(proof)
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaPrefixProver.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/api/MerklePatriciaPrefixProver.scala
@@ -1,0 +1,136 @@
+package io.constellationnetwork.metagraph_sdk.crypto.mpt.api
+
+import cats.MonadThrow
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt._
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hex.Hex
+
+trait MerklePatriciaPrefixProver[F[_]] {
+
+  /**
+   * Generate a batch proof attesting every key in the trie whose path starts with the given
+   * prefix.
+   *
+   * @param prefix The path prefix to enumerate and prove
+   * @return A batch proof covering all matching paths, or an error if none match
+   */
+  def attestPrefix(prefix: Hex): F[Either[MerklePatriciaProofError, MerklePatriciaBatchInclusionProof]]
+}
+
+object MerklePatriciaPrefixProver {
+
+  def apply[F[_]](implicit prover: MerklePatriciaPrefixProver[F]): MerklePatriciaPrefixProver[F] = prover
+
+  /**
+   * Create a prefix prover from a Merkle Patricia Trie.
+   *
+   * Walks the trie collecting every leaf whose full path starts with `prefix`, then builds a batch
+   * inclusion proof over those paths.
+   */
+  def make[F[_]: MonadThrow: JsonBinaryHasher](
+    trie: MerklePatriciaTrie
+  ): MerklePatriciaPrefixProver[F] =
+    new MerklePatriciaPrefixProver[F] {
+
+      def attestPrefix(prefix: Hex): F[Either[MerklePatriciaProofError, MerklePatriciaBatchInclusionProof]] = {
+
+        final case class CollectedLeaf(path: Hex, leaf: MerklePatriciaNode.Leaf)
+
+        // Collect every leaf reachable below `node` (whose path so far is `currentPath`).
+        def collectAllLeavesUnder(
+          node: MerklePatriciaNode,
+          currentPath: Seq[Nibble],
+          acc: List[CollectedLeaf]
+        ): F[List[CollectedLeaf]] =
+          node match {
+            case leaf: MerklePatriciaNode.Leaf =>
+              val fullPath = currentPath ++ leaf.remaining
+              (CollectedLeaf(Nibble.toHex(fullPath), leaf) :: acc).pure[F]
+
+            case extension: MerklePatriciaNode.Extension =>
+              collectAllLeavesUnder(extension.child, currentPath ++ extension.shared, acc)
+
+            case branch: MerklePatriciaNode.Branch =>
+              branch.paths.toList.foldLeftM(acc) {
+                case (currentAcc, (nibble, child)) =>
+                  collectAllLeavesUnder(child, currentPath :+ nibble, currentAcc)
+              }
+          }
+
+        // Collect leaves whose full path starts with `targetPrefix`, descending only the relevant
+        // sub-trie.
+        def collectLeavesUnderPrefix(
+          node: MerklePatriciaNode,
+          currentPath: Seq[Nibble],
+          targetPrefix: Seq[Nibble],
+          acc: List[CollectedLeaf]
+        ): F[List[CollectedLeaf]] =
+          node match {
+            case leaf: MerklePatriciaNode.Leaf =>
+              val fullPath = currentPath ++ leaf.remaining
+              if (fullPath.startsWith(targetPrefix)) (CollectedLeaf(Nibble.toHex(fullPath), leaf) :: acc).pure[F]
+              else acc.pure[F]
+
+            case extension: MerklePatriciaNode.Extension =>
+              val extendedPath = currentPath ++ extension.shared
+              if (targetPrefix.startsWith(extendedPath))
+                // The prefix runs through this extension; keep matching the remainder below it.
+                collectLeavesUnderPrefix(extension.child, extendedPath, targetPrefix, acc)
+              else if (extendedPath.startsWith(targetPrefix))
+                // The extension already extends past the prefix; everything below it matches.
+                collectAllLeavesUnder(extension.child, extendedPath, acc)
+              else acc.pure[F]
+
+            case branch: MerklePatriciaNode.Branch =>
+              if (targetPrefix.startsWith(currentPath)) {
+                val prefixRemaining = targetPrefix.drop(currentPath.length)
+                if (prefixRemaining.isEmpty)
+                  // Prefix ends exactly at this branch; everything below matches.
+                  branch.paths.toList.foldLeftM(acc) {
+                    case (currentAcc, (nibble, child)) =>
+                      collectAllLeavesUnder(child, currentPath :+ nibble, currentAcc)
+                  }
+                else
+                  branch.paths.get(prefixRemaining.head) match {
+                    case Some(child) =>
+                      collectLeavesUnderPrefix(child, currentPath :+ prefixRemaining.head, targetPrefix, acc)
+                    case None => acc.pure[F]
+                  }
+              } else if (currentPath.startsWith(targetPrefix))
+                branch.paths.toList.foldLeftM(acc) {
+                  case (currentAcc, (nibble, child)) =>
+                    collectAllLeavesUnder(child, currentPath :+ nibble, currentAcc)
+                }
+              else acc.pure[F]
+          }
+
+        val prefixNibbles = Nibble(prefix)
+
+        collectLeavesUnderPrefix(trie.rootNode, Seq.empty, prefixNibbles, List.empty).flatMap { leaves =>
+          if (leaves.isEmpty)
+            (PathNotFound(s"No paths found with prefix: ${prefix.value}"): MerklePatriciaProofError)
+              .asLeft[MerklePatriciaBatchInclusionProof]
+              .pure[F]
+          else
+            MerklePatriciaBatchInclusionProver.make[F](trie).attestPaths(leaves.reverse.map(_.path))
+        }
+          .handleError(e => ProofGenerationError(e.getMessage).asLeft[MerklePatriciaBatchInclusionProof])
+      }
+    }
+
+  /**
+   * Provides syntax extensions for more ergonomic prefix proof generation
+   */
+  object syntax {
+
+    implicit class MerklePatriciaPrefixOps(private val prefix: Hex) extends AnyVal {
+
+      def attestPrefixInclusion[F[_]](
+        implicit P: MerklePatriciaPrefixProver[F]
+      ): F[Either[MerklePatriciaProofError, MerklePatriciaBatchInclusionProof]] =
+        P.attestPrefix(prefix)
+    }
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/impl/StatelessMerklePatriciaProducer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/mpt/impl/StatelessMerklePatriciaProducer.scala
@@ -168,11 +168,18 @@ class StatelessMerklePatriciaProducer[F[_]: JsonBinaryHasher: MonadThrow] extend
         ): InsertState).asLeft[Either[MerklePatriciaError, MerklePatriciaNode]].pure[F]
       } else {
         (for {
-          newExtension <- MerklePatriciaNode.Extension[F](sharedRemaining.tail, extensionNode.child)
-          newLeaf      <- MerklePatriciaNode.Leaf[F](keyRemaining.tail, data)
+          // When the existing extension diverges at its very last shared nibble, the remaining
+          // shared path is empty. A zero-length Extension is degenerate (it duplicates its child
+          // structurally while changing the digest), which makes the resulting trie depend on
+          // insertion order. In that case the surviving subtree is simply the extension's child
+          // Branch, with no extension wrapper.
+          existingSubtree <-
+            if (sharedRemaining.tail.isEmpty) (extensionNode.child: MerklePatriciaNode).pure[F]
+            else MerklePatriciaNode.Extension[F](sharedRemaining.tail, extensionNode.child).widen[MerklePatriciaNode]
+          newLeaf <- MerklePatriciaNode.Leaf[F](keyRemaining.tail, data)
           branchNode <- MerklePatriciaNode.Branch[F](
             Map(
-              sharedRemaining.head -> newExtension,
+              sharedRemaining.head -> existingSubtree,
               keyRemaining.head    -> newLeaf
             )
           )

--- a/src/test/scala/crypto/mpt/MerklePatriciaBatchInclusionSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaBatchInclusionSuite.scala
@@ -1,0 +1,163 @@
+package crypto.mpt
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{
+  MerklePatriciaBatchInclusionProver,
+  MerklePatriciaBatchInclusionVerifier,
+  MerklePatriciaProver,
+  MerklePatriciaVerifier
+}
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaBatchInclusionProof, MerklePatriciaTrie}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.syntax.EncoderOps
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+/**
+ * Round-trip and negative tests for the batch inclusion prover/verifier (ported from
+ * tessellation). A batch proof carries one de-duplicated witness shared across all attested paths.
+ */
+object MerklePatriciaBatchInclusionSuite extends SimpleIOSuite with Checkers {
+
+  private val bogusHash: Hash =
+    Hash("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+
+  private def fixture(n: Int): IO[(MerklePatriciaTrie, List[Hex])] =
+    (1 to n).toList
+      .traverse(i => s"entry_$i".computeDigest.map(h => Hex(h.value) -> s"value_$i"))
+      .flatMap(pairs => MerklePatriciaTrie.make[IO, String](pairs.toMap).map(t => (t, pairs.map(_._1))))
+
+  test("batch proof round-trips for all attested paths") {
+    for {
+      (trie, keys) <- fixture(32)
+      prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      subset = keys.take(10)
+      proof  <- prover.attestPaths(subset).flatMap(IO.fromEither(_))
+      result <- verifier.confirm(proof)
+    } yield
+      expect.all(
+        proof.paths.toSet == subset.toSet,
+        proof.witness.nonEmpty,
+        result.isRight
+      )
+  }
+
+  test("batch proof paths are sorted and the witness is de-duplicated") {
+    for {
+      (trie, keys) <- fixture(32)
+      prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      subset = keys.take(12)
+      proof <- prover.attestPaths(subset).flatMap(IO.fromEither(_))
+      // Concatenating the individual witnesses must contain at least as many commitments as the
+      // de-duplicated batch witness; shared upper-trie nodes collapse to a single entry.
+      singleProver = MerklePatriciaProver.make[IO](trie)
+      perPathTotals <- subset.traverse(k => singleProver.attestPath(k).flatMap(IO.fromEither(_)).map(_.witness.size))
+      concatenated = perPathTotals.sum
+    } yield
+      expect.all(
+        proof.paths == subset.sorted(Ordering.by[Hex, String](_.value)),
+        proof.witness.size <= concatenated,
+        proof.witness.distinct.size == proof.witness.size
+      )
+  }
+
+  test("batch proof of a single path agrees with the single-path verifier") {
+    for {
+      (trie, keys) <- fixture(16)
+      batchProver = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      batchVerifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      singleVerifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      key = keys.head
+      batchProof   <- batchProver.attestPaths(List(key)).flatMap(IO.fromEither(_))
+      batchResult  <- batchVerifier.confirm(batchProof)
+      singleProof  <- MerklePatriciaProver.make[IO](trie).attestPath(key).flatMap(IO.fromEither(_))
+      singleResult <- singleVerifier.confirm(singleProof)
+    } yield expect(batchResult.isRight && singleResult.isRight)
+  }
+
+  test("batch proof JSON round-trips") {
+    for {
+      (trie, keys) <- fixture(16)
+      prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      proof   <- prover.attestPaths(keys.take(5)).flatMap(IO.fromEither(_))
+      decoded <- IO.fromEither(proof.asJson.as[MerklePatriciaBatchInclusionProof])
+    } yield expect(decoded == proof)
+  }
+
+  test("attesting an empty path list returns Left") {
+    for {
+      (trie, _) <- fixture(8)
+      prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      result <- prover.attestPaths(List.empty)
+    } yield expect(result.isLeft)
+  }
+
+  test("attesting a path absent from the trie returns Left") {
+    for {
+      (trie, keys) <- fixture(8)
+      prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      absent = Hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+      result <- prover.attestPaths(keys.take(2) :+ absent)
+    } yield expect(result.isLeft)
+  }
+
+  test("verifying a batch proof against the wrong root returns Left") {
+    for {
+      (trie, keys) <- fixture(16)
+      prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      wrongVerifier = MerklePatriciaBatchInclusionVerifier.make[IO](bogusHash)
+      proof  <- prover.attestPaths(keys.take(4)).flatMap(IO.fromEither(_))
+      result <- wrongVerifier.confirm(proof)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: dropping a commitment from the shared witness fails verification") {
+    for {
+      (trie, keys) <- fixture(24)
+      prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      proof <- prover.attestPaths(keys.take(8)).flatMap(IO.fromEither(_))
+      _ = assert(proof.witness.size >= 2)
+      tampered = proof.copy(witness = proof.witness.drop(1))
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: verifying a path not covered by the witness fails") {
+    for {
+      (trie, keys) <- fixture(24)
+      prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+      verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      proof <- prover.attestPaths(keys.take(4)).flatMap(IO.fromEither(_))
+      // Inject a path whose witness was never included.
+      tampered = proof.copy(paths = proof.paths :+ keys.last)
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+
+  test("batch proof round-trips over random subsets (property)") {
+    val gen = for {
+      size      <- Gen.choose(2, 40)
+      subsetLen <- Gen.choose(1, size)
+    } yield (size, subsetLen)
+
+    forall(gen) {
+      case (size, subsetLen) =>
+        for {
+          (trie, keys) <- fixture(size)
+          prover = MerklePatriciaBatchInclusionProver.make[IO](trie)
+          verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+          subset = scala.util.Random.shuffle(keys).take(subsetLen)
+          proof  <- prover.attestPaths(subset).flatMap(IO.fromEither(_))
+          result <- verifier.confirm(proof)
+        } yield expect(result.isRight && proof.paths.toSet == subset.toSet)
+    }
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaDeterminismSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaDeterminismSuite.scala
@@ -1,0 +1,182 @@
+package crypto.mpt
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaTrie
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.MerklePatriciaProducer
+import io.constellationnetwork.security.hex.Hex
+
+import org.scalacheck.Gen
+import weaver.SimpleIOSuite
+import weaver.scalacheck.Checkers
+
+/**
+ * Determinism-focused tests for the Merkle Patricia Trie producer.
+ *
+ *   - Item 1.3: inserting a key that splits an Extension at its FULL shared length must not
+ *     introduce a degenerate zero-length Extension node. Incremental and fresh builds of the
+ *     same key-set must agree.
+ *   - Item 1.2: the resulting root digest must not depend on insertion order. Several shuffles
+ *     of the same key-set, and incremental vs full rebuild, must produce identical roots.
+ */
+object MerklePatriciaDeterminismSuite extends SimpleIOSuite with Checkers {
+
+  /** Build a trie from a list of (key, value) entries by folding `insert` in the given order. */
+  private def buildIncrementally(entries: List[(Hex, String)]): IO[MerklePatriciaTrie] =
+    entries match {
+      case Nil => IO.raiseError(new RuntimeException("empty entries"))
+      case (headKey, headVal) :: tail =>
+        for {
+          initial <- MerklePatriciaTrie.make[IO, String](Map(headKey -> headVal))
+          result <- tail.foldLeftM(initial) { (trie, kv) =>
+            MerklePatriciaProducer
+              .stateless[IO]
+              .insert(trie, Map(kv._1 -> kv._2))
+              .flatMap(IO.fromEither(_))
+          }
+        } yield result
+    }
+
+  // ---------------------------------------------------------------------------
+  // Item 1.3 - zero-length Extension when splitting an extension at full length
+  // ---------------------------------------------------------------------------
+
+  test("inserting a key that splits an Extension at its full shared length is deterministic") {
+    // "abcd" and "abce" share prefix "abc" -> Extension(shared = "abc", Branch{d, e}).
+    // Inserting "abf0" shares only "ab" with that extension; sharedRemaining = "c" (length 1),
+    // so sharedRemaining.tail is empty. The unguarded producer wraps the surviving child Branch
+    // in a degenerate Extension("", child), changing the digest.
+    //
+    // The "split" order below inserts the two extension-forming keys FIRST, then the splitter,
+    // which forces the full-length split. The "no-split" order inserts the splitter first, so the
+    // extension is never created. Both orders must yield the same root.
+    val k1 = Hex("abcd")
+    val k2 = Hex("abce")
+    val k3 = Hex("abf0")
+
+    val splitOrder = List(k1 -> "v1", k2 -> "v2", k3 -> "v3")
+    val noSplitOrder = List(k3 -> "v3", k1 -> "v1", k2 -> "v2")
+
+    for {
+      split   <- buildIncrementally(splitOrder)
+      noSplit <- buildIncrementally(noSplitOrder)
+      fresh   <- MerklePatriciaTrie.make[IO, String](splitOrder.toMap)
+    } yield
+      expect.all(
+        split.rootNode.digest == noSplit.rootNode.digest,
+        split.rootNode.digest == fresh.rootNode.digest
+      )
+  }
+
+  test("splitting an Extension at full length keeps all leaves and a consistent root") {
+    // Same split scenario, then verify every key is still present after the incremental build
+    // and that the incremental build matches the fresh build exactly (structure + digest).
+    val entries = List(
+      Hex("abcd1") -> "v1",
+      Hex("abce2") -> "v2",
+      Hex("abf03") -> "v3",
+      Hex("abf14") -> "v4"
+    )
+
+    for {
+      incremental <- buildIncrementally(entries)
+      fresh       <- MerklePatriciaTrie.make[IO, String](entries.toMap)
+      leaves = MerklePatriciaTrie.collectLeafNodes(incremental)
+      values <- IO.fromEither(leaves.traverse(_.data.as[String]))
+    } yield
+      expect.all(
+        incremental == fresh,
+        values.toSet == entries.map(_._2).toSet
+      )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Item 1.2 - insertion-order independence of the root digest
+  // ---------------------------------------------------------------------------
+
+  test("root digest is independent of insertion order (example, variable-length keys)") {
+    // Variable-length, mutually-prefixing-but-not-equal keys that exercise extension splits at
+    // their full shared length. None of these keys is a strict prefix of another, so all are
+    // representable as leaves. Before the zero-length-Extension fix this set produced different
+    // roots depending on insertion order.
+    val entries = List(
+      Hex("abcd")   -> "v1",
+      Hex("abce")   -> "v2",
+      Hex("abf0")   -> "v3",
+      Hex("a1cc")   -> "v4",
+      Hex("abda99") -> "v5",
+      Hex("00aa")   -> "v6"
+    )
+
+    val permutations = List(
+      entries,
+      entries.reverse,
+      entries.sortBy(_._1.value),
+      entries.sortBy(-_._1.value.length)
+    )
+
+    for {
+      roots <- permutations.traverse(p => buildIncrementally(p).map(_.rootNode.digest))
+    } yield expect(roots.distinct.size == 1)
+  }
+
+  test("root digest is independent of insertion order (property over shuffles)") {
+    // Generate a set of distinct fixed-length hex keys (fixed length => no key is a strict prefix
+    // of another, so every key is representable as a leaf), then build the trie from several
+    // random shuffles. All roots must be identical, and must equal the full `create` rebuild.
+    val hexChar: Gen[Char] = Gen.oneOf("0123456789abcdef".toList)
+    val keyGen: Gen[String] = Gen.listOfN(4, hexChar).map(_.mkString)
+
+    val keysGen: Gen[List[String]] =
+      Gen.choose(3, 12).flatMap(n => Gen.listOfN(n, keyGen)).map(_.distinct)
+
+    forall(keysGen) { keys =>
+      val entries = keys.zipWithIndex.map { case (k, i) => Hex(k) -> s"value_$i" }
+
+      val shuffles = List(
+        entries,
+        entries.reverse,
+        scala.util.Random.shuffle(entries),
+        scala.util.Random.shuffle(entries)
+      )
+
+      for {
+        fresh    <- MerklePatriciaTrie.make[IO, String](entries.toMap)
+        incRoots <- shuffles.traverse(s => buildIncrementally(s).map(_.rootNode.digest))
+        allRoots = fresh.rootNode.digest :: incRoots
+      } yield expect(allRoots.distinct.size == 1)
+    }
+  }
+
+  test("removing keys in different orders yields the same root") {
+    // Build a 6-key trie, then remove the same 3 keys in two different orders. The resulting root
+    // must be identical and equal to building the surviving 3-key set from scratch.
+    val all = List(
+      Hex("abcd")   -> "v1",
+      Hex("abce")   -> "v2",
+      Hex("abf0")   -> "v3",
+      Hex("a1cc")   -> "v4",
+      Hex("abda99") -> "v5",
+      Hex("00aa")   -> "v6"
+    )
+    val toRemove = List(Hex("abce"), Hex("abf0"), Hex("abda99"))
+    val survivors = all.filterNot { case (k, _) => toRemove.contains(k) }
+
+    def removeInOrder(order: List[Hex]): IO[MerklePatriciaTrie] =
+      MerklePatriciaTrie
+        .make[IO, String](all.toMap)
+        .flatMap(trie => MerklePatriciaProducer.stateless[IO].remove(trie, order))
+        .flatMap(IO.fromEither(_))
+
+    for {
+      r1    <- removeInOrder(toRemove)
+      r2    <- removeInOrder(toRemove.reverse)
+      fresh <- MerklePatriciaTrie.make[IO, String](survivors.toMap)
+    } yield
+      expect.all(
+        r1.rootNode.digest == r2.rootNode.digest,
+        r1.rootNode.digest == fresh.rootNode.digest
+      )
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaPrefixProverSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaPrefixProverSuite.scala
@@ -1,0 +1,112 @@
+package crypto.mpt
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaTrie
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{MerklePatriciaBatchInclusionVerifier, MerklePatriciaPrefixProver}
+import io.constellationnetwork.security.hex.Hex
+
+import weaver.SimpleIOSuite
+
+/**
+ * Tests for the prefix prover (ported from tessellation). A prefix proof is a batch proof over
+ * every key whose path starts with the requested prefix.
+ */
+object MerklePatriciaPrefixProverSuite extends SimpleIOSuite {
+
+  // Variable-length, prefix-free keys grouped under distinguishable prefixes.
+  private val entries: Map[Hex, String] = Map(
+    Hex("ab12") -> "v1",
+    Hex("ab34") -> "v2",
+    Hex("ab56") -> "v3",
+    Hex("ac78") -> "v4",
+    Hex("cd90") -> "v5",
+    Hex("cdef") -> "v6",
+    Hex("ff00") -> "v7"
+  )
+
+  private def trieIO: IO[MerklePatriciaTrie] = MerklePatriciaTrie.make[IO, String](entries)
+
+  test("prefix proof collects every key under the prefix and verifies") {
+    for {
+      trie <- trieIO
+      prover = MerklePatriciaPrefixProver.make[IO](trie)
+      verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      proof  <- prover.attestPrefix(Hex("ab")).flatMap(IO.fromEither(_))
+      result <- verifier.confirm(proof)
+    } yield
+      expect.all(
+        proof.paths.toSet == Set(Hex("ab12"), Hex("ab34"), Hex("ab56")),
+        result.isRight
+      )
+  }
+
+  test("prefix proof for a deeper prefix narrows the matching set") {
+    for {
+      trie <- trieIO
+      prover = MerklePatriciaPrefixProver.make[IO](trie)
+      verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      proof  <- prover.attestPrefix(Hex("cde")).flatMap(IO.fromEither(_))
+      result <- verifier.confirm(proof)
+    } yield
+      expect.all(
+        proof.paths.toSet == Set(Hex("cdef")),
+        result.isRight
+      )
+  }
+
+  test("empty prefix collects every key in the trie") {
+    for {
+      trie <- trieIO
+      prover = MerklePatriciaPrefixProver.make[IO](trie)
+      verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      proof  <- prover.attestPrefix(Hex("")).flatMap(IO.fromEither(_))
+      result <- verifier.confirm(proof)
+    } yield
+      expect.all(
+        proof.paths.toSet == entries.keySet,
+        result.isRight
+      )
+  }
+
+  test("prefix matching a single full key verifies") {
+    for {
+      trie <- trieIO
+      prover = MerklePatriciaPrefixProver.make[IO](trie)
+      verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      proof  <- prover.attestPrefix(Hex("ff00")).flatMap(IO.fromEither(_))
+      result <- verifier.confirm(proof)
+    } yield expect(proof.paths.toSet == Set(Hex("ff00")) && result.isRight)
+  }
+
+  test("prefix with no matches returns Left") {
+    for {
+      trie <- trieIO
+      prover = MerklePatriciaPrefixProver.make[IO](trie)
+      result <- prover.attestPrefix(Hex("99"))
+    } yield expect(result.isLeft)
+  }
+
+  test("prefix proof over hashed-key entries verifies for a sampled prefix") {
+    for {
+      pairs <- (1 to 64).toList.traverse { i =>
+        import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+        s"item_$i".computeDigest.map(h => Hex(h.value) -> s"value_$i")
+      }
+      trie <- MerklePatriciaTrie.make[IO, String](pairs.toMap)
+      prover = MerklePatriciaPrefixProver.make[IO](trie)
+      verifier = MerklePatriciaBatchInclusionVerifier.make[IO](trie.rootNode.digest)
+      // Use the first nibble of an existing key as a prefix; at least that key must match.
+      somePrefix = Hex(pairs.head._1.value.take(1))
+      expectedMatches = pairs.map(_._1).filter(_.value.startsWith(somePrefix.value)).toSet
+      proof  <- prover.attestPrefix(somePrefix).flatMap(IO.fromEither(_))
+      result <- verifier.confirm(proof)
+    } yield
+      expect.all(
+        proof.paths.toSet == expectedMatches,
+        proof.paths.nonEmpty,
+        result.isRight
+      )
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaShortKeySuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaShortKeySuite.scala
@@ -1,0 +1,148 @@
+package crypto.mpt
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{MerklePatriciaProver, MerklePatriciaVerifier, OperationError}
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaTrie, Nibble}
+import io.constellationnetwork.security.hex.Hex
+
+import weaver.SimpleIOSuite
+
+/**
+ * Coverage for SHORT, VARIABLE-LENGTH and MUTUALLY-PREFIXING keys.
+ *
+ * The other MPT suites only exercise fixed 64-nibble hash digests, so the extension-split,
+ * variable-length-leaf and prefix-collision paths are otherwise untested.
+ */
+object MerklePatriciaShortKeySuite extends SimpleIOSuite {
+
+  private def buildIncrementally(entries: List[(Hex, String)]): IO[MerklePatriciaTrie] =
+    entries match {
+      case Nil => IO.raiseError(new RuntimeException("empty entries"))
+      case (headKey, headVal) :: tail =>
+        for {
+          initial <- MerklePatriciaTrie.make[IO, String](Map(headKey -> headVal))
+          result <- tail.foldLeftM(initial) { (trie, kv) =>
+            io.constellationnetwork.metagraph_sdk.crypto.mpt.api.MerklePatriciaProducer
+              .stateless[IO]
+              .insert(trie, Map(kv._1 -> kv._2))
+              .flatMap(IO.fromEither(_))
+          }
+        } yield result
+    }
+
+  test("two single-nibble keys form a branch of two leaves") {
+    val entries = Map(Hex("a") -> "va", Hex("b") -> "vb")
+    for {
+      trie   <- MerklePatriciaTrie.make[IO, String](entries)
+      values <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie).traverse(_.data.as[String]))
+    } yield expect(values.toSet == Set("va", "vb"))
+  }
+
+  test("variable-length keys sharing a prefix are all retrievable") {
+    // A prefix-free but mutually-prefixing, variable-length set ("ab.." family + an outlier).
+    // None of these keys is a strict prefix of another, so all are representable as leaves.
+    val entries = Map(
+      Hex("abcd")   -> "v1",
+      Hex("abce")   -> "v2",
+      Hex("ab12")   -> "v3",
+      Hex("abda99") -> "v4"
+    )
+    for {
+      trie   <- MerklePatriciaTrie.make[IO, String](entries)
+      values <- IO.fromEither(MerklePatriciaTrie.collectLeafNodes(trie).traverse(_.data.as[String]))
+    } yield expect(values.toSet == entries.values.toSet)
+  }
+
+  test("prover and verifier round-trip on short variable-length keys") {
+    val entries = Map(
+      Hex("0a")   -> "alpha",
+      Hex("0b")   -> "beta",
+      Hex("1234") -> "gamma",
+      Hex("12ff") -> "delta"
+    )
+    for {
+      trie     <- MerklePatriciaTrie.make[IO, String](entries)
+      prover   <- MerklePatriciaProver.make[IO](trie).pure[IO]
+      verifier <- MerklePatriciaVerifier.make[IO](trie.rootNode.digest).pure[IO]
+      results <- entries.keys.toList.traverse { k =>
+        for {
+          proof  <- prover.attestPath(k).flatMap(IO.fromEither(_))
+          result <- verifier.confirm(proof)
+        } yield result.isRight
+      }
+    } yield expect(results.forall(identity))
+  }
+
+  test("a key that is a strict prefix of an existing key is rejected (no value-at-branch)") {
+    // Inserting "ab" when "abcd" exists exhausts the key at a branch node. The producer must
+    // surface this as an OperationError (Left), not crash.
+    for {
+      trie <- MerklePatriciaTrie.make[IO, String](Map(Hex("abcd") -> "v1", Hex("abce") -> "v2"))
+      result <- io.constellationnetwork.metagraph_sdk.crypto.mpt.api.MerklePatriciaProducer
+        .stateless[IO]
+        .insert(trie, Map(Hex("ab") -> "prefix"))
+    } yield
+      expect(result match {
+        case Left(_: OperationError) => true
+        case _                       => false
+      })
+  }
+
+  test("a key for which an existing key is a strict prefix is rejected") {
+    // The reverse direction: "ab" exists, inserting "abcd" descends past the leaf "ab" and the
+    // extension/leaf logic exhausts at the resulting branch. Must be a Left, not a crash.
+    for {
+      trie <- MerklePatriciaTrie.make[IO, String](Map(Hex("ab") -> "short", Hex("cd") -> "other"))
+      result <- io.constellationnetwork.metagraph_sdk.crypto.mpt.api.MerklePatriciaProducer
+        .stateless[IO]
+        .insert(trie, Map(Hex("abcd") -> "long"))
+    } yield
+      expect(result match {
+        case Left(_: OperationError) => true
+        case _                       => false
+      })
+  }
+
+  test("single-nibble keys: extension split at full length stays consistent across orders") {
+    // "1a","1b" share "1" -> Extension(shared="1", Branch{a,b}); inserting "2c" splits that
+    // extension at its full length (sharedRemaining length 1). Must be order independent.
+    val a = Hex("1a") -> "va"
+    val b = Hex("1b") -> "vb"
+    val c = Hex("2c") -> "vc"
+    for {
+      o1 <- buildIncrementally(List(a, b, c))
+      o2 <- buildIncrementally(List(c, a, b))
+    } yield expect(o1.rootNode.digest == o2.rootNode.digest)
+  }
+
+  test("empty remaining path at a branch yields a clean error rather than a malformed proof") {
+    // Build a branch (two diverging single-nibble keys), then prove a path that lands on the
+    // branch with no remaining nibbles. The prover should report a Left, not throw.
+    for {
+      trie   <- MerklePatriciaTrie.make[IO, String](Map(Hex("ab") -> "v1", Hex("ac") -> "v2"))
+      prover <- MerklePatriciaProver.make[IO](trie).pure[IO]
+      // "a" leads into the branch but has no further nibble for a leaf -> not found.
+      proof <- prover.attestPath(Hex("a"))
+    } yield expect(proof.isLeft)
+  }
+
+  test("nibble path order for short keys matches direct construction") {
+    // Two keys that share a single-nibble prefix produce a config-A branch (no extension because
+    // the split happens immediately after the shared nibble forms an extension of length 1).
+    val entries = Map(Hex("1a") -> "va", Hex("1b") -> "vb")
+    for {
+      trie <- MerklePatriciaTrie.make[IO, String](entries)
+      // Root must be an Extension(shared = [1], Branch{a,b}) per Patricia compression.
+      rootIsExtension = trie.rootNode match {
+        case ext: io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaNode.Extension =>
+          ext.shared == Seq(Nibble.unsafe('1')) && ext.child.paths.keySet == Set(
+            Nibble.unsafe('a'),
+            Nibble.unsafe('b')
+          )
+        case _ => false
+      }
+    } yield expect(rootIsExtension)
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaTamperSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaTamperSuite.scala
@@ -1,0 +1,143 @@
+package crypto.mpt
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{MerklePatriciaProver, MerklePatriciaVerifier}
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaCommitment, MerklePatriciaInclusionProof, MerklePatriciaTrie, Nibble}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher.HasherOps
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import weaver.SimpleIOSuite
+
+/**
+ * Negative (tamper) tests for the prover/verifier pair. A valid proof must verify; any mutation
+ * of the witness - altering a commitment digest, dropping a step, or swapping leaf data - must
+ * cause verification to return Left.
+ */
+object MerklePatriciaTamperSuite extends SimpleIOSuite {
+
+  private val bogusHash: Hash =
+    Hash("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+
+  /** Build a trie over 16 hashed-key entries and return (trie, list of keys). */
+  private def fixture: IO[(MerklePatriciaTrie, List[Hex])] =
+    (1 to 16).toList
+      .traverse(i => s"entry_$i".computeDigest.map(h => Hex(h.value) -> s"value_$i"))
+      .flatMap { pairs =>
+        MerklePatriciaTrie.make[IO, String](pairs.toMap).map(trie => (trie, pairs.map(_._1)))
+      }
+
+  private def proofFor(trie: MerklePatriciaTrie, key: Hex): IO[MerklePatriciaInclusionProof] =
+    MerklePatriciaProver.make[IO](trie).attestPath(key).flatMap(IO.fromEither(_))
+
+  test("an untampered proof verifies") {
+    for {
+      (trie, keys) <- fixture
+      verifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      proof  <- proofFor(trie, keys.head)
+      result <- verifier.confirm(proof)
+    } yield expect(result.isRight)
+  }
+
+  test("tamper: mutating a leaf commitment's dataDigest fails verification") {
+    for {
+      (trie, keys) <- fixture
+      verifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      proof <- proofFor(trie, keys.head)
+      tampered = proof.copy(witness = proof.witness.map {
+        case leaf: MerklePatriciaCommitment.Leaf => leaf.copy(dataDigest = bogusHash)
+        case other                               => other
+      })
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: mutating a leaf commitment's remaining path fails verification") {
+    for {
+      (trie, keys) <- fixture
+      verifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      proof <- proofFor(trie, keys.head)
+      tampered = proof.copy(witness = proof.witness.map {
+        case leaf: MerklePatriciaCommitment.Leaf =>
+          leaf.copy(remaining = leaf.remaining :+ Nibble.unsafe(0x00: Byte))
+        case other => other
+      })
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: mutating a branch commitment's child digest fails verification") {
+    for {
+      (trie, keys) <- fixture
+      verifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      proof <- proofFor(trie, keys.head)
+      tampered = proof.copy(witness = proof.witness.map {
+        case branch: MerklePatriciaCommitment.Branch =>
+          branch.copy(pathsDigest = branch.pathsDigest.map { case (n, _) => n -> bogusHash })
+        case other => other
+      })
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: dropping the first (leaf) witness step fails verification") {
+    // Witness is ordered leaf-first; dropping the head removes the terminal leaf commitment.
+    for {
+      (trie, keys) <- fixture
+      verifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      deepKey   <- keys.traverse(k => proofFor(trie, k).map(p => k -> p.witness.size)).map(_.maxBy(_._2)._1)
+      deepProof <- proofFor(trie, deepKey)
+      _ = assert(deepProof.witness.size >= 2)
+      tampered = deepProof.copy(witness = deepProof.witness.drop(1))
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: dropping an intermediate branch step fails verification") {
+    for {
+      (trie, keys) <- fixture
+      verifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      // pick the key with the deepest proof so there is an intermediate step to drop
+      deepKey <- keys.traverse(k => proofFor(trie, k).map(p => k -> p.witness.size)).map(_.maxBy(_._2)._1)
+      proof   <- proofFor(trie, deepKey)
+      _ = assert(proof.witness.size >= 2)
+      // drop the last witness element (the root-most commitment, an intermediate branch/extension)
+      tampered = proof.copy(witness = proof.witness.dropRight(1))
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: swapping in another path's leaf commitment fails verification") {
+    for {
+      (trie, keys) <- fixture
+      verifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      proofA <- proofFor(trie, keys.head)
+      proofB <- proofFor(trie, keys(1))
+      leafB = proofB.witness.collectFirst { case l: MerklePatriciaCommitment.Leaf => l }.get
+      // Replace proofA's leaf commitment (witness head) with proofB's leaf commitment.
+      tampered = proofA.copy(witness = leafB :: proofA.witness.tail)
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: verifying a valid proof against the wrong root fails") {
+    for {
+      (trie, keys) <- fixture
+      proof        <- proofFor(trie, keys.head)
+      wrongVerifier = MerklePatriciaVerifier.make[IO](bogusHash)
+      result <- wrongVerifier.confirm(proof)
+    } yield expect(result.isLeft)
+  }
+
+  test("tamper: replacing the entire witness with an empty list fails verification") {
+    for {
+      (trie, keys) <- fixture
+      verifier = MerklePatriciaVerifier.make[IO](trie.rootNode.digest)
+      proof <- proofFor(trie, keys.head)
+      tampered = proof.copy(witness = List.empty[MerklePatriciaCommitment])
+      result <- verifier.confirm(tampered)
+    } yield expect(result.isLeft)
+  }
+}

--- a/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/crypto/mpt/MerklePatriciaTrieSuite.scala
@@ -111,7 +111,7 @@ object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
     for {
       leafMap <- (0 to 31).toList.traverse(el => el.computeDigest.map(hash => Hex(hash.value) -> el)).map(_.toMap)
       trie    <- MerklePatriciaTrie.make[IO, Int](leafMap)
-    } yield expect(trie.rootNode.digest == Hash("2c225239414a82ea1b72061de98199f90e910106b9e9896bd6df4cc74e6c39a0"))
+    } yield expect(trie.rootNode.digest == Hash("66658b9b010e472c26323576a2cdea0b04b619509c60161932260ea00cc9d0c8"))
 
   }
 
@@ -121,7 +121,7 @@ object MerklePatriciaTrieSuite extends SimpleIOSuite with Checkers {
       trie      <- MerklePatriciaTrie.make[IO, Int](leafMap)
       newLeaves <- (-31 to -0).toList.traverse(el => el.computeDigest.map(hash => Hex(hash.value) -> el)).map(_.toMap)
       trie2     <- MerklePatriciaProducer.stateless[IO].insert(trie, newLeaves).flatMap(IO.fromEither(_))
-    } yield expect(trie2.rootNode.digest == Hash("f01117b41e875b6f432e12a10b340ddd0cafa077a4b9b82aed688695adf58c45"))
+    } yield expect(trie2.rootNode.digest == Hash("921e485e4dab7d4a23ec4136afe8944ef177b3a38cb546195c1e860315c04c97"))
   }
 
   test("create then remove produces a trie with a known root digest") {


### PR DESCRIPTION
## What
MPT improvements from an audit comparing metakit's MPT to tessellation's.

**Fixes a real determinism bug:** when an existing Extension was split at its full shared length, the code built a degenerate zero-length `Extension(empty, child)` — changing the node digest and making the incrementally-built root depend on insertion order. Now uses the child Branch directly when the remaining shared path is empty (matching tessellation). This was also the root cause of insertion-order non-determinism: the same data inserted in different orders now converges to one root.

(The audit's headline concern — unsorted Branch-map serialization — was verified to be a NON-issue: metakit hashes commitments through the RFC 8785 canonicalizer, which sorts keys.)

## Tests + features
- MPT tests 50 → 88: determinism (full-length split + order-independence property), short/variable-length/mutually-prefixing keys, prover/verifier tamper (negative) suites.
- Ported **batch inclusion** prover/verifier + proof and the **prefix** prover from tessellation.
- Two golden root-digest tests updated (old values came from the buggy path; the new `create` digest is verified insertion-order-independent).

Full suite: 756 tests green on JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
