### PR TITLE
test(json_logic): Scala shared-vector conformance runner (3-way base cross-check)

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
@@ -298,7 +298,9 @@ object JsonLogicSemantics {
             case FloatValue(l) :: FloatValue(r) :: Nil => l != r
             case ArrayValue(l) :: ArrayValue(r) :: Nil => l != r
             case MapValue(l) :: MapValue(r) :: Nil     => l != r
-            case _                                     => false
+            // `!==` is the negation of `===`: values of mismatched types are NOT strictly equal, hence strictly
+            // not-equal. Matches the JSON Logic reference / TS (`!==` === `!(===)`).
+            case _ => true
           }
           (BoolValue(boolResult): JsonLogicValue).pure[Result].asRight[JsonLogicException]
         }
@@ -756,6 +758,9 @@ object JsonLogicSemantics {
 
         args.withMetrics {
           case NullValue :: FunctionValue(_) :: Nil => (BoolValue(false): JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
+          // `all` over an EMPTY array is false (JSON Logic reference / TS), not vacuously true.
+          case ArrayValue(Nil) :: FunctionValue(_) :: Nil =>
+            (BoolValue(false): JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
           case ArrayValue(arr) :: FunctionValue(expr) :: Nil => impl(arr, expr)
           case _ => JsonLogicException(s"Unexpected input to ${AllOp.tag}, got $values").asLeft[Result[JsonLogicValue]].pure[F]
         }

--- a/src/test/resources/conformance/README.md
+++ b/src/test/resources/conformance/README.md
@@ -1,0 +1,33 @@
+# JSON Logic cross-language conformance vectors
+
+`json_logic_test_vectors.json` is synced from
+`metakit-sdk/shared/json_logic_test_vectors.json` — the cross-language source of
+truth for the base JSON Logic VM. Keep it in sync.
+
+The same vectors are executed by:
+
+- Rust: `metakit-sdk/rust/jlvm-core/tests/differential.rs`
+- TypeScript: `metakit-sdk/packages/typescript/tests/json-logic-vectors.test.ts`
+- Scala (this repo): `src/test/scala/json_logic/SharedVectorConformanceSuite.scala`
+
+All three implementations must agree on every case. When updating semantics or
+adding vectors, update the shared file in `metakit-sdk` first, then re-copy it
+here so the three suites stay aligned.
+
+Format:
+
+```json
+{
+  "description": "...",
+  "version": "1.0.0",
+  "tests": [
+    { "category": "...", "cases": [ { "expr": "...", "data": "...", "expected": "..." } ] }
+  ]
+}
+```
+
+`expr`, `data`, and `expected` are JSON-encoded strings (the harness parses them).
+The `expected` strings use a specific textual JSON form (spaces after `,` and `:`,
+e.g. `[1, 2, 3]` and `{"a": 1, "b": 2}`); the Scala suite renders results in that
+same form and additionally performs a structural (numbers-by-value) comparison to
+match the Rust/TypeScript oracles.

--- a/src/test/resources/conformance/json_logic_test_vectors.json
+++ b/src/test/resources/conformance/json_logic_test_vectors.json
@@ -1,0 +1,238 @@
+{
+  "description": "JSON Logic VM test vectors for cross-language compatibility",
+  "version": "1.0.0",
+  "tests": [
+    {
+      "category": "constants",
+      "cases": [
+        { "expr": "null", "data": "{}", "expected": "null" },
+        { "expr": "true", "data": "{}", "expected": "true" },
+        { "expr": "false", "data": "{}", "expected": "false" },
+        { "expr": "42", "data": "{}", "expected": "42" },
+        { "expr": "3.14", "data": "{}", "expected": "3.14" },
+        { "expr": "\"hello\"", "data": "{}", "expected": "\"hello\"" },
+        { "expr": "[1, 2, 3]", "data": "{}", "expected": "[1, 2, 3]" },
+        { "expr": "{\"a\": 1, \"b\": 2}", "data": "{}", "expected": "{\"a\": 1, \"b\": 2}" }
+      ]
+    },
+    {
+      "category": "var",
+      "cases": [
+        { "expr": "{\"var\": \"x\"}", "data": "{\"x\": 42}", "expected": "42" },
+        { "expr": "{\"var\": \"a.b\"}", "data": "{\"a\": {\"b\": \"nested\"}}", "expected": "\"nested\"" },
+        { "expr": "{\"var\": \"\"}", "data": "{\"x\": 1}", "expected": "{\"x\": 1}" },
+        { "expr": "{\"var\": [\"missing\", \"default\"]}", "data": "{}", "expected": "\"default\"" },
+        { "expr": "{\"var\": 0}", "data": "[\"first\", \"second\"]", "expected": "\"first\"" },
+        { "expr": "{\"var\": \"a.b.c\"}", "data": "{\"a\": {\"b\": {\"c\": 123}}}", "expected": "123" },
+        { "expr": "{\"var\": \"missing\"}", "data": "{\"x\": 1}", "expected": "null" }
+      ]
+    },
+    {
+      "category": "arithmetic",
+      "cases": [
+        { "expr": "{\"+\": [1, 2]}", "data": "{}", "expected": "3" },
+        { "expr": "{\"+\": [1, 2, 3]}", "data": "{}", "expected": "6" },
+        { "expr": "{\"-\": [5, 3]}", "data": "{}", "expected": "2" },
+        { "expr": "{\"-\": [5]}", "data": "{}", "expected": "-5" },
+        { "expr": "{\"*\": [2, 3]}", "data": "{}", "expected": "6" },
+        { "expr": "{\"*\": [2, 3, 4]}", "data": "{}", "expected": "24" },
+        { "expr": "{\"/\": [10, 2]}", "data": "{}", "expected": "5" },
+        { "expr": "{\"/\": [7, 2]}", "data": "{}", "expected": "3.5" },
+        { "expr": "{\"%\": [10, 3]}", "data": "{}", "expected": "1" },
+        { "expr": "{\"max\": [1, 2, 3]}", "data": "{}", "expected": "3" },
+        { "expr": "{\"min\": [1, 2, 3]}", "data": "{}", "expected": "1" },
+        { "expr": "{\"abs\": [-5]}", "data": "{}", "expected": "5" },
+        { "expr": "{\"round\": [2.6]}", "data": "{}", "expected": "3" },
+        { "expr": "{\"floor\": [2.9]}", "data": "{}", "expected": "2" },
+        { "expr": "{\"ceil\": [2.1]}", "data": "{}", "expected": "3" },
+        { "expr": "{\"pow\": [2, 3]}", "data": "{}", "expected": "8" }
+      ]
+    },
+    {
+      "category": "comparison",
+      "cases": [
+        { "expr": "{\"==\": [1, 1]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"==\": [1, \"1\"]}", "data": "{}", "expected": "true", "note": "loose equality with coercion" },
+        { "expr": "{\"==\": [1, 2]}", "data": "{}", "expected": "false" },
+        { "expr": "{\"===\": [1, 1]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"===\": [1, \"1\"]}", "data": "{}", "expected": "false", "note": "strict equality - no coercion" },
+        { "expr": "{\"!=\": [1, 2]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"!==\": [1, \"1\"]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"<\": [1, 2]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"<=\": [2, 2]}", "data": "{}", "expected": "true" },
+        { "expr": "{\">\": [3, 2]}", "data": "{}", "expected": "true" },
+        { "expr": "{\">=\": [2, 2]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"<\": [1, 2, 3]}", "data": "{}", "expected": "true", "note": "chained comparison" },
+        { "expr": "{\"<\": [1, 3, 2]}", "data": "{}", "expected": "false", "note": "chained comparison fails" }
+      ]
+    },
+    {
+      "category": "strict_equality_int_vs_float",
+      "note": "Key metakit semantic: 1 !== 1.0 (IntValue vs FloatValue)",
+      "cases": [
+        { "expr": "{\"===\": [1, 1]}", "data": "{}", "expected": "true", "note": "int === int" },
+        { "expr": "{\"===\": [1.0, 1.0]}", "data": "{}", "expected": "true", "note": "float === float" },
+        { "expr": "{\"===\": [1, 1.5]}", "data": "{}", "expected": "false", "note": "int !== float (different values)" },
+        { "expr": "{\"==\": [1, 1.0]}", "data": "{}", "expected": "true", "note": "loose equality coerces" }
+      ]
+    },
+    {
+      "category": "logic",
+      "cases": [
+        { "expr": "{\"!\": [true]}", "data": "{}", "expected": "false" },
+        { "expr": "{\"!\": [false]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"!\": [0]}", "data": "{}", "expected": "true", "note": "0 is falsy" },
+        { "expr": "{\"!\": [\"\"]}", "data": "{}", "expected": "true", "note": "empty string is falsy" },
+        { "expr": "{\"!!\": [1]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"!!\": [0]}", "data": "{}", "expected": "false" },
+        { "expr": "{\"and\": [true, true]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"and\": [true, false]}", "data": "{}", "expected": "false" },
+        { "expr": "{\"and\": [1, 2, 3]}", "data": "{}", "expected": "3", "note": "returns last truthy" },
+        { "expr": "{\"and\": [1, 0, 3]}", "data": "{}", "expected": "0", "note": "returns first falsy" },
+        { "expr": "{\"or\": [false, true]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"or\": [false, false]}", "data": "{}", "expected": "false" },
+        { "expr": "{\"or\": [0, 1, 2]}", "data": "{}", "expected": "1", "note": "returns first truthy" }
+      ]
+    },
+    {
+      "category": "control_flow",
+      "cases": [
+        { "expr": "{\"if\": [true, \"yes\", \"no\"]}", "data": "{}", "expected": "\"yes\"" },
+        { "expr": "{\"if\": [false, \"yes\", \"no\"]}", "data": "{}", "expected": "\"no\"" },
+        { "expr": "{\"if\": [false, \"a\", true, \"b\", \"c\"]}", "data": "{}", "expected": "\"b\"", "note": "else-if chain" },
+        { "expr": "{\"if\": [false, \"a\", false, \"b\", \"c\"]}", "data": "{}", "expected": "\"c\"", "note": "falls through to else" },
+        { "expr": "{\"default\": [null, \"\", 0, \"fallback\"]}", "data": "{}", "expected": "\"fallback\"" },
+        { "expr": "{\"default\": [null, \"found\"]}", "data": "{}", "expected": "\"found\"" }
+      ]
+    },
+    {
+      "category": "string",
+      "cases": [
+        { "expr": "{\"cat\": [\"hello\", \" \", \"world\"]}", "data": "{}", "expected": "\"hello world\"" },
+        { "expr": "{\"substr\": [\"hello\", 0, 2]}", "data": "{}", "expected": "\"he\"" },
+        { "expr": "{\"substr\": [\"hello\", -2]}", "data": "{}", "expected": "\"lo\"", "note": "negative start" },
+        { "expr": "{\"lower\": [\"HELLO\"]}", "data": "{}", "expected": "\"hello\"" },
+        { "expr": "{\"upper\": [\"hello\"]}", "data": "{}", "expected": "\"HELLO\"" },
+        { "expr": "{\"trim\": [\"  hello  \"]}", "data": "{}", "expected": "\"hello\"" },
+        { "expr": "{\"split\": [\"a-b-c\", \"-\"]}", "data": "{}", "expected": "[\"a\", \"b\", \"c\"]" },
+        { "expr": "{\"startsWith\": [\"hello\", \"he\"]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"endsWith\": [\"hello\", \"lo\"]}", "data": "{}", "expected": "true" }
+      ]
+    },
+    {
+      "category": "array",
+      "cases": [
+        { "expr": "{\"merge\": [[1, 2], [3, 4]]}", "data": "{}", "expected": "[1, 2, 3, 4]" },
+        { "expr": "{\"in\": [2, [1, 2, 3]]}", "data": "{}", "expected": "true" },
+        { "expr": "{\"in\": [\"world\", \"hello world\"]}", "data": "{}", "expected": "true", "note": "substring check" },
+        { "expr": "{\"slice\": [[1, 2, 3, 4], 1, 3]}", "data": "{}", "expected": "[2, 3]" },
+        { "expr": "{\"reverse\": [[1, 2, 3]]}", "data": "{}", "expected": "[3, 2, 1]" },
+        { "expr": "{\"unique\": [[1, 2, 2, 3, 3, 3]]}", "data": "{}", "expected": "[1, 2, 3]" },
+        { "expr": "{\"flatten\": [[[1, 2], [3, 4]]]}", "data": "{}", "expected": "[1, 2, 3, 4]" }
+      ]
+    },
+    {
+      "category": "array_iteration",
+      "cases": [
+        { 
+          "expr": "{\"map\": [{\"var\": \"items\"}, {\"*\": [{\"var\": \"\"}, 2]}]}", 
+          "data": "{\"items\": [1, 2, 3]}", 
+          "expected": "[2, 4, 6]",
+          "note": "var '' returns current item"
+        },
+        { 
+          "expr": "{\"filter\": [{\"var\": \"items\"}, {\">\": [{\"var\": \"\"}, 2]}]}", 
+          "data": "{\"items\": [1, 2, 3, 4]}", 
+          "expected": "[3, 4]"
+        },
+        { 
+          "expr": "{\"reduce\": [{\"var\": \"items\"}, {\"+\": [{\"var\": \"accumulator\"}, {\"var\": \"current\"}]}, 0]}", 
+          "data": "{\"items\": [1, 2, 3, 4]}", 
+          "expected": "10"
+        },
+        { 
+          "expr": "{\"all\": [{\"var\": \"items\"}, {\">\": [{\"var\": \"\"}, 0]}]}", 
+          "data": "{\"items\": [1, 2, 3]}", 
+          "expected": "true"
+        },
+        { 
+          "expr": "{\"some\": [{\"var\": \"items\"}, {\">\": [{\"var\": \"\"}, 2]}]}", 
+          "data": "{\"items\": [1, 2, 3]}", 
+          "expected": "true"
+        },
+        { 
+          "expr": "{\"none\": [{\"var\": \"items\"}, {\"<\": [{\"var\": \"\"}, 0]}]}", 
+          "data": "{\"items\": [1, 2, 3]}", 
+          "expected": "true"
+        },
+        { 
+          "expr": "{\"all\": [[], {\">\": [{\"var\": \"\"}, 0]}]}", 
+          "data": "{}", 
+          "expected": "false",
+          "note": "all on empty array returns false"
+        }
+      ]
+    },
+    {
+      "category": "object",
+      "cases": [
+        { "expr": "{\"keys\": [{\"var\": \"obj\"}]}", "data": "{\"obj\": {\"a\": 1, \"b\": 2}}", "expected": "[\"a\", \"b\"]" },
+        { "expr": "{\"values\": [{\"var\": \"obj\"}]}", "data": "{\"obj\": {\"a\": 1, \"b\": 2}}", "expected": "[1, 2]" },
+        { "expr": "{\"get\": [{\"var\": \"obj\"}, \"a\"]}", "data": "{\"obj\": {\"a\": 42}}", "expected": "42" },
+        { "expr": "{\"get\": [{\"var\": \"obj\"}, \"missing\", \"default\"]}", "data": "{\"obj\": {}}", "expected": "\"default\"" },
+        { "expr": "{\"has\": [{\"var\": \"obj\"}, \"a\"]}", "data": "{\"obj\": {\"a\": 1}}", "expected": "true" },
+        { "expr": "{\"has\": [{\"var\": \"obj\"}, \"missing\"]}", "data": "{\"obj\": {}}", "expected": "false" }
+      ]
+    },
+    {
+      "category": "typeof",
+      "cases": [
+        { "expr": "{\"typeof\": [42]}", "data": "{}", "expected": "\"int\"" },
+        { "expr": "{\"typeof\": [3.14]}", "data": "{}", "expected": "\"float\"" },
+        { "expr": "{\"typeof\": [\"hello\"]}", "data": "{}", "expected": "\"string\"" },
+        { "expr": "{\"typeof\": [true]}", "data": "{}", "expected": "\"bool\"" },
+        { "expr": "{\"typeof\": [null]}", "data": "{}", "expected": "\"null\"" },
+        { "expr": "{\"typeof\": [{\"var\": \"arr\"}]}", "data": "{\"arr\": [1, 2]}", "expected": "\"array\"" },
+        { "expr": "{\"typeof\": [{\"var\": \"obj\"}]}", "data": "{\"obj\": {\"a\": 1}}", "expected": "\"map\"" }
+      ]
+    },
+    {
+      "category": "let_bindings",
+      "cases": [
+        { 
+          "expr": "{\"let\": [{\"x\": 5}, {\"var\": \"x\"}]}", 
+          "data": "{}", 
+          "expected": "5"
+        },
+        { 
+          "expr": "{\"let\": [{\"x\": 5}, {\"+\": [{\"var\": \"x\"}, 1]}]}", 
+          "data": "{}", 
+          "expected": "6"
+        },
+        { 
+          "expr": "{\"let\": [{\"doubled\": {\"*\": [{\"var\": \"x\"}, 2]}}, {\"+\": [{\"var\": \"doubled\"}, 1]}]}", 
+          "data": "{\"x\": 5}", 
+          "expected": "11",
+          "note": "bindings can reference outer scope"
+        }
+      ]
+    },
+    {
+      "category": "complex",
+      "cases": [
+        {
+          "expr": "{\"if\": [{\">\": [{\"var\": \"score\"}, 90]}, \"A\", {\">\": [{\"var\": \"score\"}, 80]}, \"B\", {\">\": [{\"var\": \"score\"}, 70]}, \"C\", \"F\"]}",
+          "data": "{\"score\": 85}",
+          "expected": "\"B\"",
+          "note": "grade calculator"
+        },
+        {
+          "expr": "{\"map\": [{\"var\": \"users\"}, {\"cat\": [{\"var\": \"name\"}, \" (\", {\"var\": \"age\"}, \")\"]}]}",
+          "data": "{\"users\": [{\"name\": \"Alice\", \"age\": 30}, {\"name\": \"Bob\", \"age\": 25}]}",
+          "expected": "[\"Alice (30)\", \"Bob (25)\"]",
+          "note": "transform objects to strings"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/scala/json_logic/JsonLogicSpec.scala
+++ b/src/test/scala/json_logic/JsonLogicSpec.scala
@@ -610,7 +610,7 @@ object JsonLogicSpec extends SimpleIOSuite with Checkers {
     }
   }
 
-  test("!== can test strict not-equal with type coercion for un-like types") {
+  test("!== is strict not-equal: un-like types are not strictly equal (=> true)") {
     val exprStr =
       """
         |{"!==" : [1, "1"]}
@@ -623,7 +623,7 @@ object JsonLogicSpec extends SimpleIOSuite with Checkers {
 
     parseTestJson(exprStr, dataStr).flatMap {
       case (expr, data) =>
-        staticTestRunner(expr, data, BoolValue(false))
+        staticTestRunner(expr, data, BoolValue(true))
     }
   }
 
@@ -2971,6 +2971,16 @@ object JsonLogicSpec extends SimpleIOSuite with Checkers {
     parseTestJson(exprStr, dataStr).flatMap {
       case (expr, data) =>
         expectError(expr, data)
+    }
+  }
+
+  test("`all` over an empty array is false (not vacuously true)") {
+    val exprStr = """{"all": [[], {">": [{"var": ""}, 0]}]}"""
+    val dataStr = """null"""
+
+    parseTestJson(exprStr, dataStr).flatMap {
+      case (expr, data) =>
+        staticTestRunner(expr, data, BoolValue(false))
     }
   }
 

--- a/src/test/scala/json_logic/SharedVectorConformanceSuite.scala
+++ b/src/test/scala/json_logic/SharedVectorConformanceSuite.scala
@@ -1,0 +1,230 @@
+package json_logic
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.json_logic.core.JsonLogicValue.showJsonLogicValue
+import io.constellationnetwork.metagraph_sdk.json_logic.core._
+import io.constellationnetwork.metagraph_sdk.json_logic.runtime.JsonLogicEvaluator
+
+import io.circe.{Decoder, parser}
+import weaver.SimpleIOSuite
+
+/**
+ * Cross-language conformance suite for the base JSON Logic VM.
+ *
+ * Runs the SHARED test vectors that are also executed by the Rust
+ * (`metakit-sdk/rust/jlvm-core/tests/differential.rs`) and TypeScript
+ * (`metakit-sdk/packages/typescript/tests/json-logic-vectors.test.ts`)
+ * implementations. The vector file is the cross-language source of truth, synced
+ * from `metakit-sdk/shared/json_logic_test_vectors.json` into
+ * `src/test/resources/conformance/json_logic_test_vectors.json`.
+ *
+ * Comparison strategy (matched to the Rust/TS oracles):
+ *
+ *   1. STRUCTURAL (primary): the `expected` string is parsed as JSON into a
+ *      [[JsonLogicValue]] and compared against the evaluated value with numbers
+ *      compared by value (int-vs-float tolerant), exactly like Rust's
+ *      `json_struct_eq` and TS's `toEqual`. This is the authoritative assertion.
+ *
+ *   2. TEXTUAL (secondary): the evaluated value is rendered via `Show` into the
+ *      same textual JSON form the vectors use (spaces after `,` and `:`,
+ *      e.g. `[1, 2, 3]` / `{"a": 1, "b": 2}`) and is checked to equal the raw
+ *      `expected` string. This guards the exact rendering format.
+ *
+ * One weaver test is registered per category; each reports per-case pass/fail.
+ */
+object SharedVectorConformanceSuite extends SimpleIOSuite {
+
+  private val VectorsPath = "src/test/resources/conformance/json_logic_test_vectors.json"
+
+  final case class Vectors(description: String, version: String, tests: List[Category])
+  final case class Category(category: String, note: Option[String], cases: List[VecCase])
+  final case class VecCase(expr: String, data: String, expected: String, note: Option[String])
+
+  private implicit val caseDecoder: Decoder[VecCase] = Decoder.forProduct4(
+    "expr",
+    "data",
+    "expected",
+    "note"
+  )(VecCase.apply)
+
+  private implicit val categoryDecoder: Decoder[Category] = Decoder.forProduct3(
+    "category",
+    "note",
+    "cases"
+  )(Category.apply)
+
+  private implicit val vectorsDecoder: Decoder[Vectors] = Decoder.forProduct3(
+    "description",
+    "version",
+    "tests"
+  )(Vectors.apply)
+
+  // Loaded eagerly so tests can be registered per category during object init.
+  private val vectors: Vectors = {
+    val raw = new String(Files.readAllBytes(Paths.get(VectorsPath)), StandardCharsets.UTF_8)
+    parser
+      .parse(raw)
+      .flatMap(_.as[Vectors])
+      .fold(err => throw new RuntimeException(s"Failed to load shared vectors: $err"), identity)
+  }
+
+  /**
+   * Structural, numbers-by-value comparison, mirroring Rust's `json_struct_eq`
+   * and the TS harness's `toEqual`. Maps and arrays are compared deeply; numeric
+   * leaves compare by BigDecimal value so `IntValue(5)` matches `FloatValue(5.0)`.
+   */
+  private def structEq(a: JsonLogicValue, b: JsonLogicValue): Boolean =
+    (a, b) match {
+      case (NullValue, NullValue)         => true
+      case (BoolValue(x), BoolValue(y))   => x == y
+      case (StrValue(x), StrValue(y))     => x == y
+      case (IntValue(x), IntValue(y))     => x == y
+      case (FloatValue(x), FloatValue(y)) => x == y
+      case (IntValue(x), FloatValue(y))   => BigDecimal(x) == y
+      case (FloatValue(x), IntValue(y))   => x == BigDecimal(y)
+      case (ArrayValue(xs), ArrayValue(ys)) =>
+        xs.length == ys.length && xs.zip(ys).forall { case (p, q) => structEq(p, q) }
+      case (MapValue(xs), MapValue(ys)) =>
+        xs.keySet == ys.keySet && xs.keys.forall(k => structEq(xs(k), ys(k)))
+      case _ => false
+    }
+
+  /**
+   * Known cross-language divergences: cases the shared vectors (and the Rust/TS
+   * reference impls) cover but the Scala JLVM does NOT yet implement. These are
+   * REAL discrepancies (not explained by any unmerged fix). Per the conformance
+   * policy we do not alter the vectors or the JLVM semantics here; instead we
+   * record each divergence so the suite stays green while keeping the gap loud:
+   * if a listed case ever starts passing, the suite FAILS, signaling that the
+   * entry must be removed.
+   *
+   * Keyed by (category, raw expr string). Documented for review:
+   *
+   *   - object / `{"get": [map, key, default]}`: Scala `get` only accepts the
+   *     2-arg `[map, key]` form (missing key -> null) and errors on a 3rd
+   *     `default` arg. Rust/TS accept the 3-arg default form
+   *     (see metakit-sdk rust/jlvm-core/src/eval.rs::op_get, which explicitly
+   *     notes "Scala handleGetOp only supports [Map, Str]").
+   *
+   *   - let_bindings / object-form `{"let": [{name: expr, ...}, result]}`: Scala
+   *     `let` only accepts the array-of-pairs form
+   *     `{"let": [[[name, expr], ...], result]}`. Rust/TS additionally accept the
+   *     object form used by the vectors
+   *     (see rust/jlvm-core/src/eval.rs::eval_let "convenience object form ...
+   *     as used by the conformance vectors").
+   */
+  private val KnownDivergences: Set[(String, String)] = Set(
+    "object" -> """{"get": [{"var": "obj"}, "missing", "default"]}""",
+    "let_bindings" -> """{"let": [{"x": 5}, {"var": "x"}]}""",
+    "let_bindings" -> """{"let": [{"x": 5}, {"+": [{"var": "x"}, 1]}]}""",
+    "let_bindings" -> """{"let": [{"doubled": {"*": [{"var": "x"}, 2]}}, {"+": [{"var": "doubled"}, 1]}]}"""
+  )
+
+  private final case class CaseOutcome(
+    category:     String,
+    expr:         String,
+    label:        String,
+    structPass:   Boolean,
+    textPass:     Boolean,
+    detail:       String
+  ) {
+    def isKnownDivergence: Boolean = KnownDivergences.contains((category, expr))
+  }
+
+  private def runCase(category: String, c: VecCase): IO[CaseOutcome] = {
+    val label = c.note.fold(c.expr)(n => s"${c.expr}  ($n)")
+
+    def outcome(structPass: Boolean, textPass: Boolean, detail: String): CaseOutcome =
+      CaseOutcome(category, c.expr, label, structPass, textPass, detail)
+
+    val parsed: Either[String, (JsonLogicExpression, JsonLogicValue, JsonLogicValue)] =
+      for {
+        exprJson     <- parser.parse(c.expr).left.map(e => s"EXPR-PARSE: ${e.getMessage}")
+        expr         <- exprJson.as[JsonLogicExpression].left.map(e => s"EXPR-DECODE: ${e.getMessage}")
+        dataJson     <- parser.parse(c.data).left.map(e => s"DATA-PARSE: ${e.getMessage}")
+        data         <- dataJson.as[JsonLogicValue].left.map(e => s"DATA-DECODE: ${e.getMessage}")
+        expectedJson <- parser.parse(c.expected).left.map(e => s"EXPECTED-PARSE: ${e.getMessage}")
+        expected     <- expectedJson.as[JsonLogicValue].left.map(e => s"EXPECTED-DECODE: ${e.getMessage}")
+      } yield (expr, data, expected)
+
+    parsed match {
+      case Left(err) =>
+        IO.pure(outcome(structPass = false, textPass = false, s"$label\n    $err"))
+      case Right((expr, data, expected)) =>
+        JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, data, None).map {
+          case Left(evalErr) =>
+            outcome(structPass = false, textPass = false, s"$label\n    EVAL-ERR: ${evalErr.getMessage}")
+          case Right(result) =>
+            val sOk      = structEq(result, expected)
+            val rendered = showJsonLogicValue.show(result)
+            val tOk      = rendered == c.expected
+            val detail =
+              s"""$label
+                 |    data     = ${c.data}
+                 |    expected = ${c.expected}
+                 |    got      = $rendered
+                 |    struct=${if (sOk) "ok" else "FAIL"} text=${if (tOk) "ok" else "FAIL"}""".stripMargin
+            outcome(structPass = sOk, textPass = tOk, detail)
+        }
+    }
+  }
+
+  // Register one weaver test per category.
+  vectors.tests.foreach { cat =>
+    test(s"[${cat.category}] shared vectors") {
+      cat.cases.traverseOutcomes(cat.category).map { outcomes =>
+        val total      = outcomes.length
+        val structPass = outcomes.count(_.structPass)
+        val textPass   = outcomes.count(_.textPass)
+
+        val (known, enforced) = outcomes.partition(_.isKnownDivergence)
+
+        // Enforced cases (everything not on the documented-divergence allowlist)
+        // MUST pass. Structural is authoritative (matches the Rust/TS oracles);
+        // textual is a secondary rendering-format check.
+        val structFailures   = enforced.filterNot(_.structPass)
+        val textOnlyFailures = enforced.filter(o => o.structPass && !o.textPass)
+
+        // xfail guard: each known divergence must STILL be failing. If one starts
+        // passing, the JLVM gained the feature and the allowlist entry is stale —
+        // fail loudly so it gets removed.
+        val resolvedDivergences = known.filter(_.structPass)
+
+        val header =
+          s"[${cat.category}] struct ${structPass}/${total}, text ${textPass}/${total}" +
+            (if (known.nonEmpty) s", known-divergences ${known.length}" else "")
+
+        val structMsg =
+          if (structFailures.isEmpty) ""
+          else "\n  structural failures:\n" + structFailures.map(o => "  " + o.detail).mkString("\n")
+        val textMsg =
+          if (textOnlyFailures.isEmpty) ""
+          else "\n  textual-only divergences:\n" + textOnlyFailures.map(o => "  " + o.detail).mkString("\n")
+        val resolvedMsg =
+          if (resolvedDivergences.isEmpty) ""
+          else
+            "\n  known-divergence(s) now PASSING (remove from KnownDivergences):\n" +
+              resolvedDivergences.map(o => "  " + o.detail).mkString("\n")
+
+        expect(structFailures.isEmpty, s"$header$structMsg$textMsg")
+          .and(expect(textOnlyFailures.isEmpty, s"$header$structMsg$textMsg"))
+          .and(expect(resolvedDivergences.isEmpty, s"$header$resolvedMsg"))
+      }
+    }
+  }
+
+  // Small helper to evaluate all cases in a category sequentially.
+  private implicit class CaseListOps(cs: List[VecCase]) {
+    def traverseOutcomes(category: String): IO[List[CaseOutcome]] =
+      cs.foldRight(IO.pure(List.empty[CaseOutcome])) { (c, acc) =>
+        for {
+          o    <- runCase(category, c)
+          rest <- acc
+        } yield o :: rest
+      }
+  }
+}


### PR DESCRIPTION
## What

Adds the **Scala leg of the 3-way JLVM cross-check**. Rust (`rust/jlvm-core/tests/differential.rs`) and TypeScript (`packages/typescript/tests/json-logic-vectors.test.ts`) already run the shared vectors at `metakit-sdk/shared/json_logic_test_vectors.json`; the Scala impl did **not**. This adds `SharedVectorConformanceSuite` that runs the same ~59 cases.

- Copies the shared vectors into `src/test/resources/conformance/json_logic_test_vectors.json` plus a `README.md` marking them as the cross-language source of truth ("keep in sync").
- `SharedVectorConformanceSuite` (weaver): one test per category, parses each `expr`/`data`, evaluates via the Scala JLVM (`JsonLogicEvaluator.tailRecursive`), and compares to `expected` two ways:
  - **Structural (authoritative):** parse `expected` as JSON, deep-equal with numbers-by-value — mirrors Rust's `json_struct_eq` and TS's `toEqual`.
  - **Textual (rendering guard):** `Show[JsonLogicValue]` render must equal the raw `expected` string in its spaced JSON form (`[1, 2, 3]`, `{"a": 1, "b": 2}`).

## Output-rendering approach

The vectors use a specific textual JSON form (spaces after `,` and `:`). Scala's existing `Show[JsonLogicValue]` already emits exactly that form, so the textual check uses it directly. The **primary** assertion is the structural numbers-by-value comparison, replicated from the Rust harness so the three languages assert identically.

## Dependency on PR #19 (`fix/jlvm-semantics`)

On `dev`, two vectors fail and pass **only** with #19 merged:
- `comparison`: `{"!==": [1, "1"]}` → `dev` returns `false`, vector expects `true`.
- `array_iteration`: `{"all": [[], ...]}` → `dev` returns `true`, vector expects `false`.

This branch **includes #19** (fast-forward merge) so the suite is green. Merge #19 first (or together).

## Two REAL cross-language gaps (reported, not fixed)

Two cases are genuine discrepancies — the Scala JLVM lacks features the vectors (and Rust/TS) support — **not** explained by any unmerged fix. Per policy, neither the vectors nor JLVM semantics were changed. They are recorded as documented xfail entries in `KnownDivergences`, so the suite stays green while the gap stays loud (a guard fails the suite if either case ever starts passing, forcing removal):

1. **`object` — 3-arg `get`:** `{"get": [map, key, default]}`. Scala `get` only accepts `[map, key]` (missing → null) and errors on a 3rd `default` arg. Rust/TS honor the default; `rust/jlvm-core/src/eval.rs::op_get` even comments *"Scala handleGetOp only supports [Map, Str]"*.
2. **`let_bindings` — object-form `let`:** `{"let": [{name: expr}, result]}`. Scala `let` only accepts the array-of-pairs form `{"let": [[[name, expr], ...], result]}`. Rust/TS additionally accept the object form; `rust/jlvm-core/src/eval.rs::eval_let` calls it *"convenience object form ... as used by the conformance vectors"*.

**Recommendation for review:** either extend the Scala JLVM to support 3-arg `get` and object-form `let` (to match Rust/TS), or trim those cases from the shared vectors. Until decided, the xfail entries keep all three languages honest.

## Per-category result (this branch, with #19)

All 14 categories green: constants, var, arithmetic, comparison, strict_equality_int_vs_float, logic, control_flow, string, array, array_iteration, object, typeof, let_bindings, complex. Full `json_logic` package: 567/567 passing.

## Files added
- `src/test/resources/conformance/json_logic_test_vectors.json`
- `src/test/resources/conformance/README.md`
- `src/test/scala/json_logic/SharedVectorConformanceSuite.scala`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
