### PR TITLE
fix(jlvm/gas): charge each op once + pre-charge size-scaled costs

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/GasMetering.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/GasMetering.scala
@@ -123,13 +123,24 @@ case class GasConfig(
   missing: GasCost = GasCost(10),
   missingSome: GasCost = GasCost(15),
   typeOf: GasCost = GasCost(1),
+  // Charging schedule (see GasAwareSemantics for the mechanics). Every operation is charged
+  // EXACTLY ONCE against the shared gas ref:
+  //   base(op) + depthPenalty(depth) + inputScaledCost(args) [+ outputScaledCost(result)].
+  // Children pay for themselves when they are evaluated; ancestors never re-charge their subtree.
+  // The base, depth, and input-scaled components are consumed BEFORE the primitive runs, so
+  // out-of-gas is raised before any input-scaled work (Miller loops, BLS aggregation, proof
+  // folds, string building) is performed. Only residual components that are observable solely on
+  // the produced value (split piece count, merge/flatten/slice output size, substr output length)
+  // are consumed after the primitive; the work they price is bounded by already-paid-for inputs.
+  //
   // ZK / crypto opcodes. Costs are set relative to real compute and are the DoS bound for the VM:
   //   - groth16Verify is by far the most expensive (a BN254 pairing product + final exponentiation),
   //   - ecvrf is high (Ed25519 scalar muls + hash-to-curve),
-  //   - pmtVerify is a flat base plus a per-sibling cost (pmtPerSibling) charged in the gas-aware
-  //     layer, since cost scales with path length,
-  //   - poseidon is a flat base plus a per-input cost (poseidonPerInput), since each input widens the
-  //     permutation.
+  //   - pmtVerify is a flat base plus a per-sibling cost (pmtPerSibling) pre-charged from the
+  //     proof's sibling count in the gas-aware layer before any hashing runs, since cost scales
+  //     with path length,
+  //   - poseidon is a flat base plus a per-input cost (poseidonPerInput) pre-charged from the
+  //     input count before the permutation runs, since each input widens the permutation.
   poseidon: GasCost = GasCost(150),
   poseidonPerInput: GasCost = GasCost(150),
   pmtVerify: GasCost = GasCost(200),
@@ -139,10 +150,11 @@ case class GasConfig(
   // ZK / crypto opcodes -- second wave (BN254 curve, BLS12-381, Schnorr). Costs follow the
   // wave-1 scale (groth16Verify = 250k, ecvrfVerify = 50k) and are the DoS bound for the VM:
   //   - bn254Pairing is the most expensive: a flat base plus a per-pair cost (bn254PairingPerPair,
-  //     charged in the gas-aware layer), since each pair adds a Miller loop; the final exponentiation
-  //     is amortized once across the product,
+  //     pre-charged from the pairs count in the gas-aware layer BEFORE any Miller loop runs), since
+  //     each pair adds a Miller loop; the final exponentiation is amortized once across the product,
   //   - blsVerify / blsAggregateVerify are high (hash-to-curve + two pairings); aggregation adds a
-  //     per-key cost (blsAggregatePerKey) for each extra public key summed into the aggregate,
+  //     per-key cost (blsAggregatePerKey, pre-charged from the key count before any key is summed)
+  //     for each extra public key summed into the aggregate,
   //   - schnorrVerify is medium (two BN254 scalar multiplications + a point add + a SHA-256),
   //   - bn254Mul (a scalar multiplication) is far more expensive than bn254Add (a single point add).
   bn254Add: GasCost = GasCost(500),
@@ -155,7 +167,8 @@ case class GasConfig(
   schnorrVerify: GasCost = GasCost(45_000),
   // ZK / crypto opcodes -- third wave (clear-text authenticated databases: SMT + MPT). These run an
   // authentication-path / witness fold that hashes one canonical-JSON commitment per node, so cost is
-  // a flat base plus a per-element charge (charged in the gas-aware layer):
+  // a flat base plus a per-element charge (pre-charged from the proof shape in the gas-aware layer
+  // before the fold runs):
   //   - smt_verify cost scales with the proof DEPTH (#siblings on the authentication path),
   //   - mpt_verify cost scales with the #nodes in the proof witness,
   //   - mpt_prefix_verify cost scales with the #entries proven complete under the prefix.

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/runtime/JsonLogicEvaluator.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/runtime/JsonLogicEvaluator.scala
@@ -92,10 +92,15 @@ object JsonLogicEvaluator {
             })
         }
 
-        evaluateGasAware(expr, ctx, 0, data).map {
-          case Left(err) => err.asLeft[EvaluationResult[JsonLogicValue]]
+        evaluateGasAware(expr, ctx, 0, data).flatMap {
+          case Left(err)               => err.asLeft[EvaluationResult[JsonLogicValue]].pure[F]
           case Right((value, metrics)) =>
-            EvaluationResult(value, GasUsed(metrics.cost.amount), metrics.depth, metrics.opCount.toLong).asRight[JsonLogicException]
+            // Report gasUsed as the gas-ref delta: the gas that was ACTUALLY consumed
+            // (each op charged exactly once at evaluation time, see GasAwareSemantics).
+            gasLimitRef.get.map { remaining =>
+              EvaluationResult(value, GasUsed(gasLimit.amount - remaining.amount), metrics.depth, metrics.opCount.toLong)
+                .asRight[JsonLogicException]
+            }
         }
       }
 

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/GasAwareSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/GasAwareSemantics.scala
@@ -6,8 +6,27 @@ import cats.syntax.all._
 import io.constellationnetwork.metagraph_sdk.json_logic.core.JsonLogicOp._
 import io.constellationnetwork.metagraph_sdk.json_logic.core._
 import io.constellationnetwork.metagraph_sdk.json_logic.gas.{GasConfig, GasCost, GasLimit}
+import io.constellationnetwork.metagraph_sdk.json_logic.ops.NumericOps.floatToPlainString
 import io.constellationnetwork.metagraph_sdk.json_logic.runtime.ResultContext
 
+/**
+ * Gas-aware semantics: meters every operation against a shared gas `Ref`.
+ *
+ * Charging contract (charge-once, pre-charge):
+ *   - Each operation consumes EXACTLY ONCE from the gas ref:
+ *     `baseCost(op) + depthPenalty(depth) + inputScaledCost(op, args) [+ outputScaledCost(op, result)]`.
+ *     Child sub-results have already consumed their own cost while they were evaluated; an
+ *     ancestor never re-consumes its subtree (no compounding with depth).
+ *   - `baseCost + depthPenalty + inputScaledCost` is consumed BEFORE the underlying primitive
+ *     runs, so out-of-gas is raised before any input-scaled work (pairings, BLS aggregation,
+ *     proof folds, string building) is performed.
+ *   - `outputScaledCost` is the residual component that can only be observed on the produced
+ *     value (split piece count, flatten/slice/merge output size, substr output length). It is
+ *     consumed AFTER the primitive; the work it prices is bounded by already-paid-for inputs.
+ *   - Variable accesses consume `varAccess + pathSegments` at lookup time.
+ *   - Total consumption (the gas-ref delta) is the authoritative gasUsed reported by the
+ *     evaluator.
+ */
 object GasAwareSemantics {
 
   def make[F[_]: Sync](
@@ -47,56 +66,65 @@ object GasAwareSemantics {
 
     new JsonLogicSemantics[F, ResultContext.WithGas] {
 
+      /** Atomically consume `cost` from the shared gas ref, or fail with GasExhaustedException. */
+      private def consumeGas(cost: GasCost): F[Either[JsonLogicException, Unit]] =
+        gasLimitRef.modify { limit =>
+          limit.consume(cost) match {
+            case Right(newLimit) => (newLimit, ().asRight[JsonLogicException])
+            case Left(err)       => (limit, (err: JsonLogicException).asLeft[Unit])
+          }
+        }
+
       override def getVar(
         key: String,
         ctx: Option[JsonLogicValue] = None
-      ): F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] =
-        baseSemantics
-          .getVar(key, ctx)
-          .map(_.map {
-            case (value, metrics) =>
-              val varCost = gasConfig.varAccess + GasCost(key.split("\\.").length.toLong)
-              (value, metrics.withCost(varCost))
-          })
+      ): F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] = {
+        val varCost = gasConfig.varAccess + GasCost(key.split("\\.").length.toLong)
+        // The lookup itself is the work being priced, so consume from the gas ref here
+        // (exactly once); ancestors never re-consume it.
+        consumeGas(varCost).flatMap {
+          case Left(err) => err.asLeft[ResultContext.WithGas[JsonLogicValue]].pure[F]
+          case Right(()) =>
+            baseSemantics
+              .getVar(key, ctx)
+              .map(_.map {
+                case (value, metrics) =>
+                  (value, metrics.withCost(varCost))
+              })
+        }
+      }
 
       override def applyOp(
         op: JsonLogicOp
       ): List[ResultContext.WithGas[JsonLogicValue]] => F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] =
         args => {
-          val baseCost = getOpCost(op)(gasConfig)
           val argValues = args.map { case (value, _) => value }
+          val argMaxDepth = if (args.isEmpty) 0 else args.map(_._2.depth).max
+          val newDepth = argMaxDepth + 1
+          val depthPenalty = gasConfig.depthPenalty(newDepth.toLong)
+          // Everything derivable from the (already evaluated, already paid-for) inputs is
+          // pre-charged BEFORE the primitive runs: out-of-gas must be raised before any
+          // input-scaled work (Miller loops, BLS key aggregation, proof folds, string
+          // concatenation) is performed. Children consumed their own cost while they were
+          // evaluated, so it is NOT re-consumed here (charge-once).
+          val preCost = getOpCost(op)(gasConfig) + depthPenalty + getInputScaledCost(op, argValues)
 
-          gasLimitRef.get.flatMap { currentLimit =>
-            currentLimit
-              .consume(baseCost)
-              .fold(
-                err => (err: JsonLogicException).asLeft[ResultContext.WithGas[JsonLogicValue]].pure[F],
-                newLimit =>
-                  gasLimitRef.set(newLimit) >>
-                  baseSemantics.applyOp(op)(args).flatMap {
-                    case Right((value, metrics)) =>
-                      val additionalCost = getAdditionalCost(op, argValues, value)
-                      val argMaxDepth = if (args.isEmpty) 0 else args.map(_._2.depth).max
-                      val newDepth = argMaxDepth + 1
-                      val depthPenalty = gasConfig.depthPenalty(newDepth.toLong)
-
-                      gasLimitRef.get.flatMap { limit =>
-                        limit
-                          .consume(metrics.cost + depthPenalty + additionalCost)
-                          .fold(
-                            err => (err: JsonLogicException).asLeft[ResultContext.WithGas[JsonLogicValue]].pure[F],
-                            finalLimit =>
-                              gasLimitRef
-                                .set(finalLimit)
-                                .as(
-                                  (value, metrics.withCost(baseCost + depthPenalty + additionalCost).withDepth(newDepth))
-                                    .asRight[JsonLogicException]
-                                )
-                          )
-                      }
-                    case Left(err) => err.asLeft[ResultContext.WithGas[JsonLogicValue]].pure[F]
+          consumeGas(preCost).flatMap {
+            case Left(err) => err.asLeft[ResultContext.WithGas[JsonLogicValue]].pure[F]
+            case Right(()) =>
+              baseSemantics.applyOp(op)(args).flatMap {
+                case Right((value, metrics)) =>
+                  // Residual component only observable on the produced value (e.g. split piece
+                  // count); the work it prices is bounded by inputs that were already paid for.
+                  val outputCost = getOutputScaledCost(op, value)
+                  consumeGas(outputCost).map {
+                    case Left(err) => err.asLeft[ResultContext.WithGas[JsonLogicValue]]
+                    case Right(()) =>
+                      (value, metrics.withCost(preCost + outputCost).withDepth(newDepth))
+                        .asRight[JsonLogicException]
                   }
-              )
+                case Left(err) => err.asLeft[ResultContext.WithGas[JsonLogicValue]].pure[F]
+              }
           }
         }
 
@@ -178,23 +206,43 @@ object GasAwareSemantics {
         case MptPrefixVerifyOp    => config.mptPrefixVerify
       }
 
-      private def getAdditionalCost(op: JsonLogicOp, args: List[JsonLogicValue], result: JsonLogicValue): GasCost =
+      /**
+       * Length of the string a value coerces to in `cat` / `join` (mirrors handleCatOp's
+       * coercion and handleJoinOp's arrayToString). Collections / functions price at zero:
+       * `cat` rejects them and `join` renders them as the empty string.
+       */
+      private def coercedStringLength(value: JsonLogicValue): Long = value match {
+        case NullValue         => 0L
+        case BoolValue(value)  => value.toString.length.toLong
+        case IntValue(value)   => value.toString.length.toLong
+        case FloatValue(value) => floatToPlainString(value).length.toLong
+        case StrValue(value)   => value.length.toLong
+        case _                 => 0L
+      }
+
+      /**
+       * Size-scaled cost derivable from the argument values ALONE. Consumed BEFORE the
+       * primitive runs, so out-of-gas is raised before the input-scaled work is performed.
+       * Output sizes that are exactly determined by the inputs (cat / join string length,
+       * entries count) are re-derived from the inputs and charged here as well.
+       */
+      private def getInputScaledCost(op: JsonLogicOp, args: List[JsonLogicValue]): GasCost =
         op match {
+          // cat output length == sum of the coerced input string lengths; charge it up front.
           case CatOp =>
-            result match {
-              case StrValue(s) => gasConfig.sizeCost(s.length.toLong)
-              case _           => GasCost.Zero
+            gasConfig.sizeCost(args.map(coercedStringLength).sum)
+          // join output length == sum of coerced element lengths + separators; charge it up front.
+          case JoinOp =>
+            args match {
+              case ArrayValue(arr) :: StrValue(separator) :: Nil =>
+                gasConfig.sizeCost(arr.map(coercedStringLength).sum + separator.length.toLong * Math.max(0, arr.size - 1).toLong)
+              case _ => GasCost.Zero
             }
-          case SplitOp =>
-            result match {
-              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong * 2)
-              case _               => GasCost.Zero
-            }
-          case MergeOp =>
-            result match {
-              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong)
-              case MapValue(m)     => gasConfig.sizeCost(m.size.toLong)
-              case _               => GasCost.Zero
+          // entries produces exactly one [key, value] pair per map entry.
+          case EntriesOp =>
+            args match {
+              case MapValue(m) :: Nil => gasConfig.sizeCost(m.size.toLong * 2)
+              case _                  => GasCost.Zero
             }
           case UniqueOp =>
             args match {
@@ -223,16 +271,6 @@ object GasAwareSemantics {
               case ArrayValue(arr) :: Nil => gasConfig.sizeCost(arr.size.toLong)
               case _                      => GasCost.Zero
             }
-          case FlattenOp =>
-            result match {
-              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong)
-              case _               => GasCost.Zero
-            }
-          case SliceOp =>
-            result match {
-              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong)
-              case _               => GasCost.Zero
-            }
           case InOp =>
             args match {
               case _ :: ArrayValue(arr) :: Nil => gasConfig.sizeCost(arr.size.toLong)
@@ -254,25 +292,10 @@ object GasAwareSemantics {
               case ArrayValue(arr) :: Nil => gasConfig.sizeCost(arr.size.toLong)
               case list                   => gasConfig.sizeCost(list.size.toLong)
             }
-          case JoinOp =>
-            result match {
-              case StrValue(s) => gasConfig.sizeCost(s.length.toLong)
-              case _           => GasCost.Zero
-            }
-          case SubStrOp =>
-            result match {
-              case StrValue(s) => gasConfig.sizeCost(s.length.toLong)
-              case _           => GasCost.Zero
-            }
           case MapValuesOp | MapKeysOp =>
             args match {
               case MapValue(m) :: Nil => gasConfig.sizeCost(m.size.toLong)
               case _                  => GasCost.Zero
-            }
-          case EntriesOp =>
-            result match {
-              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong * 2) // Each entry creates a 2-element array
-              case _               => GasCost.Zero
             }
           // poseidon cost scales with the number of inputs (the permutation width = #inputs + 1).
           case PoseidonOp =>
@@ -326,6 +349,44 @@ object GasAwareSemantics {
             args match {
               case _ :: _ :: MapValue(entries) :: _ :: Nil => gasConfig.mptPrefixPerEntry * entries.size.toLong
               case _                                       => GasCost.Zero
+            }
+          case _ => GasCost.Zero
+        }
+
+      /**
+       * Residual size-scaled cost that is only observable on the PRODUCED value and cannot be
+       * derived from the inputs without re-doing the op (split piece count depends on string
+       * content; merge / flatten / slice / substr output sizes depend on clamping or collision
+       * behavior). Consumed AFTER the primitive runs; the work these ops perform is linear in
+       * inputs that were already evaluated and paid for, so nothing unbounded runs un-charged.
+       */
+      private def getOutputScaledCost(op: JsonLogicOp, result: JsonLogicValue): GasCost =
+        op match {
+          case SplitOp =>
+            result match {
+              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong * 2)
+              case _               => GasCost.Zero
+            }
+          case MergeOp =>
+            result match {
+              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong)
+              case MapValue(m)     => gasConfig.sizeCost(m.size.toLong)
+              case _               => GasCost.Zero
+            }
+          case FlattenOp =>
+            result match {
+              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong)
+              case _               => GasCost.Zero
+            }
+          case SliceOp =>
+            result match {
+              case ArrayValue(arr) => gasConfig.sizeCost(arr.size.toLong)
+              case _               => GasCost.Zero
+            }
+          case SubStrOp =>
+            result match {
+              case StrValue(s) => gasConfig.sizeCost(s.length.toLong)
+              case _           => GasCost.Zero
             }
           case _ => GasCost.Zero
         }

--- a/src/test/scala/json_logic/GasMeteringSuite.scala
+++ b/src/test/scala/json_logic/GasMeteringSuite.scala
@@ -1,10 +1,11 @@
 package json_logic
 
-import cats.effect.IO
+import cats.effect.{IO, Ref, Sync}
 
 import io.constellationnetwork.metagraph_sdk.json_logic.core._
 import io.constellationnetwork.metagraph_sdk.json_logic.gas._
-import io.constellationnetwork.metagraph_sdk.json_logic.runtime.JsonLogicEvaluator
+import io.constellationnetwork.metagraph_sdk.json_logic.runtime.{JsonLogicEvaluator, JsonLogicRuntime, ResultContext}
+import io.constellationnetwork.metagraph_sdk.json_logic.semantics.GasAwareSemantics
 
 import org.scalacheck.Gen
 import weaver.SimpleIOSuite
@@ -869,6 +870,117 @@ object GasMeteringSuite extends SimpleIOSuite with Checkers {
       expect(
         three.gasUsed.amount - two.gasUsed.amount == GasConfig.Default.blsAggregatePerKey.amount,
         s"3-key (${three.gasUsed.amount}) should exceed 2-key (${two.gasUsed.amount}) by exactly one per-key charge"
+      )
+  }
+
+  // ===========================================================================
+  // Charge-once / pre-charge mechanics (see GasAwareSemantics).
+  // ===========================================================================
+
+  test("nested arithmetic charges each op exactly once: sum of per-op costs + depth penalties, no compounding") {
+    val evaluator = JsonLogicEvaluator.tailRecursive[IO]
+    // {"+":[{"+":[{"+":[1,2]},3]},4]}
+    val expr = ApplyExpression(
+      JsonLogicOp.AddOp,
+      List(
+        ApplyExpression(
+          JsonLogicOp.AddOp,
+          List(
+            ApplyExpression(JsonLogicOp.AddOp, List(ConstExpression(IntValue(1)), ConstExpression(IntValue(2)))),
+            ConstExpression(IntValue(3))
+          )
+        ),
+        ConstExpression(IntValue(4))
+      )
+    )
+    val config = GasConfig.Default
+    // Each `+` charges exactly once: add base + depthPenalty(opDepth) + sizeCost(#args - 1).
+    // An ancestor must NOT re-consume its already-paid subtree (the old double-charge bug).
+    def opCharge(depth: Long): Long =
+      config.add.amount + config.depthPenalty(depth).amount + config.sizeCost(1L).amount
+    val expected = opCharge(1) + opCharge(2) + opCharge(3) // (5+5+1) + (5+10+1) + (5+15+1) = 48
+
+    evaluator
+      .evaluateWithGas(expr, MapValue.empty, None, GasLimit.Default, config)
+      .flatMap(IO.fromEither)
+      .map { result =>
+        expect.all(
+          result.value == IntValue(10),
+          result.gasUsed.amount == expected
+        )
+      }
+  }
+
+  test("bn254_pairing pre-charges the per-pair cost: OOG is raised before the pairing runs") {
+    val evaluator = JsonLogicEvaluator.tailRecursive[IO]
+    // Two MALFORMED pairs: if the pairing primitive ever ran, it would reject the
+    // points with a non-gas JsonLogicException (see sanity run below). Observing
+    // GasExhaustedException at the tiny limit therefore proves the per-pair charge
+    // is consumed BEFORE the primitive is invoked.
+    val malformedPair = ArrayValue(List(StrValue("0xdead"), StrValue("0xbeef")))
+    val expr = ApplyExpression(
+      JsonLogicOp.Bn254PairingOp,
+      List(ConstExpression(ArrayValue(List(malformedPair, malformedPair))))
+    )
+    val config = GasConfig.Default
+    // Covers base + depth penalty + ONE per-pair charge, but not the second pair.
+    val tinyLimit = GasLimit(
+      config.bn254Pairing.amount + config.depthPenalty(1).amount + config.bn254PairingPerPair.amount
+    )
+
+    for {
+      overBudget <- evaluator.evaluateWithGas(expr, MapValue.empty, None, tinyLimit, config)
+      sanity     <- evaluator.evaluateWithGas(expr, MapValue.empty, None, GasLimit.Unlimited, config)
+    } yield {
+      val oogBeforePairing = overBudget match {
+        case Left(_: GasExhaustedException) => success
+        case other                          => failure(s"Expected GasExhaustedException before the pairing ran, got: $other")
+      }
+      val primitiveWouldReject = sanity match {
+        case Left(_: GasExhaustedException) => failure("Sanity run must not exhaust gas")
+        case Left(_)                        => success // pairing ran and rejected the malformed points
+        case Right(v)                       => failure(s"Malformed pairs must not verify, got: $v")
+      }
+      oogBeforePairing && primitiveWouldReject
+    }
+  }
+
+  test("reported gasUsed equals the gas-ref delta (gas limit minus remaining)") {
+    val expr = ApplyExpression(
+      JsonLogicOp.AddOp,
+      List(
+        ApplyExpression(JsonLogicOp.TimesOp, List(ConstExpression(IntValue(2)), ConstExpression(IntValue(3)))),
+        VarExpression(Left("x"))
+      )
+    )
+    val data = MapValue(Map("x" -> IntValue(4)))
+    val limit = GasLimit(10_000)
+    val config = GasConfig.Default
+
+    // Drive the gas-aware semantics over an externally owned ref (the same wiring
+    // JsonLogicEvaluator.evaluateWithGas uses) to observe actual consumption.
+    def evalWithRef(ref: Ref[IO, GasLimit])(
+      e: JsonLogicExpression,
+      c: Option[JsonLogicValue],
+      d: Int
+    ): IO[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] = {
+      val sem = GasAwareSemantics.makeWithRef[IO](data, ref, config, (e2, c2, d2) => evalWithRef(ref)(e2, c2, d2), d)
+      JsonLogicRuntime.evaluate(e, c)(Sync[IO], ResultContext.gasContext, sem)
+    }
+
+    for {
+      ref       <- Ref.of[IO, GasLimit](limit)
+      _         <- evalWithRef(ref)(expr, None, 0).flatMap(IO.fromEither)
+      remaining <- ref.get
+      reported <- JsonLogicEvaluator
+        .tailRecursive[IO]
+        .evaluateWithGas(expr, data, None, limit, config)
+        .flatMap(IO.fromEither)
+    } yield
+      expect.all(
+        reported.value == IntValue(10),
+        reported.gasUsed.amount > 0,
+        reported.gasUsed.amount == limit.amount - remaining.amount
       )
   }
 }


### PR DESCRIPTION
Fixes the two structural metering bugs from the 2026-06-10 soundness review and defines the charging contract the Rust/TS meters must replicate.

**Bug 1 — subtree double-charge:** `applyOp` consumed `baseCost`, ran the op, then consumed `metrics.cost`, which already summed the children's self-consumed costs — every ancestor re-paid its subtree, compounding with depth.

**Bug 2 — post-charged size costs:** per-element terms (pairing per-pair, BLS per-key, pmt per-sibling, cat by length) were charged AFTER the primitive ran — N Miller loops executed before the N-term was charged, so gas did not bound compute.

**Charging contract (normative for the Rust/TS meters):** per op exactly once, `base + depthPenalty + inputScaledCost` consumed atomically BEFORE the primitive; OOG fires before input-scaled work. Input-scaled terms derive from arguments (cat/join from coerced input lengths); only split/merge/flatten/slice/substr keep a post-charged output residual. Var lookups charge `varAccess + #pathSegments` once at lookup. Reported `gasUsed` = gas-counter delta. No cost constants changed.

New tests: exact no-compounding total for a nested arithmetic chain; OOG-before-pairing; gasUsed ≡ Ref delta. Flagged for the cross-language spec: the tail-recursive runtime never charges if/let base cost (pre-existing lazy special-case) — decide deliberately when the Rust meter lands.

Full suite: **983/983**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)