### PR TITLE
feat(std): JSON depth DoS guard + restore drop-nulls-before-canonicalize

### DIFF
--- a/src/test/scala/std/JsonBinaryHasherSuite.scala
+++ b/src/test/scala/std/JsonBinaryHasherSuite.scala
@@ -30,6 +30,10 @@ object JsonBinaryHasherSuite extends SimpleIOSuite with Checkers {
       hashExpected = Hash(expected)
     } yield expect.same(hashExpected, hashActual)
 
+  // arrays.json contains an object field `"10": null`. The codec drops null OBJECT fields BEFORE
+  // canonicalizing (schema-evolution-safe — lets you add optional fields without changing the hash of
+  // prior data; matches ottochain-sdk `drop-nulls.ts` and released metakit 1.7.0's null-dropping). The
+  // canonical form is therefore [56,{"1":[],"d":true}] (the null `"10"` removed, keys sorted).
   test("arrays.json should produce a known hash") {
     runTest("arrays.json", "060ba9d4be65e7b773f67328b6fd6a5360f8f66ef88d57351dbc6e39b46f2ea9")
   }


### PR DESCRIPTION
Two changes to `JsonBinaryCodec`:

### 1. Depth DoS guard
Rejects JSON nested past `DefaultMaxDepth = 64` **on deserialization**, with a stack-safe (work-list) depth check so the guard itself can't be overflowed. Configurable via `deriveWithMaxDepth` / `deriveDataUpdateWithMaxDepth`.

### 2. Restore drop-nulls-before-canonicalize
dev's serialization **regressed** at `852e938` ("add JsonCanonicalizer and use in serialization") — it stopped dropping null object-fields, so a `None` optional field canonicalizes as `"f":null`. That changes the hash vs data written before the field existed → **breaks signatures and blocks schema evolution**. This restores dropping null **object** fields (recursively; array nulls preserved) **before** RFC-8785 canonicalization.

This matches **ottochain-sdk `src/ottochain/drop-nulls.ts`** (written to mirror this very behavior) and **released metakit 1.7.0** ("deriveDataUpdate drops nulls") — dev was behind both.

**Test:** `arrays.json` contains `"10":null`, so its canonical form is `[56,{"1":[],"d":true}]` and its known hash updates to `060ba9d4…` (verified against the actual canonical bytes). 48 codec/hasher/canonicalizer tests pass; the full integration suite (all stacked PRs merged) is green.

⚠️ This changes canonical hashing for null-containing data on `dev` (aligning it with the release) — intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)