### PR TITLE
feat(json_logic): wave-2 ZK/crypto opcodes — bn254 add/mul/pairing, bls_verify, bls_aggregate_verify, schnorr_verify (stacks on #28)

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/bls/MiraclBls12381.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/bls/MiraclBls12381.scala
@@ -1,0 +1,107 @@
+package io.constellationnetwork.metagraph_sdk.crypto.bls
+
+import org.miracl.core.BLS12381._
+
+/**
+ * Thin Scala wrapper over MIRACL Core's BLS12-381 signature scheme, consumed
+ * as-is (no MIRACL source is modified). Provides single-signature verification
+ * (delegating to [[BLS.core_verify]]) and same-message N-of-N signature
+ * aggregation verification (which MIRACL has no built-in helper for, so it is
+ * implemented here directly with the pairing engine).
+ *
+ * ==Ciphersuite==
+ * MIRACL's `BLS` is the "minimal-signature-size" variant. The hash-to-curve
+ * domain separation tag baked into [[BLS.bls_hash_to_point]] is
+ * {{{
+ *   BLS_SIG_BLS12381G1_XMD:SHA-256_SVDW_RO_NUL_
+ * }}}
+ * i.e. messages are hashed to '''G1''' with `expand_message_xmd` over SHA-256
+ * and the SvdW map (random-oracle encoding). This corresponds to the IRTF BLS
+ * signature draft's "minimal-signature-size" profile, except MIRACL uses SvdW
+ * rather than SSWU as the base map — so this is interoperable with other MIRACL
+ * BLS deployments, not with `BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_` (eth2)
+ * signatures.
+ *
+ * ==Groups and sizes==
+ *   - Signatures live in '''G1''' and are serialized COMPRESSED via
+ *     `ECP.toBytes(buf, true)`. BLS12-381 has `MODBYTES = 48`; the standard
+ *     (non-alt) MIRACL compression prefixes one flag byte, so a signature is
+ *     `1 + 48 = 49` bytes ([[SignatureBytes]]).
+ *   - Public keys live in '''G2''' and are serialized COMPRESSED via
+ *     `ECP2.toBytes(buf, true)`: `1 + 2 * 48 = 97` bytes ([[PublicKeyBytes]]).
+ *   - Private keys are `MODBYTES = 48` bytes ([[PrivateKeyBytes]]).
+ *
+ * ==Verification relations==
+ *   - Single: accept iff `e(-sig, G2gen) · e(H(m), pk) == 1`, equivalently
+ *     `e(sig, G2gen) == e(H(m), pk)` (exactly [[BLS.core_verify]]).
+ *   - Same-message aggregate of `N` signers over one message `m`: the aggregate
+ *     signature is the G1 sum `S = Σ_i sig_i` and the relation checked is
+ *     `e(-S, G2gen) · e(H(m), Σ_i pk_i) == 1`, equivalently
+ *     `e(S, G2gen) == e(H(m), Σ_i pk_i)`. This is the threshold / multisig case
+ *     (one message, many signers); it is NOT secure for distinct messages
+ *     without the rogue-key defenses that distinct-message aggregation requires.
+ */
+object MiraclBls12381 {
+
+  /** Compressed G1 signature size: `1 + MODBYTES`. */
+  val SignatureBytes: Int = 1 + BLS.BFS // 49
+
+  /** Compressed G2 public-key size: `1 + 2 * MODBYTES`. */
+  val PublicKeyBytes: Int = 1 + 2 * BLS.BGS // 97
+
+  /** Private-key size: `MODBYTES`. */
+  val PrivateKeyBytes: Int = BLS.BGS // 48
+
+  // BLS.init() builds the G2 generator precomputation table used by core_verify.
+  // It is idempotent and cheap; we run it once at class-load.
+  private val initOk: Boolean = BLS.init() == BLS.BLS_OK
+
+  /**
+   * Verify a single BLS signature. Returns `false` (never throws) for any
+   * malformed input or failed check. `pk` is a compressed G2 point
+   * ([[PublicKeyBytes]]), `sig` a compressed G1 point ([[SignatureBytes]]),
+   * `msg` arbitrary message bytes.
+   */
+  def verify(pk: Array[Byte], msg: Array[Byte], sig: Array[Byte]): Boolean =
+    if (!initOk || pk.length != PublicKeyBytes || sig.length != SignatureBytes) false
+    else
+      try BLS.core_verify(sig, msg, pk) == BLS.BLS_OK
+      catch { case _: Throwable => false }
+
+  /**
+   * Verify an aggregate of `N` BLS signatures over the SAME message. `aggSig`
+   * is the compressed G1 sum of the individual signatures; `pks` are the `N`
+   * compressed G2 public keys; `msg` the common message. Returns `false` (never
+   * throws) on any malformed input, non-member point, or failed pairing check.
+   *
+   * Relation: `e(-aggSig, G2gen) · e(H(m), Σ pk_i) == 1`.
+   */
+  def aggregateVerify(pks: List[Array[Byte]], msg: Array[Byte], aggSig: Array[Byte]): Boolean =
+    if (!initOk || pks.isEmpty || aggSig.length != SignatureBytes || pks.exists(_.length != PublicKeyBytes)) false
+    else
+      try {
+        // Aggregate signature point (G1), must be a valid subgroup member.
+        val sig = ECP.fromBytes(aggSig)
+        if (sig.is_infinity() || !PAIR.G1member(sig)) false
+        else {
+          // Aggregate public key = Σ pk_i (G2), each a valid subgroup member.
+          val aggPk = new ECP2()
+          var membersOk = true
+          pks.foreach { pkBytes =>
+            val pk = ECP2.fromBytes(pkBytes)
+            if (pk.is_infinity() || !PAIR.G2member(pk)) membersOk = false
+            else aggPk.add(pk)
+          }
+          if (!membersOk || aggPk.is_infinity()) false
+          else {
+            val hm = BLS.bls_hash_to_point(msg)
+            val g = ECP2.generator()
+            val negSig = new ECP(sig)
+            negSig.neg()
+            // e(G, -aggSig) * e(aggPk, H(m)) == 1  (ate2 args: ECP2, ECP, ECP2, ECP)
+            val v: FP12 = PAIR.fexp(PAIR.ate2(g, negSig, aggPk, hm))
+            v.isunity()
+          }
+        }
+      } catch { case _: Throwable => false }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/core/JsonLogicOp.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/core/JsonLogicOp.scala
@@ -91,4 +91,12 @@ object JsonLogicOp extends Enum[JsonLogicOp] with CirceEnum[JsonLogicOp] {
   case object PmtVerifyOp extends JsonLogicOp("pmt_verify")
   case object Groth16VerifyOp extends JsonLogicOp("groth16_verify")
   case object EcVrfVerifyOp extends JsonLogicOp("ecvrf_verify")
+
+  // ZK / Crypto Operations -- second wave (BN254 curve, BLS12-381, Schnorr)
+  case object Bn254AddOp extends JsonLogicOp("bn254_add")
+  case object Bn254MulOp extends JsonLogicOp("bn254_mul")
+  case object Bn254PairingOp extends JsonLogicOp("bn254_pairing")
+  case object BlsVerifyOp extends JsonLogicOp("bls_verify")
+  case object BlsAggregateVerifyOp extends JsonLogicOp("bls_aggregate_verify")
+  case object SchnorrVerifyOp extends JsonLogicOp("schnorr_verify")
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/GasMetering.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/GasMetering.scala
@@ -136,6 +136,23 @@ case class GasConfig(
   pmtPerSibling: GasCost = GasCost(300),
   groth16Verify: GasCost = GasCost(250_000),
   ecvrfVerify: GasCost = GasCost(50_000),
+  // ZK / crypto opcodes -- second wave (BN254 curve, BLS12-381, Schnorr). Costs follow the
+  // wave-1 scale (groth16Verify = 250k, ecvrfVerify = 50k) and are the DoS bound for the VM:
+  //   - bn254Pairing is the most expensive: a flat base plus a per-pair cost (bn254PairingPerPair,
+  //     charged in the gas-aware layer), since each pair adds a Miller loop; the final exponentiation
+  //     is amortized once across the product,
+  //   - blsVerify / blsAggregateVerify are high (hash-to-curve + two pairings); aggregation adds a
+  //     per-key cost (blsAggregatePerKey) for each extra public key summed into the aggregate,
+  //   - schnorrVerify is medium (two BN254 scalar multiplications + a point add + a SHA-256),
+  //   - bn254Mul (a scalar multiplication) is far more expensive than bn254Add (a single point add).
+  bn254Add: GasCost = GasCost(500),
+  bn254Mul: GasCost = GasCost(40_000),
+  bn254Pairing: GasCost = GasCost(45_000),
+  bn254PairingPerPair: GasCost = GasCost(35_000),
+  blsVerify: GasCost = GasCost(120_000),
+  blsAggregateVerify: GasCost = GasCost(120_000),
+  blsAggregatePerKey: GasCost = GasCost(15_000),
+  schnorrVerify: GasCost = GasCost(45_000),
   const: GasCost = GasCost.Zero,
   varAccess: GasCost = GasCost(2),
   depthPenaltyMultiplier: Long = 5L,

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/CryptoOps.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/CryptoOps.scala
@@ -1,12 +1,16 @@
 package io.constellationnetwork.metagraph_sdk.json_logic.ops
 
+import java.math.BigInteger
+import java.security.MessageDigest
+
 import cats.syntax.either._
 import cats.syntax.traverse._
 
+import io.constellationnetwork.metagraph_sdk.crypto.bls.MiraclBls12381
 import io.constellationnetwork.metagraph_sdk.crypto.vrf.MiraclEcVrf25519
-import io.constellationnetwork.metagraph_sdk.crypto.zk.Sp1Groth16Verifier
 import io.constellationnetwork.metagraph_sdk.crypto.zk.merkle.{PoseidonMerkleProof, PoseidonMerkleTree}
 import io.constellationnetwork.metagraph_sdk.crypto.zk.poseidon.Poseidon
+import io.constellationnetwork.metagraph_sdk.crypto.zk.{Bn254, Sp1Groth16Verifier}
 import io.constellationnetwork.metagraph_sdk.json_logic.core._
 
 /**
@@ -145,6 +149,213 @@ object CryptoOps {
         JsonLogicException(
           s"ecvrf_verify: expected [pkHex, alphaHex, proofHex], got $values"
         ).asLeft
+    }
+
+  // ===========================================================================
+  // SECOND WAVE: BN254 (alt_bn128) curve ops, BLS12-381 signatures, Schnorr.
+  // ===========================================================================
+
+  private def bigInteger(v: BigInt): BigInteger = v.bigInteger
+
+  // Build an on-curve Bn254.G1 from a parsed (x, y); reject off-curve points.
+  // The all-zero point (0,0) is the EVM point-at-infinity and is on-curve.
+  private def g1OnCurve(coords: (BigInt, BigInt), role: String): Either[JsonLogicException, Bn254.G1] = {
+    val (x, y) = coords
+    val p = Bn254.G1(bigInteger(x), bigInteger(y))
+    Either.cond(p.isOnCurve, p, JsonLogicException(s"$role: point is not on the BN254 curve"))
+  }
+
+  // Build a valid Bn254.G2 from a parsed (xReal, xImag, yReal, yImag). Two-step
+  // validation (mirrored byte-for-byte by the Rust `g2_on_curve`):
+  //   1. curve membership (`isOnCurve`);
+  //   2. order-r subgroup membership (`isInGroup`). BN254 G2 has a non-trivial
+  //      cofactor, so an on-curve point may lie OUTSIDE the order-r subgroup.
+  //      Such a point is not a valid pairing input (it breaks the soundness
+  //      assumptions of the Groth16 check), so we reject it as malformed --
+  //      identical handling to the off-curve case (a JsonLogicException). G1 is
+  //      prime-order (cofactor 1), so on-curve already implies subgroup
+  //      membership and `g1OnCurve` needs no analogous check.
+  private def g2OnCurve(coords: (BigInt, BigInt, BigInt, BigInt), role: String): Either[JsonLogicException, Bn254.G2] = {
+    val (xr, xi, yr, yi) = coords
+    val p = Bn254.G2(bigInteger(xr), bigInteger(xi), bigInteger(yr), bigInteger(yi))
+    for {
+      _ <- Either.cond(p.isOnCurve, (), JsonLogicException(s"$role: point is not on the BN254 G2 curve"))
+      _ <- Either.cond(p.isInGroup, (), JsonLogicException(s"$role: point is not in the BN254 G2 order-r subgroup"))
+    } yield p
+  }
+
+  private def encodeG1(p: Bn254.G1): Either[JsonLogicException, String] =
+    HexBytes.encodeG1(BigInt(p.x), BigInt(p.y))
+
+  // ---------------------------------------------------------------------------
+  // bn254_add: [aHex(64B), bHex(64B)] -> 64B G1 (EIP-196 ecAdd).
+  // ---------------------------------------------------------------------------
+
+  def bn254Add(values: List[JsonLogicValue]): Either[JsonLogicException, JsonLogicValue] =
+    values match {
+      case aV :: bV :: Nil =>
+        for {
+          aHex <- expectStr("bn254_add a")(aV)
+          bHex <- expectStr("bn254_add b")(bV)
+          aC   <- HexBytes.parseG1(aHex, "bn254_add a")
+          bC   <- HexBytes.parseG1(bHex, "bn254_add b")
+          a    <- g1OnCurve(aC, "bn254_add a")
+          b    <- g1OnCurve(bC, "bn254_add b")
+          out  <- encodeG1(a.add(b))
+        } yield StrValue(out)
+      case _ =>
+        JsonLogicException(s"bn254_add: expected [aHex(64B), bHex(64B)], got $values").asLeft
+    }
+
+  // ---------------------------------------------------------------------------
+  // bn254_mul: [pHex(64B), sHex(32B)] -> 64B G1 (EIP-196 ecMul).
+  // ---------------------------------------------------------------------------
+
+  def bn254Mul(values: List[JsonLogicValue]): Either[JsonLogicException, JsonLogicValue] =
+    values match {
+      case pV :: sV :: Nil =>
+        for {
+          pHex <- expectStr("bn254_mul point")(pV)
+          sHex <- expectStr("bn254_mul scalar")(sV)
+          pC   <- HexBytes.parseG1(pHex, "bn254_mul point")
+          // Scalar is any 256-bit value; Bn254.G1.multiply reduces it mod R.
+          s   <- HexBytes.parseScalar(sHex, "bn254_mul scalar")
+          p   <- g1OnCurve(pC, "bn254_mul point")
+          out <- encodeG1(p.multiply(bigInteger(s)))
+        } yield StrValue(out)
+      case _ =>
+        JsonLogicException(s"bn254_mul: expected [pointHex(64B), scalarHex(32B)], got $values").asLeft
+    }
+
+  // ---------------------------------------------------------------------------
+  // bn254_pairing: [[g1Hex(64B), g2Hex(128B)], ...] -> bool (EIP-197).
+  //   true iff product of e(g1_i, g2_i) == 1; empty input -> true.
+  // ---------------------------------------------------------------------------
+
+  def bn254Pairing(values: List[JsonLogicValue]): Either[JsonLogicException, JsonLogicValue] = {
+    // Accept the natural EIP-197 shape (a single array of [g1, g2] pairs) as well
+    // as variadic pairs. Disambiguate the single-pair case `[[g1, g2]]` (which
+    // parses to one ArrayValue wrapping one pair) from `[g1, g2]` by only
+    // unwrapping the outer array when every element is itself an array (a pair).
+    val rawPairs: List[JsonLogicValue] = values match {
+      case ArrayValue(arr) :: Nil if arr.forall(_.isInstanceOf[ArrayValue]) => arr
+      case other                                                            => other
+    }
+
+    for {
+      pairs <- rawPairs.zipWithIndex.traverse {
+        case (ArrayValue(g1Hex :: g2Hex :: Nil), i) =>
+          for {
+            g1H <- expectStr(s"bn254_pairing[$i].g1")(g1Hex)
+            g2H <- expectStr(s"bn254_pairing[$i].g2")(g2Hex)
+            g1C <- HexBytes.parseG1(g1H, s"bn254_pairing[$i].g1")
+            g2C <- HexBytes.parseG2(g2H, s"bn254_pairing[$i].g2")
+            g1  <- g1OnCurve(g1C, s"bn254_pairing[$i].g1")
+            g2  <- g2OnCurve(g2C, s"bn254_pairing[$i].g2")
+          } yield (g1, g2)
+        case (other, i) =>
+          JsonLogicException(s"bn254_pairing[$i]: expected [g1Hex(64B), g2Hex(128B)], got $other").asLeft
+      }
+    } yield BoolValue(Bn254.pairingProductIsOne(pairs))
+  }
+
+  // ---------------------------------------------------------------------------
+  // bls_verify: [pkHex(97B G2), msgHex, sigHex(49B G1)] -> bool.
+  // ---------------------------------------------------------------------------
+
+  def blsVerify(values: List[JsonLogicValue]): Either[JsonLogicException, JsonLogicValue] =
+    values match {
+      case pkV :: msgV :: sigV :: Nil =>
+        for {
+          pkHex  <- expectStr("bls_verify pk")(pkV)
+          msgHex <- expectStr("bls_verify msg")(msgV)
+          sigHex <- expectStr("bls_verify sig")(sigV)
+          pk     <- HexBytes.parseBytes(pkHex, Some(MiraclBls12381.PublicKeyBytes), "bls_verify pk")
+          msg    <- HexBytes.parseBytes(msgHex, None, "bls_verify msg")
+          sig    <- HexBytes.parseBytes(sigHex, Some(MiraclBls12381.SignatureBytes), "bls_verify sig")
+        } yield BoolValue(MiraclBls12381.verify(pk, msg, sig))
+      case _ =>
+        JsonLogicException(s"bls_verify: expected [pkHex(97B), msgHex, sigHex(49B)], got $values").asLeft
+    }
+
+  // ---------------------------------------------------------------------------
+  // bls_aggregate_verify: [[pkHex(97B), ...], msgHex, aggSigHex(49B)] -> bool.
+  //   SAME-message N-of-N aggregation (threshold / multisig case).
+  // ---------------------------------------------------------------------------
+
+  def blsAggregateVerify(values: List[JsonLogicValue]): Either[JsonLogicException, JsonLogicValue] =
+    values match {
+      case ArrayValue(pksV) :: msgV :: aggSigV :: Nil =>
+        for {
+          _      <- Either.cond(pksV.nonEmpty, (), JsonLogicException("bls_aggregate_verify: at least one public key required"))
+          msgHex <- expectStr("bls_aggregate_verify msg")(msgV)
+          sigHex <- expectStr("bls_aggregate_verify aggSig")(aggSigV)
+          pks <- pksV.zipWithIndex.traverse {
+            case (pkV, i) =>
+              expectStr(s"bls_aggregate_verify pk[$i]")(pkV)
+                .flatMap(HexBytes.parseBytes(_, Some(MiraclBls12381.PublicKeyBytes), s"bls_aggregate_verify pk[$i]"))
+          }
+          msg    <- HexBytes.parseBytes(msgHex, None, "bls_aggregate_verify msg")
+          aggSig <- HexBytes.parseBytes(sigHex, Some(MiraclBls12381.SignatureBytes), "bls_aggregate_verify aggSig")
+        } yield BoolValue(MiraclBls12381.aggregateVerify(pks, msg, aggSig))
+      case _ =>
+        JsonLogicException(
+          s"bls_aggregate_verify: expected [[pkHex(97B), ...], msgHex, aggSigHex(49B)], got $values"
+        ).asLeft
+    }
+
+  // ---------------------------------------------------------------------------
+  // schnorr_verify: [pkHex(64B G1), msgHex, proofHex(96B)] -> bool.
+  //   Schnorr proof of knowledge / signature on BN254 G1. Convention:
+  //     proof    = R(64B) || s(32B)
+  //     generator G = (1, 2) (the alt_bn128 G1 base point)
+  //     challenge c = SHA256(R || pk || msg) mod r   (r = BN254 group order)
+  //     accept iff  s*G == R + c*pk
+  // ---------------------------------------------------------------------------
+
+  /** The BN254 G1 generator (1, 2), matching Besu's `AltBn128Point.g1()`. */
+  private val SchnorrGenerator: Bn254.G1 = Bn254.G1(BigInteger.ONE, BigInteger.valueOf(2))
+
+  def schnorrVerify(values: List[JsonLogicValue]): Either[JsonLogicException, JsonLogicValue] =
+    values match {
+      case pkV :: msgV :: proofV :: Nil =>
+        for {
+          pkHex    <- expectStr("schnorr_verify pk")(pkV)
+          msgHex   <- expectStr("schnorr_verify msg")(msgV)
+          proofHex <- expectStr("schnorr_verify proof")(proofV)
+          pkC      <- HexBytes.parseG1(pkHex, "schnorr_verify pk")
+          msg      <- HexBytes.parseBytes(msgHex, None, "schnorr_verify msg")
+          // proof = R(64B) || s(32B) -> total 96 bytes.
+          proof <- HexBytes.parseBytes(proofHex, Some(HexBytes.G1Bytes + HexBytes.ScalarBytes), "schnorr_verify proof")
+          rBytes = proof.slice(0, HexBytes.G1Bytes)
+          sBytes = proof.slice(HexBytes.G1Bytes, HexBytes.G1Bytes + HexBytes.ScalarBytes)
+          rC <- HexBytes.parseG1(HexBytes.encodeBytes(rBytes), "schnorr_verify R")
+          s = BigInt(1, sBytes)
+          pk <- g1OnCurve(pkC, "schnorr_verify pk")
+          r  <- g1OnCurve(rC, "schnorr_verify R")
+          // SOUNDNESS: reject the identity / point-at-infinity public key.
+          // BN254 G1 is prime-order (cofactor 1), so on-curve => in-subgroup
+          // EXCEPT for the identity O = (0,0). With pk = O the verification
+          // equation `s*G == R + c*pk` collapses to `s*G == R`, which an
+          // attacker satisfies for ANY message by choosing s and setting
+          // R = s*G -- a universal forgery. The identity pk is correct-WIDTH
+          // but cryptographically invalid, so this is `false`, NOT an error
+          // (malformed-width inputs still error above, as before).
+          pkIsIdentity = pk.x.signum == 0 && pk.y.signum == 0
+        } yield
+          if (pkIsIdentity) BoolValue(false)
+          else {
+            // c = SHA256(R || pk || msg) mod groupOrder
+            val pkBytes = HexBytes.parseBytes(pkHex, Some(HexBytes.G1Bytes), "schnorr_verify pk").toOption.get
+            val digest = MessageDigest.getInstance("SHA-256").digest(rBytes ++ pkBytes ++ msg)
+            val c = BigInt(1, digest).mod(BigInt(Bn254.R))
+            // accept iff s*G == R + c*pk
+            val lhs = SchnorrGenerator.multiply(bigInteger(s.mod(BigInt(Bn254.R))))
+            val rhs = r.add(pk.multiply(bigInteger(c)))
+            BoolValue(lhs.x == rhs.x && lhs.y == rhs.y)
+          }
+      case _ =>
+        JsonLogicException(s"schnorr_verify: expected [pkHex(64B), msgHex, proofHex(96B)], got $values").asLeft
     }
 
   // ---------------------------------------------------------------------------

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/HexBytes.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/HexBytes.scala
@@ -1,6 +1,7 @@
 package io.constellationnetwork.metagraph_sdk.json_logic.ops
 
 import cats.syntax.either._
+import cats.syntax.traverse._
 
 import io.constellationnetwork.metagraph_sdk.crypto.zk.poseidon.Poseidon
 import io.constellationnetwork.metagraph_sdk.json_logic.core.JsonLogicException
@@ -32,8 +33,24 @@ object HexBytes {
   /** Byte width of a BN254 Fr field element. */
   val FrBytes: Int = 32
 
+  /** Byte width of a single BN254 (alt_bn128) base-field coordinate. */
+  val FqBytes: Int = 32
+
+  /** Byte width of a serialized BN254 G1 point (`x || y`, 32B each). */
+  val G1Bytes: Int = 64
+
+  /** Byte width of a serialized BN254 G2 point (EIP-197 order, 4 x 32B). */
+  val G2Bytes: Int = 128
+
+  /** Byte width of a 256-bit big-endian scalar (e.g. a Schnorr response `s`). */
+  val ScalarBytes: Int = 32
+
   /** The BN254 / alt_bn128 scalar field modulus, shared with [[Poseidon.R]]. */
   val Modulus: BigInt = Poseidon.R
+
+  /** The BN254 / alt_bn128 base-field (Fp) modulus P. */
+  val BaseFieldModulus: BigInt =
+    BigInt("21888242871839275222246405745257275088696311157297823662689037894645226208583")
 
   private val HexPattern = "^0x[0-9a-f]*$".r
 
@@ -90,9 +107,82 @@ object HexBytes {
       )
     }
 
+  /**
+   * Parse a 32-byte hex string into a canonical BN254 base-field (Fq) coordinate
+   * (`0 <= value < P`). Rejects wrong width and non-canonical (`>= P`) values.
+   */
+  def parseFq(hex: String, role: String): Either[JsonLogicException, BigInt] =
+    parseBytes(hex, Some(FqBytes), role).flatMap { bytes =>
+      val value = BigInt(1, bytes)
+      Either.cond(
+        value < BaseFieldModulus,
+        value,
+        JsonLogicException(
+          s"$role: not a canonical BN254 base-field element (must be < P): $value"
+        )
+      )
+    }
+
+  /**
+   * Parse a 64-byte hex string into a BN254 G1 affine coordinate pair `(x, y)`.
+   * Each 32-byte half is validated as a canonical Fq element (`< P`). The
+   * all-zero point `(0, 0)` is the EVM point-at-infinity and is accepted here;
+   * on-curve membership is enforced by the caller (it is trivially satisfied by
+   * `(0, 0)`).
+   */
+  def parseG1(hex: String, role: String): Either[JsonLogicException, (BigInt, BigInt)] =
+    parseBytes(hex, Some(G1Bytes), role).flatMap { bytes =>
+      val x = BigInt(1, bytes.slice(0, FqBytes))
+      val y = BigInt(1, bytes.slice(FqBytes, G1Bytes))
+      for {
+        _ <- Either.cond(x < BaseFieldModulus, (), JsonLogicException(s"$role: x not in base field (>= P): $x"))
+        _ <- Either.cond(y < BaseFieldModulus, (), JsonLogicException(s"$role: y not in base field (>= P): $y"))
+      } yield (x, y)
+    }
+
+  /**
+   * Parse a 128-byte hex string into a BN254 G2 affine point in EIP-197 byte
+   * order, i.e. each Fp2 coordinate is serialized imaginary-part-first:
+   * `x.c1 || x.c0 || y.c1 || y.c0`. Returns `(xReal, xImag, yReal, yImag)` (the
+   * Besu / SP1 `(real, imag)` convention), so the caller can build a
+   * `Bn254.G2(xReal, xImag, yReal, yImag)` directly. Each 32-byte limb is
+   * validated as a canonical Fq element (`< P`).
+   */
+  def parseG2(hex: String, role: String): Either[JsonLogicException, (BigInt, BigInt, BigInt, BigInt)] =
+    parseBytes(hex, Some(G2Bytes), role).flatMap { bytes =>
+      def limb(i: Int): BigInt = BigInt(1, bytes.slice(i * FqBytes, (i + 1) * FqBytes))
+      // EIP-197 order: imaginary-before-real for each Fp2 coordinate.
+      val xImag = limb(0)
+      val xReal = limb(1)
+      val yImag = limb(2)
+      val yReal = limb(3)
+      val all = List("x.imag" -> xImag, "x.real" -> xReal, "y.imag" -> yImag, "y.real" -> yReal)
+      all.traverse {
+        case (name, v) =>
+          Either.cond(v < BaseFieldModulus, (), JsonLogicException(s"$role: $name not in base field (>= P): $v"))
+      }
+        .map(_ => (xReal, xImag, yReal, yImag))
+    }
+
+  /**
+   * Parse a 32-byte hex string into a non-negative big-endian scalar with NO
+   * field-canonicity constraint (any 256-bit value is accepted). Used for
+   * Schnorr responses and similar values that are reduced mod the group order
+   * by the consuming primitive.
+   */
+  def parseScalar(hex: String, role: String): Either[JsonLogicException, BigInt] =
+    parseBytes(hex, Some(ScalarBytes), role).map(bytes => BigInt(1, bytes))
+
   /** Encode raw bytes as a lowercase `0x`-prefixed hex string (exactly `bytes.length` bytes wide). */
   def encodeBytes(bytes: Array[Byte]): String =
     "0x" + bytes.map(b => f"${b & 0xff}%02x").mkString
+
+  /** Encode a BN254 G1 point `(x, y)` as a 64-byte `0x`-hex string (`x || y`, 32B each). */
+  def encodeG1(x: BigInt, y: BigInt): Either[JsonLogicException, String] =
+    for {
+      xs <- encodeUInt(x, FqBytes)
+      ys <- encodeUInt(y, FqBytes)
+    } yield "0x" + xs.substring(2) + ys.substring(2)
 
   /** Encode a non-negative `BigInt` as a `0x`-prefixed, big-endian, zero-padded hex of `width` bytes. */
   def encodeUInt(value: BigInt, width: Int): Either[JsonLogicException, String] =

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/GasAwareSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/GasAwareSemantics.scala
@@ -101,72 +101,78 @@ object GasAwareSemantics {
         }
 
       private def getOpCost(op: JsonLogicOp)(config: GasConfig): GasCost = op match {
-        case NoOp            => GasCost.Zero
-        case MissingNoneOp   => config.exists
-        case ExistsOp        => config.exists
-        case MissingSomeOp   => config.missingSome
-        case IfElseOp        => config.ifElse
-        case LetOp           => config.ifElse // Similar cost to if/else (control flow)
-        case EqOp            => config.eq
-        case EqStrictOp      => config.eqStrict
-        case NEqOp           => config.neq
-        case NEqStrictOp     => config.neqStrict
-        case NotOp           => config.not
-        case NOp             => config.doubleNot
-        case OrOp            => config.or
-        case AndOp           => config.and
-        case Lt              => config.lt
-        case Leq             => config.leq
-        case Gt              => config.gt
-        case Geq             => config.geq
-        case ModuloOp        => config.modulo
-        case MaxOp           => config.max
-        case MinOp           => config.min
-        case AddOp           => config.add
-        case TimesOp         => config.times
-        case MinusOp         => config.minus
-        case DivOp           => config.div
-        case MergeOp         => config.merge
-        case InOp            => config.in
-        case CatOp           => config.cat
-        case SubStrOp        => config.substr
-        case MapOp           => config.map
-        case FilterOp        => config.filter
-        case ReduceOp        => config.reduce
-        case AllOp           => config.all
-        case NoneOp          => config.none
-        case SomeOp          => config.some
-        case MapValuesOp     => config.mapValues
-        case MapKeysOp       => config.mapKeys
-        case GetOp           => config.get
-        case IntersectOp     => config.intersect
-        case CountOp         => config.count
-        case LengthOp        => config.length
-        case FindOp          => config.find
-        case LowerOp         => config.lower
-        case UpperOp         => config.upper
-        case JoinOp          => config.join
-        case SplitOp         => config.split
-        case DefaultOp       => config.default
-        case UniqueOp        => config.unique
-        case SliceOp         => config.slice
-        case ReverseOp       => config.reverse
-        case FlattenOp       => config.flatten
-        case TrimOp          => config.trim
-        case StartsWithOp    => config.startsWith
-        case EndsWithOp      => config.endsWith
-        case AbsOp           => config.abs
-        case RoundOp         => config.round
-        case FloorOp         => config.floor
-        case CeilOp          => config.ceil
-        case PowOp           => config.pow
-        case HasOp           => config.has
-        case EntriesOp       => config.entries
-        case TypeOfOp        => config.typeOf
-        case PoseidonOp      => config.poseidon
-        case PmtVerifyOp     => config.pmtVerify
-        case Groth16VerifyOp => config.groth16Verify
-        case EcVrfVerifyOp   => config.ecvrfVerify
+        case NoOp                 => GasCost.Zero
+        case MissingNoneOp        => config.exists
+        case ExistsOp             => config.exists
+        case MissingSomeOp        => config.missingSome
+        case IfElseOp             => config.ifElse
+        case LetOp                => config.ifElse // Similar cost to if/else (control flow)
+        case EqOp                 => config.eq
+        case EqStrictOp           => config.eqStrict
+        case NEqOp                => config.neq
+        case NEqStrictOp          => config.neqStrict
+        case NotOp                => config.not
+        case NOp                  => config.doubleNot
+        case OrOp                 => config.or
+        case AndOp                => config.and
+        case Lt                   => config.lt
+        case Leq                  => config.leq
+        case Gt                   => config.gt
+        case Geq                  => config.geq
+        case ModuloOp             => config.modulo
+        case MaxOp                => config.max
+        case MinOp                => config.min
+        case AddOp                => config.add
+        case TimesOp              => config.times
+        case MinusOp              => config.minus
+        case DivOp                => config.div
+        case MergeOp              => config.merge
+        case InOp                 => config.in
+        case CatOp                => config.cat
+        case SubStrOp             => config.substr
+        case MapOp                => config.map
+        case FilterOp             => config.filter
+        case ReduceOp             => config.reduce
+        case AllOp                => config.all
+        case NoneOp               => config.none
+        case SomeOp               => config.some
+        case MapValuesOp          => config.mapValues
+        case MapKeysOp            => config.mapKeys
+        case GetOp                => config.get
+        case IntersectOp          => config.intersect
+        case CountOp              => config.count
+        case LengthOp             => config.length
+        case FindOp               => config.find
+        case LowerOp              => config.lower
+        case UpperOp              => config.upper
+        case JoinOp               => config.join
+        case SplitOp              => config.split
+        case DefaultOp            => config.default
+        case UniqueOp             => config.unique
+        case SliceOp              => config.slice
+        case ReverseOp            => config.reverse
+        case FlattenOp            => config.flatten
+        case TrimOp               => config.trim
+        case StartsWithOp         => config.startsWith
+        case EndsWithOp           => config.endsWith
+        case AbsOp                => config.abs
+        case RoundOp              => config.round
+        case FloorOp              => config.floor
+        case CeilOp               => config.ceil
+        case PowOp                => config.pow
+        case HasOp                => config.has
+        case EntriesOp            => config.entries
+        case TypeOfOp             => config.typeOf
+        case PoseidonOp           => config.poseidon
+        case PmtVerifyOp          => config.pmtVerify
+        case Groth16VerifyOp      => config.groth16Verify
+        case EcVrfVerifyOp        => config.ecvrfVerify
+        case Bn254AddOp           => config.bn254Add
+        case Bn254MulOp           => config.bn254Mul
+        case Bn254PairingOp       => config.bn254Pairing
+        case BlsVerifyOp          => config.blsVerify
+        case BlsAggregateVerifyOp => config.blsAggregateVerify
+        case SchnorrVerifyOp      => config.schnorrVerify
       }
 
       private def getAdditionalCost(op: JsonLogicOp, args: List[JsonLogicValue], result: JsonLogicValue): GasCost =
@@ -276,6 +282,21 @@ object GasAwareSemantics {
             args match {
               case _ :: _ :: _ :: ArrayValue(siblings) :: Nil => gasConfig.pmtPerSibling * siblings.size.toLong
               case _                                          => GasCost.Zero
+            }
+          // bn254_pairing cost scales with the number of (G1, G2) pairs (each adds a Miller loop).
+          // Mirror CryptoOps.bn254Pairing's single-vs-list disambiguation: a lone
+          // ArrayValue is the pairs list only when every element is itself a pair (array).
+          case Bn254PairingOp =>
+            args match {
+              case ArrayValue(pairs) :: Nil if pairs.forall(_.isInstanceOf[ArrayValue]) =>
+                gasConfig.bn254PairingPerPair * pairs.size.toLong
+              case list => gasConfig.bn254PairingPerPair * list.size.toLong
+            }
+          // bls_aggregate_verify cost scales with the number of public keys summed into the aggregate.
+          case BlsAggregateVerifyOp =>
+            args match {
+              case ArrayValue(pks) :: _ :: _ :: Nil => gasConfig.blsAggregatePerKey * pks.size.toLong
+              case _                                => GasCost.Zero
             }
           case _ => GasCost.Zero
         }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
@@ -85,72 +85,78 @@ object JsonLogicSemantics {
 
       override def applyOp(op: JsonLogicOp): List[Result[JsonLogicValue]] => F[Either[JsonLogicException, Result[JsonLogicValue]]] =
         op match {
-          case NoOp            => _ => JsonLogicException("Got unexpected NoOp!").asLeft[Result[JsonLogicValue]].pure[F]
-          case MissingNoneOp   => handleMissingNone
-          case ExistsOp        => handleExists
-          case MissingSomeOp   => handleMissingSome
-          case IfElseOp        => handleIfElseOp
-          case LetOp           => handleLetOp
-          case EqOp            => handleEqOp
-          case EqStrictOp      => handleEqStrictOp
-          case NEqOp           => handleNEqOp
-          case NEqStrictOp     => handleNEqStrictOp
-          case NotOp           => handleNotOp
-          case NOp             => handleNOp
-          case OrOp            => handleOrOp
-          case AndOp           => handleAndOp
-          case Lt              => handleLt
-          case Leq             => handleLeq
-          case Gt              => handleGt
-          case Geq             => handleGeq
-          case ModuloOp        => handleModuloOp
-          case MaxOp           => handleMaxOp
-          case MinOp           => handleMinOp
-          case AddOp           => handleAddOp
-          case TimesOp         => handleTimesOp
-          case MinusOp         => handleMinusOp
-          case DivOp           => handleDivOp
-          case MergeOp         => handleMergeOp
-          case InOp            => handleInOp
-          case CatOp           => handleCatOp
-          case SubStrOp        => handleSubstrOp
-          case MapOp           => handleMapOp
-          case FilterOp        => handleFilterOp
-          case ReduceOp        => handleReduceOp
-          case AllOp           => handleAllOp
-          case NoneOp          => handleNoneOp
-          case SomeOp          => handleSomeOp
-          case MapValuesOp     => handleMapValuesOp
-          case MapKeysOp       => handleMapKeysOp
-          case GetOp           => handleGetOp
-          case IntersectOp     => handleIntersectOp
-          case CountOp         => handleCountOp
-          case LengthOp        => handleLengthOp
-          case FindOp          => handleFindOp
-          case LowerOp         => handleLowerOp
-          case UpperOp         => handleUpperOp
-          case JoinOp          => handleJoinOp
-          case SplitOp         => handleSplitOp
-          case DefaultOp       => handleDefaultOp
-          case UniqueOp        => handleUniqueOp
-          case SliceOp         => handleSliceOp
-          case ReverseOp       => handleReverseOp
-          case FlattenOp       => handleFlattenOp
-          case TrimOp          => handleTrimOp
-          case StartsWithOp    => handleStartsWithOp
-          case EndsWithOp      => handleEndsWithOp
-          case AbsOp           => handleAbsOp
-          case RoundOp         => handleRoundOp
-          case FloorOp         => handleFloorOp
-          case CeilOp          => handleCeilOp
-          case PowOp           => handlePowOp
-          case HasOp           => handleHasOp
-          case EntriesOp       => handleEntriesOp
-          case TypeOfOp        => handleTypeOfOp
-          case PoseidonOp      => handlePoseidonOp
-          case PmtVerifyOp     => handlePmtVerifyOp
-          case Groth16VerifyOp => handleGroth16VerifyOp
-          case EcVrfVerifyOp   => handleEcVrfVerifyOp
+          case NoOp                 => _ => JsonLogicException("Got unexpected NoOp!").asLeft[Result[JsonLogicValue]].pure[F]
+          case MissingNoneOp        => handleMissingNone
+          case ExistsOp             => handleExists
+          case MissingSomeOp        => handleMissingSome
+          case IfElseOp             => handleIfElseOp
+          case LetOp                => handleLetOp
+          case EqOp                 => handleEqOp
+          case EqStrictOp           => handleEqStrictOp
+          case NEqOp                => handleNEqOp
+          case NEqStrictOp          => handleNEqStrictOp
+          case NotOp                => handleNotOp
+          case NOp                  => handleNOp
+          case OrOp                 => handleOrOp
+          case AndOp                => handleAndOp
+          case Lt                   => handleLt
+          case Leq                  => handleLeq
+          case Gt                   => handleGt
+          case Geq                  => handleGeq
+          case ModuloOp             => handleModuloOp
+          case MaxOp                => handleMaxOp
+          case MinOp                => handleMinOp
+          case AddOp                => handleAddOp
+          case TimesOp              => handleTimesOp
+          case MinusOp              => handleMinusOp
+          case DivOp                => handleDivOp
+          case MergeOp              => handleMergeOp
+          case InOp                 => handleInOp
+          case CatOp                => handleCatOp
+          case SubStrOp             => handleSubstrOp
+          case MapOp                => handleMapOp
+          case FilterOp             => handleFilterOp
+          case ReduceOp             => handleReduceOp
+          case AllOp                => handleAllOp
+          case NoneOp               => handleNoneOp
+          case SomeOp               => handleSomeOp
+          case MapValuesOp          => handleMapValuesOp
+          case MapKeysOp            => handleMapKeysOp
+          case GetOp                => handleGetOp
+          case IntersectOp          => handleIntersectOp
+          case CountOp              => handleCountOp
+          case LengthOp             => handleLengthOp
+          case FindOp               => handleFindOp
+          case LowerOp              => handleLowerOp
+          case UpperOp              => handleUpperOp
+          case JoinOp               => handleJoinOp
+          case SplitOp              => handleSplitOp
+          case DefaultOp            => handleDefaultOp
+          case UniqueOp             => handleUniqueOp
+          case SliceOp              => handleSliceOp
+          case ReverseOp            => handleReverseOp
+          case FlattenOp            => handleFlattenOp
+          case TrimOp               => handleTrimOp
+          case StartsWithOp         => handleStartsWithOp
+          case EndsWithOp           => handleEndsWithOp
+          case AbsOp                => handleAbsOp
+          case RoundOp              => handleRoundOp
+          case FloorOp              => handleFloorOp
+          case CeilOp               => handleCeilOp
+          case PowOp                => handlePowOp
+          case HasOp                => handleHasOp
+          case EntriesOp            => handleEntriesOp
+          case TypeOfOp             => handleTypeOfOp
+          case PoseidonOp           => handlePoseidonOp
+          case PmtVerifyOp          => handlePmtVerifyOp
+          case Groth16VerifyOp      => handleGroth16VerifyOp
+          case EcVrfVerifyOp        => handleEcVrfVerifyOp
+          case Bn254AddOp           => handleBn254AddOp
+          case Bn254MulOp           => handleBn254MulOp
+          case Bn254PairingOp       => handleBn254PairingOp
+          case BlsVerifyOp          => handleBlsVerifyOp
+          case BlsAggregateVerifyOp => handleBlsAggregateVerifyOp
+          case SchnorrVerifyOp      => handleSchnorrVerifyOp
         }
 
       private def isFieldMissing(field: JsonLogicValue): F[Option[JsonLogicValue]] = field match {
@@ -1238,6 +1244,36 @@ object JsonLogicSemantics {
       private def handleEcVrfVerifyOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
         args.withMetrics { values =>
           CryptoOps.ecVrfVerify(values).map(_.pure[Result])
+        }
+
+      private def handleBn254AddOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+        args.withMetrics { values =>
+          CryptoOps.bn254Add(values).map(_.pure[Result])
+        }
+
+      private def handleBn254MulOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+        args.withMetrics { values =>
+          CryptoOps.bn254Mul(values).map(_.pure[Result])
+        }
+
+      private def handleBn254PairingOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+        args.withMetrics { values =>
+          CryptoOps.bn254Pairing(values).map(_.pure[Result])
+        }
+
+      private def handleBlsVerifyOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+        args.withMetrics { values =>
+          CryptoOps.blsVerify(values).map(_.pure[Result])
+        }
+
+      private def handleBlsAggregateVerifyOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+        args.withMetrics { values =>
+          CryptoOps.blsAggregateVerify(values).map(_.pure[Result])
+        }
+
+      private def handleSchnorrVerifyOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+        args.withMetrics { values =>
+          CryptoOps.schnorrVerify(values).map(_.pure[Result])
         }
 
       // Let is handled specially in the runtime; this should not be reached

--- a/src/test/scala/json_logic/GasMeteringSuite.scala
+++ b/src/test/scala/json_logic/GasMeteringSuite.scala
@@ -818,4 +818,56 @@ object GasMeteringSuite extends SimpleIOSuite with Checkers {
         s"Large intersect (${largeResult.gasUsed.amount}) should cost more than small intersect (${smallResult.gasUsed.amount})"
       )
   }
+
+  // ===========================================================================
+  // Wave-2 ZK / crypto opcode gas costs.
+  // ===========================================================================
+
+  test("GasConfig.Default wave-2 crypto costs follow the documented ordering") {
+    val c = GasConfig.Default
+    IO.pure(
+      expect.all(
+        c.bn254Add == GasCost(500),
+        c.bn254Mul == GasCost(40_000),
+        c.bn254Pairing == GasCost(45_000),
+        c.bn254PairingPerPair == GasCost(35_000),
+        c.blsVerify == GasCost(120_000),
+        c.blsAggregateVerify == GasCost(120_000),
+        c.blsAggregatePerKey == GasCost(15_000),
+        c.schnorrVerify == GasCost(45_000),
+        // ordering: mul >> add; a multi-pair pairing grows past blsVerify; blsVerify > schnorr.
+        c.bn254Mul.amount > c.bn254Add.amount,
+        (c.bn254Pairing + c.bn254PairingPerPair * 3L).amount > c.blsVerify.amount,
+        c.blsVerify.amount > c.schnorrVerify.amount,
+        // the per-pair marginal cost is the steepest crypto charge in the config.
+        c.bn254PairingPerPair.amount > c.blsAggregatePerKey.amount
+      )
+    )
+  }
+
+  test("bls_aggregate_verify gas scales with the number of public keys (per-key charge)") {
+    val evaluator = JsonLogicEvaluator.tailRecursive[IO]
+    // Use well-formed (97-byte) but bogus keys and a well-formed (49-byte) bogus
+    // aggregate signature so the op returns Right(false) -- the per-key cost is
+    // applied on success, so the values must parse cleanly.
+    val zeroPk = "0x" + "0" * (97 * 2)
+    val zeroSig = "0x" + "0" * (49 * 2)
+    def aggExpr(nKeys: Int): ApplyExpression =
+      ApplyExpression(
+        JsonLogicOp.BlsAggregateVerifyOp,
+        List(
+          ConstExpression(ArrayValue(List.fill(nKeys)(StrValue(zeroPk)))),
+          ConstExpression(StrValue("0xabcd")),
+          ConstExpression(StrValue(zeroSig))
+        )
+      )
+    for {
+      two   <- evaluator.evaluateWithGas(aggExpr(2), MapValue.empty, None, GasLimit.Unlimited, GasConfig.Default).flatMap(IO.fromEither)
+      three <- evaluator.evaluateWithGas(aggExpr(3), MapValue.empty, None, GasLimit.Unlimited, GasConfig.Default).flatMap(IO.fromEither)
+    } yield
+      expect(
+        three.gasUsed.amount - two.gasUsed.amount == GasConfig.Default.blsAggregatePerKey.amount,
+        s"3-key (${three.gasUsed.amount}) should exceed 2-key (${two.gasUsed.amount}) by exactly one per-key charge"
+      )
+  }
 }

--- a/src/test/scala/json_logic/ZkOpsWave2Suite.scala
+++ b/src/test/scala/json_logic/ZkOpsWave2Suite.scala
@@ -1,0 +1,370 @@
+package json_logic
+
+import java.math.BigInteger
+import java.security.MessageDigest
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.crypto.bls.MiraclBls12381
+import io.constellationnetwork.metagraph_sdk.crypto.zk.Bn254
+import io.constellationnetwork.metagraph_sdk.json_logic.core._
+import io.constellationnetwork.metagraph_sdk.json_logic.gas.{GasConfig, GasLimit}
+import io.constellationnetwork.metagraph_sdk.json_logic.ops.{CryptoOps, HexBytes}
+import io.constellationnetwork.metagraph_sdk.json_logic.runtime.JsonLogicEvaluator
+
+import io.circe.parser
+import org.miracl.core.BLS12381.{BLS, ECP}
+import weaver.SimpleIOSuite
+
+/**
+ * End-to-end tests for the SECOND-WAVE JLVM ZK / crypto opcodes:
+ *   - BN254 (alt_bn128) curve ops: `bn254_add`, `bn254_mul`, `bn254_pairing`,
+ *   - BLS12-381 signatures: `bls_verify`, `bls_aggregate_verify`,
+ *   - `schnorr_verify` (Schnorr signature on BN254 G1).
+ *
+ * Each opcode is exercised with a positive and a negative case (both directly
+ * through [[CryptoOps]] and end-to-end through the evaluator), plus the
+ * malformed-input / off-curve / wrong-width cases that must surface as a Result
+ * error rather than a thrown exception, and a worked threshold-gate contract.
+ */
+object ZkOpsWave2Suite extends SimpleIOSuite {
+
+  private def evalExpr(exprJson: String, dataJson: String = "{}"): IO[Either[JsonLogicException, JsonLogicValue]] =
+    for {
+      expr <- IO.fromEither(parser.parse(exprJson).flatMap(_.as[JsonLogicExpression]))
+      data <- IO.fromEither(parser.parse(dataJson).flatMap(_.as[JsonLogicValue]))
+      out  <- JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, data, None)
+    } yield out
+
+  // ===========================================================================
+  // BN254 helpers (use the Besu-backed Bn254 wrapper to build known points).
+  // ===========================================================================
+
+  private val R: BigInt = BigInt(Bn254.R)
+
+  // G1 generator (1, 2) and its 64-byte encoding.
+  private val g1: Bn254.G1 = Bn254.G1(BigInteger.ONE, BigInteger.valueOf(2))
+  private def encG1(p: Bn254.G1): String = HexBytes.encodeG1(BigInt(p.x), BigInt(p.y)).fold(throw _, identity)
+  private val g1Hex: String = encG1(g1)
+
+  // -g1 = (x, P - y).
+  private val negG1: Bn254.G1 = Bn254.G1(g1.x, HexBytes.BaseFieldModulus.bigInteger.subtract(g1.y))
+  private val negG1Hex: String = encG1(negG1)
+
+  // A canonical G2 generator in EIP-197 (imag-first) byte order. These are the
+  // standard alt_bn128 G2 generator coordinates (EIP-197 test vector).
+  private val g2Hex: String = {
+    val x1 = "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2" // x.imag (c1)
+    val x0 = "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed" // x.real (c0)
+    val y1 = "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b" // y.imag (c1)
+    val y0 = "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa" // y.real (c0)
+    "0x" + x1 + x0 + y1 + y0
+  }
+
+  // ===========================================================================
+  // bn254_add / bn254_mul
+  // ===========================================================================
+
+  test("bn254_add(g1, g1) == bn254_mul(g1, 2) (self-consistency)") {
+    val two = HexBytes.encodeUInt(BigInt(2), 32).fold(throw _, identity)
+    for {
+      added <- evalExpr(s"""{"bn254_add":["$g1Hex","$g1Hex"]}""")
+      muled <- evalExpr(s"""{"bn254_mul":["$g1Hex","$two"]}""")
+    } yield expect(added == muled) && expect(added == Right(StrValue(encG1(g1.add(g1)))))
+  }
+
+  test("bn254_mul(g1, 1) == g1 and bn254_mul(g1, 0) == infinity (zero point)") {
+    val one = HexBytes.encodeUInt(BigInt(1), 32).fold(throw _, identity)
+    val zero = HexBytes.encodeUInt(BigInt(0), 32).fold(throw _, identity)
+    val infHex = "0x" + "0" * 128
+    for {
+      m1 <- evalExpr(s"""{"bn254_mul":["$g1Hex","$one"]}""")
+      m0 <- evalExpr(s"""{"bn254_mul":["$g1Hex","$zero"]}""")
+    } yield expect(m1 == Right(StrValue(g1Hex))) && expect(m0 == Right(StrValue(infHex)))
+  }
+
+  test("bn254_add errors on an off-curve point (Result error, no crash)") {
+    // (1, 1) is not on y^2 = x^3 + 3.
+    val offCurve = HexBytes.encodeG1(BigInt(1), BigInt(1)).fold(throw _, identity)
+    evalExpr(s"""{"bn254_add":["$offCurve","$g1Hex"]}""").map(r => expect(r.isLeft))
+  }
+
+  test("bn254_mul errors on a wrong-width point") {
+    evalExpr(s"""{"bn254_mul":["0xdead","0x${"0" * 64}"]}""").map(r => expect(r.isLeft))
+  }
+
+  // ===========================================================================
+  // bn254_pairing
+  // ===========================================================================
+
+  test("bn254_pairing([(g1,g2),(-g1,g2)]) == true (e(g1,g2)*e(-g1,g2) == 1)") {
+    evalExpr(s"""{"bn254_pairing":[["$g1Hex","$g2Hex"],["$negG1Hex","$g2Hex"]]}""")
+      .map(r => expect(r == Right(BoolValue(true))))
+  }
+
+  test("bn254_pairing([(g1,g2)]) == false (single non-trivial pairing != 1)") {
+    evalExpr(s"""{"bn254_pairing":[["$g1Hex","$g2Hex"]]}""")
+      .map(r => expect(r == Right(BoolValue(false))))
+  }
+
+  test("bn254_pairing([]) == true (empty product is the identity)") {
+    evalExpr("""{"bn254_pairing":[[]]}""").map(r => expect(r == Right(BoolValue(true)))) // [[]] -> single empty array arg
+  }
+
+  test("bn254_pairing errors on an off-curve / wrong-width G2 point") {
+    evalExpr(s"""{"bn254_pairing":[["$g1Hex","0xdead"]]}""").map(r => expect(r.isLeft))
+  }
+
+  // An on-curve-but-NOT-order-r-subgroup G2 point: x = Fp2(c0=2, c1=1) on the
+  // BN254 twist, y solved from y^2 = x^3 + b2. It satisfies isOnCurve == true but
+  // isInGroup == false (it lies outside the prime-order G2 subgroup). Feeding it
+  // to the pairing breaks soundness, so bn254_pairing must reject it as malformed
+  // (a JsonLogicException), identically to the off-curve case. EIP-197 imag-first
+  // byte order: x.c1 || x.c0 || y.c1 || y.c0. (Cross-checked against the Rust
+  // ark-bn254 is_in_correct_subgroup_assuming_on_curve == false; same hex lives
+  // in shared/zk_opcode_test_vectors.json.)
+  private val nonSubgroupG2Hex: String =
+    "0x" +
+    "0000000000000000000000000000000000000000000000000000000000000001" + // x.imag (c1) = 1
+    "0000000000000000000000000000000000000000000000000000000000000002" + // x.real (c0) = 2
+    "2b76c179599bb92a963dac85546a005a777f7c13f6a7b75d5918b6b5808f5fde" + // y.imag (c1)
+    "101f7278419308b95099eca02dcee0c5381f4d26d1d62313f057167f064101ce" // y.real (c0)
+
+  test("bn254_pairing rejects an on-curve-but-non-subgroup G2 point (G2 subgroup check)") {
+    evalExpr(s"""{"bn254_pairing":[["$g1Hex","$nonSubgroupG2Hex"]]}""").map(r => expect(r.isLeft))
+  }
+
+  test("bn254_pairing gas scales by exactly one per-pair charge for each extra pair") {
+    val evaluator = JsonLogicEvaluator.tailRecursive[IO]
+    def pairingExpr(json: String): IO[Long] =
+      for {
+        expr <- IO.fromEither(parser.parse(json).flatMap(_.as[JsonLogicExpression]))
+        res <- evaluator
+          .evaluateWithGas(expr, MapValue.empty, None, GasLimit.Unlimited, GasConfig.Default)
+          .flatMap(IO.fromEither)
+      } yield res.gasUsed.amount
+    for {
+      one <- pairingExpr(s"""{"bn254_pairing":[["$g1Hex","$g2Hex"]]}""")
+      two <- pairingExpr(s"""{"bn254_pairing":[["$g1Hex","$g2Hex"],["$negG1Hex","$g2Hex"]]}""")
+    } yield
+      expect(
+        two - one == GasConfig.Default.bn254PairingPerPair.amount,
+        s"two-pair ($two) should exceed one-pair ($one) by one per-pair charge"
+      )
+  }
+
+  // ===========================================================================
+  // BLS12-381 (bls_verify / bls_aggregate_verify) -- MIRACL keygen + sign.
+  // ===========================================================================
+
+  // Deterministic keypair from an IKM seed. Returns (privateScalar bytes, pkHex 97B).
+  private def blsKeygen(seed: Byte): (Array[Byte], String) = {
+    val ikm = Array.fill[Byte](32)(seed)
+    val s = new Array[Byte](MiraclBls12381.PrivateKeyBytes)
+    val w = new Array[Byte](MiraclBls12381.PublicKeyBytes)
+    BLS.KeyPairGenerate(ikm, s, w)
+    (s, HexBytes.encodeBytes(w))
+  }
+
+  // Sign a message with a private-key scalar, returning the raw 49-byte G1 signature.
+  private def blsSign(s: Array[Byte], msg: Array[Byte]): Array[Byte] = {
+    val sig = new Array[Byte](MiraclBls12381.SignatureBytes)
+    BLS.core_sign(sig, msg, s)
+    sig
+  }
+
+  private val blsMsg: Array[Byte] = "hello, threshold world".getBytes("UTF-8")
+  private val blsMsgHex: String = HexBytes.encodeBytes(blsMsg)
+  private val (blsSk, blsPkHex) = blsKeygen(1.toByte)
+  private val blsSigHex: String = HexBytes.encodeBytes(blsSign(blsSk, blsMsg))
+
+  test("bls_verify roundtrip: KeyPairGenerate -> sign -> verify == true") {
+    evalExpr(s"""{"bls_verify":["$blsPkHex","$blsMsgHex","$blsSigHex"]}""")
+      .map(r => expect(r == Right(BoolValue(true))))
+  }
+
+  test("bls_verify == false for a wrong message") {
+    val otherMsg = HexBytes.encodeBytes("a different message".getBytes("UTF-8"))
+    evalExpr(s"""{"bls_verify":["$blsPkHex","$otherMsg","$blsSigHex"]}""")
+      .map(r => expect(r == Right(BoolValue(false))))
+  }
+
+  test("bls_verify == false for a signature from a different key") {
+    val (sk2, _) = blsKeygen(9.toByte)
+    val wrongSig = HexBytes.encodeBytes(blsSign(sk2, blsMsg))
+    evalExpr(s"""{"bls_verify":["$blsPkHex","$blsMsgHex","$wrongSig"]}""")
+      .map(r => expect(r == Right(BoolValue(false))))
+  }
+
+  test("bls_verify errors on a wrong-width public key") {
+    evalExpr(s"""{"bls_verify":["0xdead","$blsMsgHex","$blsSigHex"]}""").map(r => expect(r.isLeft))
+  }
+
+  // ---- aggregate (same message, N signers) ----
+
+  // Sum a list of raw 49-byte G1 signatures into one aggregate (49-byte) signature.
+  private def aggregateSigs(sigs: List[Array[Byte]]): String = {
+    val acc = ECP.fromBytes(sigs.head)
+    sigs.tail.foreach(s => acc.add(ECP.fromBytes(s)))
+    val out = new Array[Byte](MiraclBls12381.SignatureBytes)
+    acc.toBytes(out, true)
+    HexBytes.encodeBytes(out)
+  }
+
+  private val quorum: List[(Array[Byte], String)] = List(blsKeygen(2), blsKeygen(3), blsKeygen(4))
+  private val quorumPkHexes: List[String] = quorum.map(_._2)
+  private val quorumGoodSigs: List[Array[Byte]] = quorum.map { case (sk, _) => blsSign(sk, blsMsg) }
+  private val quorumAggGood: String = aggregateSigs(quorumGoodSigs)
+
+  private def pksJson(pks: List[String]): String = pks.map(p => "\"" + p + "\"").mkString("[", ",", "]")
+
+  test("bls_aggregate_verify == true for N signers over the same message") {
+    evalExpr(s"""{"bls_aggregate_verify":[${pksJson(quorumPkHexes)},"$blsMsgHex","$quorumAggGood"]}""")
+      .map(r => expect(r == Right(BoolValue(true))))
+  }
+
+  test("bls_aggregate_verify == false when one signer is bad (signs a different message)") {
+    val (badSk, _) = quorum(1)
+    val badSigs = List(quorumGoodSigs.head, blsSign(badSk, "WRONG".getBytes("UTF-8")), quorumGoodSigs(2))
+    val aggBad = aggregateSigs(badSigs)
+    evalExpr(s"""{"bls_aggregate_verify":[${pksJson(quorumPkHexes)},"$blsMsgHex","$aggBad"]}""")
+      .map(r => expect(r == Right(BoolValue(false))))
+  }
+
+  test("bls_aggregate_verify == false when a public key is omitted from the set") {
+    // Aggregate signature includes all 3 signers but only 2 pubkeys are presented.
+    evalExpr(s"""{"bls_aggregate_verify":[${pksJson(quorumPkHexes.take(2))},"$blsMsgHex","$quorumAggGood"]}""")
+      .map(r => expect(r == Right(BoolValue(false))))
+  }
+
+  // ===========================================================================
+  // schnorr_verify -- generate a valid proof in-test using the documented rules.
+  // ===========================================================================
+
+  // proof = R(64B) || s(32B); c = SHA256(R || pk || msg) mod r; s = k + c*x mod r.
+  private def schnorrProve(x: BigInt, msg: Array[Byte], k: BigInt): (String, String) = {
+    val pk = g1.multiply(x.bigInteger)
+    val rPoint = g1.multiply(k.bigInteger)
+    val pkBytes = HexBytes.parseBytes(encG1(pk), Some(64), "pk").fold(throw _, identity)
+    val rBytes = HexBytes.parseBytes(encG1(rPoint), Some(64), "R").fold(throw _, identity)
+    val c = BigInt(1, MessageDigest.getInstance("SHA-256").digest(rBytes ++ pkBytes ++ msg)).mod(R)
+    val s = (k + c * x).mod(R)
+    val sHex = HexBytes.encodeUInt(s, 32).fold(throw _, identity)
+    val proof = "0x" + HexBytes.encodeBytes(rBytes).substring(2) + sHex.substring(2)
+    (encG1(pk), proof)
+  }
+
+  private val schnorrX: BigInt = BigInt("123456789012345678901234567890").mod(R)
+  private val schnorrK: BigInt = BigInt("987654321098765432109876543210").mod(R)
+  private val schnorrMsg: Array[Byte] = "authorize transfer".getBytes("UTF-8")
+  private val schnorrMsgHex: String = HexBytes.encodeBytes(schnorrMsg)
+  private val (schnorrPkHex, schnorrProofHex) = schnorrProve(schnorrX, schnorrMsg, schnorrK)
+
+  test("schnorr_verify == true for a valid proof") {
+    evalExpr(s"""{"schnorr_verify":["$schnorrPkHex","$schnorrMsgHex","$schnorrProofHex"]}""")
+      .map(r => expect(r == Right(BoolValue(true))))
+  }
+
+  test("schnorr_verify == false for a tampered s") {
+    val tampered = {
+      val bytes = HexBytes.parseBytes(schnorrProofHex, Some(96), "p").fold(throw _, identity)
+      bytes(95) = (bytes(95) ^ 0x01).toByte
+      HexBytes.encodeBytes(bytes)
+    }
+    evalExpr(s"""{"schnorr_verify":["$schnorrPkHex","$schnorrMsgHex","$tampered"]}""")
+      .map(r => expect(r == Right(BoolValue(false))))
+  }
+
+  test("schnorr_verify == false for the wrong message") {
+    val otherMsg = HexBytes.encodeBytes("a different action".getBytes("UTF-8"))
+    evalExpr(s"""{"schnorr_verify":["$schnorrPkHex","$otherMsg","$schnorrProofHex"]}""")
+      .map(r => expect(r == Right(BoolValue(false))))
+  }
+
+  test("schnorr_verify errors on a wrong-width proof") {
+    evalExpr(s"""{"schnorr_verify":["$schnorrPkHex","$schnorrMsgHex","0xdead"]}""").map(r => expect(r.isLeft))
+  }
+
+  // ---- SOUNDNESS: identity / point-at-infinity public-key forgery ----
+  //
+  // With pk = O the verification equation `s*G == R + c*pk` collapses to
+  // `s*G == R`. An attacker forges a "signature" for ANY message by picking a
+  // scalar s, computing R = s*G, and setting pk = O (the all-zero 64-byte G1).
+  // PRE-fix this verified `true` (universal forgery); POST-fix it MUST be
+  // `false` (identity pk is correct-width but cryptographically invalid -> a
+  // value, NOT a Result error). This mirrors the Rust differential vector
+  // "identity-pk forgery rejected" in shared/zk_opcode_test_vectors.json and
+  // must stay byte-identical.
+
+  // Forge: choose s, set R = s*G, pk = O, arbitrary msg; proof = R(64B) || s(32B).
+  private def schnorrIdentityForgery(s: BigInt, msg: Array[Byte]): (String, String, String) = {
+    val pkHex = "0x" + "0" * 128 // identity O = all-zero 64-byte G1
+    val rPoint = g1.multiply(s.bigInteger) // R = s*G
+    val rBytes = HexBytes.parseBytes(encG1(rPoint), Some(64), "R").fold(throw _, identity)
+    val sHex = HexBytes.encodeUInt(s, 32).fold(throw _, identity)
+    val proof = "0x" + HexBytes.encodeBytes(rBytes).substring(2) + sHex.substring(2)
+    val msgHex = HexBytes.encodeBytes(msg)
+    (pkHex, msgHex, proof)
+  }
+
+  private val (forgePkHex, forgeMsgHex, forgeProofHex) =
+    schnorrIdentityForgery(BigInt(123456789), "authorize transfer".getBytes("UTF-8"))
+
+  test("schnorr_verify == false for an identity (point-at-infinity) public-key forgery") {
+    // Lock byte-identity with the shared Rust differential vector.
+    val expectedProofHex =
+      "0x142a7688cf05c29f7593351e1b86eb87e3ad5dcb1b0fc3d853e9852040c57019" +
+      "136b5d7e238ae6edc22d1fba5a2dcde8a7b0df53b0c4af7f600e6a0c4610c899" +
+      "00000000000000000000000000000000000000000000000000000000075bcd15"
+    val vectorMatch =
+      expect(forgePkHex == "0x" + "0" * 128) &&
+      expect(forgeMsgHex == "0x617574686f72697a65207472616e73666572") &&
+      expect(forgeProofHex == expectedProofHex)
+    for {
+      r <- evalExpr(s"""{"schnorr_verify":["$forgePkHex","$forgeMsgHex","$forgeProofHex"]}""")
+    } yield vectorMatch && expect(r == Right(BoolValue(false)))
+  }
+
+  // ===========================================================================
+  // Worked example: a BLS threshold gate evaluated end-to-end.
+  // ===========================================================================
+
+  private def thresholdGate(pks: List[String], aggSig: String): String =
+    s"""
+       |{"if":[
+       |  {"bls_aggregate_verify":[${pksJson(pks)},"$blsMsgHex","$aggSig"]},
+       |  "authorized",
+       |  "rejected"
+       |]}
+       |""".stripMargin
+
+  test("worked example: threshold gate returns 'authorized' for a valid quorum") {
+    evalExpr(thresholdGate(quorumPkHexes, quorumAggGood))
+      .map(r => expect(r == Right(StrValue("authorized"))))
+  }
+
+  test("worked example: threshold gate returns 'rejected' when a signer is bad") {
+    val (badSk, _) = quorum(2)
+    val badSigs = List(quorumGoodSigs.head, quorumGoodSigs(1), blsSign(badSk, "nope".getBytes("UTF-8")))
+    val aggBad = aggregateSigs(badSigs)
+    evalExpr(thresholdGate(quorumPkHexes, aggBad))
+      .map(r => expect(r == Right(StrValue("rejected"))))
+  }
+
+  // A direct sanity check that our pairing-based aggregate relation matches MIRACL's
+  // own single core_verify when N = 1 (defends the relation, not just the wrapper).
+  pureTest("aggregate relation matches MIRACL core_verify for a single signer") {
+    val singleAgg = aggregateSigs(List(quorumGoodSigs.head))
+    val viaAggregate = CryptoOps.blsAggregateVerify(
+      List(
+        ArrayValue(List(StrValue(quorumPkHexes.head))),
+        StrValue(blsMsgHex),
+        StrValue(singleAgg)
+      )
+    )
+    val sigBytes = HexBytes.parseBytes(singleAgg, Some(49), "s").fold(throw _, identity)
+    val pkBytes = HexBytes.parseBytes(quorumPkHexes.head, Some(97), "p").fold(throw _, identity)
+    val viaMiracl = BLS.core_verify(sigBytes, blsMsg, pkBytes) == BLS.BLS_OK
+    expect(viaAggregate == Right(BoolValue(true))) && expect(viaMiracl)
+  }
+}


### PR DESCRIPTION
## What

Wave-2 ZK/crypto opcodes for the JLVM: `bn254_add`, `bn254_mul`, `bn254_pairing` (EIP-196/197 semantics), `bls_verify`, `bls_aggregate_verify`, and `schnorr_verify`. Stacked after #28 (now merged); the diff shows only the wave-2 additions.

## Reviewer questions (ryle-ai)

**Vendored crypto provenance.**
- Besu `altbn128`: copied Apache-2.0 from `hyperledger/besu` package `org.hyperledger.besu.crypto.altbn128` (the EIP-196/197 mainnet precompile implementation); only change is removing Guava/Tuweni so it's JDK-only. Provenance documented in `src/main/java/org/hyperledger/besu/crypto/altbn128/README.md` (landed in #25/#21).
- MIRACL Core: generated Java sources (ED25519/BN254/BLS12381) vendored per MIRACL's source-generator distribution model (#25). At the stack tip only `ED25519` (ECVRF) is load-bearing; MIRACL BN254 (≠ alt_bn128) and MIRACL BLS12381 (superseded by #33) are queued for deletion in the post-merge cleanup pass.

**Rogue-key defense for `bls_aggregate_verify`.** This PR's BLS lands on MIRACL; the immediate follow-up #33 (fix/bls-eth2) reworks it to the **eth2 proof-of-possession ciphersuite** (`BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`) on BouncyCastle 1.85, byte-matching tessellation-bls. `bls_aggregate_verify` is fastAggregateVerify (one message, n pubkeys), which is **only safe under PoP registration** — that responsibility sits with the calling contract/protocol and is documented at the opcode. Identity-point pubkeys/signatures are rejected.

**Schnorr scheme.** Custom BN254-G1 Schnorr matching the Rust `jlvm-core` implementation byte-for-byte: pk = 64-byte uncompressed G1 (validated on-curve, identity rejected), proof = 96 bytes (R ‖ s), challenge = SHA-256 → scalar mod r. Validated by shared cross-language KAT vectors (`shared/zk_opcode_test_vectors.json`) incl. adversarial cases (identity pk, tampered proof, off-curve points). It is deliberately *not* BIP-340 (different curve); naming/docs say so.

**Pairing gas.** `bn254_pairing` = 45,000 base + **35,000 per pair** (size-scaled); `bls_aggregate_verify` = 120,000 + 15,000/key; `schnorr_verify` = 45,000. Rationale comments in `GasMetering.scala`. Known improvement (tracked): per-element costs are currently charged post-execution; moving to pre-charge from argument sizes is queued in the hardening backlog.

## Hardening in this PR

bn254 G2 inputs are checked for **subgroup membership** (G2 cofactor ≠ 1; on-curve alone is insufficient), coordinates validated < P, malformed encodings are JLVM errors while valid-but-failing verification returns `false` (error-vs-false discipline, byte-matched with Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)