### PR TITLE
feat(crypto/zk): pure-JVM SP1 Groth16-BN254 verifier (M3 — verifies a real JLVM proof)

### DIFF
--- a/src/main/java/org/hyperledger/besu/crypto/altbn128/AbstractFqp.java
+++ b/src/main/java/org/hyperledger/besu/crypto/altbn128/AbstractFqp.java
@@ -181,19 +181,24 @@ public abstract class AbstractFqp<T extends AbstractFqp> implements FieldElement
     }
   }
 
+  // Deviation from upstream Besu: iterative square-and-multiply. Upstream's
+  // recursion consumes one stack frame per exponent bit (~2790 frames for the
+  // Groth16 final exponentiation (P^12 - 1) / R), which can StackOverflowError
+  // on threads with a reduced stack size (e.g. -Xss256k).
   @SuppressWarnings("unchecked")
   @Override
   public T power(final BigInteger n) {
-    if (n.compareTo(BigInteger.ZERO) == 0) {
-      return one();
+    T result = one();
+    T base = (T) this;
+    BigInteger exp = n;
+    while (exp.signum() > 0) {
+      if (exp.testBit(0)) {
+        result = (T) result.multiply(base);
+      }
+      base = (T) base.multiply(base);
+      exp = exp.shiftRight(1);
     }
-    if (n.compareTo(BigInteger.ONE) == 0) {
-      return (T) this;
-    } else if (n.mod(BIGINT_2).compareTo(BigInteger.ZERO) == 0) {
-      return (T) multiply((T) this).power(n.divide(BIGINT_2));
-    } else {
-      return (T) multiply((T) this).power(n.divide(BIGINT_2)).multiply(this);
-    }
+    return result;
   }
 
   /**

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/zk/Bn254.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/zk/Bn254.scala
@@ -46,6 +46,9 @@ object Bn254 {
       G1.fromBesu(toBesu.multiply(scalar.mod(R)))
 
     def isOnCurve: Boolean = toBesu.isOnCurve
+
+    /** The EVM / Besu point-at-infinity is the all-zero point `(0, 0)`. */
+    def isInfinity: Boolean = x.signum == 0 && y.signum == 0
   }
 
   object G1 {
@@ -73,6 +76,18 @@ object Bn254 {
       new AltBn128Fq2Point(fq2(xReal, xImag), fq2(yReal, yImag))
 
     def isOnCurve: Boolean = toBesu.isOnCurve
+
+    /**
+     * Order-`r` (G2) subgroup membership: `r * P == O`. G2 has a non-trivial
+     * cofactor, so on-curve is NOT sufficient; this is the defence against
+     * non-subgroup (small-subgroup) attack points. Delegates to Besu's
+     * `AltBn128Fq2Point.isInGroup`, which multiplies by the curve order.
+     */
+    def isInGroup: Boolean = toBesu.isInGroup
+
+    /** The all-zero Fp2 point `(0, 0)` is the point-at-infinity / identity. */
+    def isInfinity: Boolean =
+      xReal.signum == 0 && xImag.signum == 0 && yReal.signum == 0 && yImag.signum == 0
   }
 
   /** Build an Fp2 element `real + imag * i` (Besu order: c0 = real, c1 = imag). */

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/zk/Groth16Verifier.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/zk/Groth16Verifier.scala
@@ -89,6 +89,18 @@ object Groth16Verifier {
   val NumPublicInputs: Int = 5
 
   /**
+   * Sentinel prefix marking a MALFORMED-ENCODING failure: a proof coordinate
+   * `>= P`, i.e. a non-canonical base-field-element encoding. Besu's `Fq.create`
+   * stores the value unreduced and later arithmetic silently reduces it mod P,
+   * so a `>= P` coordinate must be rejected explicitly BEFORE it reaches the
+   * curve. The opcode layer distinguishes these (a hard `JsonLogicException`)
+   * from cryptographic-invalidity failures (off-curve / non-subgroup), which
+   * verify to `false`. Kept in lockstep with the Rust
+   * `groth16::ENCODING_ERROR_PREFIX`.
+   */
+  val EncodingErrorPrefix: String = "ENCODING: "
+
+  /**
    * Public-input linear combination `L = CONSTANT + sum_i input_i * PUB_i`.
    * Each input scalar must already be reduced (`< R`); unreduced scalars are
    * rejected, matching the Solidity `lt(s, R)` checks.
@@ -113,23 +125,53 @@ object Groth16Verifier {
    *              produced by gnark / abi-encoded SP1 proofs).
    * @param input five public-input scalars (elements of Fr).
    * @return `Right(())` if the proof is valid, `Left(reason)` otherwise.
+   *
+   * ==Proof-point validation (soundness hardening)==
+   * Before pairing, every proof point is validated, in lockstep with the Rust
+   * `groth16::verify_proof`:
+   *   1. CANONICAL ENCODING: every coordinate must be `< P`. A `>= P` coordinate
+   *      is a non-canonical encoding (Besu's `Fq.create` would silently reduce
+   *      it mod P) and yields `Left` tagged with [[EncodingErrorPrefix]] -- a
+   *      hard error at the opcode layer.
+   *   2. ON-CURVE: A, B, C must satisfy the curve equation.
+   *   3. SUBGROUP: B (G2) must lie in the order-`r` subgroup (G2 has a
+   *      non-trivial cofactor, so on-curve is NOT sufficient). A, C (G1) are
+   *      cofactor-1 (prime order), so on-curve implies correct subgroup; the
+   *      identity is rejected for A/B/C as a degenerate proof point.
+   * A well-formed but cryptographically invalid point (off-curve, non-subgroup
+   * or identity) yields `Left` WITHOUT the encoding prefix -- the opcode maps it
+   * to `false`, exactly like a failed pairing.
    */
   def verifyProof(proof: IndexedSeq[BigInteger], input: IndexedSeq[BigInteger]): Either[String, Unit] =
     if (proof.length != 8) Left(s"expected 8 proof elements, got ${proof.length}")
     else
-      publicInputMSM(input).flatMap { l =>
-        val a = G1(proof(0), proof(1))
+      for {
+        l <- publicInputMSM(input)
+        // (1) Canonical-encoding check on every coordinate (>= P -> Left ENCODING).
+        _ <- canonicalCoord(proof(0), "proof A.x")
+        _ <- canonicalCoord(proof(1), "proof A.y")
+        _ <- canonicalCoord(proof(2), "proof B.x_imag")
+        _ <- canonicalCoord(proof(3), "proof B.x_real")
+        _ <- canonicalCoord(proof(4), "proof B.y_imag")
+        _ <- canonicalCoord(proof(5), "proof B.y_real")
+        _ <- canonicalCoord(proof(6), "proof C.x")
+        _ <- canonicalCoord(proof(7), "proof C.y")
+        a = G1(proof(0), proof(1))
         // EIP-197 order in `proof`: imag before real.
-        val b = G2(
+        b = G2(
           xReal = proof(3),
           xImag = proof(2),
           yReal = proof(5),
           yImag = proof(4)
         )
-        val c = G1(proof(6), proof(7))
-
+        c = G1(proof(6), proof(7))
+        // (2)+(3) On-curve / subgroup / non-identity. Cryptographic invalidity
+        // (no encoding prefix) -> the opcode maps these Lefts to `false`.
+        _ <- checkG1(a, "proof A")
+        _ <- checkG2(b, "proof B")
+        _ <- checkG1(c, "proof C")
         // e(A, B) * e(C, -delta) * e(alpha, -beta) * e(L, -gamma) == 1
-        val ok = Bn254.pairingProductIsOne(
+        ok = Bn254.pairingProductIsOne(
           Seq(
             a     -> b,
             c     -> deltaNeg,
@@ -137,6 +179,31 @@ object Groth16Verifier {
             l     -> gammaNeg
           )
         )
-        if (ok) Right(()) else Left("pairing check failed")
-      }
+        _ <- if (ok) Right(()) else Left("pairing check failed")
+      } yield ()
+
+  /** Reject a non-canonical (`>= P`) coordinate as a malformed encoding. */
+  private def canonicalCoord(value: BigInteger, role: String): Either[String, Unit] =
+    if (value.signum >= 0 && value.compareTo(Bn254.P) < 0) Right(())
+    else Left(s"$EncodingErrorPrefix$role: coordinate not in base field (>= P): $value")
+
+  /**
+   * G1 proof-point validation: on-curve and non-identity. BN254 G1 has cofactor
+   * 1 (prime order), so on-curve already implies correct-subgroup membership;
+   * the identity is rejected as a degenerate proof point.
+   */
+  private def checkG1(p: G1, role: String): Either[String, Unit] =
+    if (p.isInfinity) Left(s"$role: point is the identity (degenerate)")
+    else if (!p.isOnCurve) Left(s"$role: point is not on the BN254 G1 curve")
+    else Right(())
+
+  /**
+   * G2 proof-point validation: on-curve, non-identity, AND order-`r` subgroup
+   * membership (G2 has a non-trivial cofactor, so on-curve is NOT sufficient).
+   */
+  private def checkG2(p: G2, role: String): Either[String, Unit] =
+    if (p.isInfinity) Left(s"$role: point is the identity (degenerate)")
+    else if (!p.isOnCurve) Left(s"$role: point is not on the BN254 G2 curve")
+    else if (!p.isInGroup) Left(s"$role: G2 point is not in the order-r subgroup")
+    else Right(())
 }

--- a/src/test/scala/crypto/zk/Sp1Groth16VerifierSuite.scala
+++ b/src/test/scala/crypto/zk/Sp1Groth16VerifierSuite.scala
@@ -6,7 +6,7 @@ import cats.effect.IO
 
 import scala.io.Source
 
-import io.constellationnetwork.metagraph_sdk.crypto.zk.{Bn254, Sp1Groth16Verifier}
+import io.constellationnetwork.metagraph_sdk.crypto.zk.{Bn254, Groth16Verifier, Sp1Groth16Verifier}
 
 import io.circe.parser.{parse => parseJson}
 import org.hyperledger.besu.crypto.altbn128.{AltBn128Fq2Point, AltBn128Point, Fq2}
@@ -172,6 +172,79 @@ object Sp1Groth16VerifierSuite extends SimpleIOSuite {
       val tampered = flipByte(fixture.vkey, 0)
       val result = Sp1Groth16Verifier.verify(tampered, fixture.publicValues, fixture.proofBytes)
       expect(result.isLeft)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Soundness hardening: proof-point validation (on-curve, subgroup, range).
+  //   Mirrors the Rust crypto.rs adversarial unit tests. The proof[8] words live
+  //   at byte offset 4 + 32*3 = 100; word i is [100 + 32*i, 100 + 32*(i+1)).
+  //   Layout (EIP-197): 0=A.x 1=A.y 2=B.x_imag 3=B.x_real 4=B.y_imag 5=B.y_real
+  //   6=C.x 7=C.y.
+  // ---------------------------------------------------------------------------
+
+  private val ProofWordBase: Int = 4 + 32 * 3
+
+  /** Overwrite proof word `idx` with the 32-byte big-endian encoding of `value`. */
+  private def setProofWord(bytes: Array[Byte], idx: Int, value: BigInteger): Array[Byte] = {
+    val copy = bytes.clone()
+    val word = new Array[Byte](32)
+    val raw = value.toByteArray // big-endian, possibly with a sign byte or shorter
+    val src = if (raw.length > 32) raw.takeRight(32) else raw
+    System.arraycopy(src, 0, word, 32 - src.length, src.length)
+    System.arraycopy(word, 0, copy, ProofWordBase + idx * 32, 32)
+    copy
+  }
+
+  private def proofWord(bytes: Array[Byte], idx: Int): BigInteger = {
+    val word = new Array[Byte](32)
+    System.arraycopy(bytes, ProofWordBase + idx * 32, word, 0, 32)
+    new BigInteger(1, word)
+  }
+
+  // An on-curve BN254 G2 point at x=(real=2, imag=1) that is NOT in the order-r
+  // subgroup (constructed offline; see crypto.rs ADV_NONSUB_B).
+  private val NonSubgroupBxReal: BigInteger = BigInteger.valueOf(2)
+  private val NonSubgroupBxImag: BigInteger = BigInteger.ONE
+  private val NonSubgroupByReal: BigInteger =
+    new BigInteger("7292567877523311580221095596750716176434782432868683424513645834767876293070")
+  private val NonSubgroupByImag: BigInteger =
+    new BigInteger("19659275751359636165940301690575149581329631496732780143538578556285923319774")
+
+  test("ADVERSARIAL: off-curve proof point A is REJECTED as false (no encoding prefix)") {
+    IO {
+      // A.y := A.y + 1 -> still < P, but the point is no longer on the curve.
+      val ay = proofWord(fixture.proofBytes, 1)
+      val tampered = setProofWord(fixture.proofBytes, 1, ay.add(BigInteger.ONE).mod(Bn254.P))
+      val result = Sp1Groth16Verifier.verify(fixture.vkey, fixture.publicValues, tampered)
+      expect(result.isLeft).and(expect(result.swap.exists(!_.startsWith(Groth16Verifier.EncodingErrorPrefix))))
+    }
+  }
+
+  test("ADVERSARIAL: on-curve-but-non-subgroup proof point B is REJECTED (subgroup check fires)") {
+    IO {
+      // Isolate the subgroup check: the planted point must pass the on-curve
+      // check (otherwise this test would also pass via the wrong rejection path).
+      val planted = Bn254.G2(NonSubgroupBxReal, NonSubgroupBxImag, NonSubgroupByReal, NonSubgroupByImag)
+      val t0 = setProofWord(fixture.proofBytes, 2, NonSubgroupBxImag) // B.x_imag
+      val t1 = setProofWord(t0, 3, NonSubgroupBxReal) // B.x_real
+      val t2 = setProofWord(t1, 4, NonSubgroupByImag) // B.y_imag
+      val t3 = setProofWord(t2, 5, NonSubgroupByReal) // B.y_real
+      val result = Sp1Groth16Verifier.verify(fixture.vkey, fixture.publicValues, t3)
+      expect(planted.isOnCurve)
+        .and(expect(!planted.isInGroup))
+        .and(expect(result.isLeft))
+        .and(expect(result.swap.exists(_.contains("subgroup"))))
+        .and(expect(result.swap.exists(!_.startsWith(Groth16Verifier.EncodingErrorPrefix))))
+    }
+  }
+
+  test("ADVERSARIAL: a proof coordinate >= P is an ENCODING error (not a false verdict)") {
+    IO {
+      // A.x := P (== base-field modulus) -> non-canonical encoding.
+      val tampered = setProofWord(fixture.proofBytes, 0, Bn254.P)
+      val result = Sp1Groth16Verifier.verify(fixture.vkey, fixture.publicValues, tampered)
+      expect(result.isLeft).and(expect(result.swap.exists(_.startsWith(Groth16Verifier.EncodingErrorPrefix))))
     }
   }
 }


### PR DESCRIPTION
## What

A pure-JVM (zero native dependencies) verifier for **SP1's Groth16-BN254 wrapper proofs**, i.e. the constant-size proof SP1 emits when wrapping its STARK into Groth16 over alt_bn128. Pairing arithmetic comes from vendored Hyperledger Besu `altbn128` classes (EIP-196/197 semantics); the verifier implements the standard Groth16 check `e(A,B) = e(alpha,beta) · e(L_pub,gamma) · e(C,delta)` against an SP1 verifying key.

## Why now

This is M3 of the zk-JLVM track: metagraph validators (JVM processes) must verify SP1 proofs of off-chain JLVM execution **in-process** — a native blst/arkworks dependency would complicate deployment across validator environments. The `groth16_verify` JLVM opcode (#28) builds directly on this verifier; the shielded-transfer capstone (#26) verifies a real proof end-to-end.

## Soundness hardening (this PR)

Full proof-point validation before pairing: coordinate canonicality (< P), on-curve checks for A/B/C, and **G2 subgroup membership** for B (G2 has a non-trivial cofactor, so on-curve is insufficient — defends against small-subgroup attack points). Malformed encodings are distinguished from failed verification via `EncodingErrorPrefix` (error vs `false` discipline, matching the Rust implementation in metakit-sdk `rust/jlvm-core`). Adversarial tests cover off-curve A, on-curve-but-non-subgroup B, and coordinate ≥ P.

## Performance / deployment constraints

Verification is ~100ms-class on the JVM (reference-style bignum arithmetic, not Montgomery-form) — acceptable for guard-evaluation rates, and gas-metered at the opcode layer. Per review: `AbstractFqp.power` is now an **iterative** square-and-multiply — upstream Besu's recursion consumes one stack frame per exponent bit (~2790 for the final exponentiation), which could `StackOverflowError` on reduced-stack threads (`-Xss256k` containers).

## Review fixes (ryle-ai)

- ✅ Iterative `power(BigInteger)` (recursion depth → constant)
- ✅ Non-subgroup adversarial test now asserts the planted point IS on-curve and NOT in-group, isolating the subgroup-check rejection path
- ✅ This description

🤖 Generated with [Claude Code](https://claude.com/claude-code)