### PR TITLE
fix(json_logic): finish numeric-model unification against the Rust reference

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
@@ -572,7 +572,7 @@ object JsonLogicSemantics {
                 if (rn.toBigDecimal == 0) {
                   JsonLogicException("Division by zero").asLeft[Result[JsonLogicValue]]
                 } else {
-                  // Use safeDivide for explicit DECIMAL128 precision
+                  // Exact rational division — no rounding anywhere in the evaluator path.
                   combineNumeric(safeDivide)(ln, rn).pure[Result].asRight[JsonLogicException]
                 }).fold(_.asLeft[Result[JsonLogicValue]], identity)
             case _ =>
@@ -1174,8 +1174,9 @@ object JsonLogicSemantics {
             case IntValue(base) :: IntValue(exp) :: Nil if exp >= 0 && exp.isValidInt && exp <= maxSafeExponent =>
               ((IntValue(base.pow(exp.toInt)): JsonLogicValue).pure[Result]: Result[JsonLogicValue]).asRight[JsonLogicException]
             case IntValue(_) :: IntValue(exp) :: Nil if exp > maxSafeExponent =>
+              // Error text matches the Rust reference (eval.rs op_pow) byte-for-byte.
               JsonLogicException(
-                s"Exponent $exp exceeds maximum safe value $maxSafeExponent for integer exponentiation"
+                s"Exponent $exp exceeds maximum safe value $maxSafeExponent"
               ).asLeft[Result[JsonLogicValue]]
             case base :: exp :: Nil =>
               for {

--- a/src/test/resources/conformance/json_logic_test_vectors.json
+++ b/src/test/resources/conformance/json_logic_test_vectors.json
@@ -1,6 +1,6 @@
 {
   "description": "JSON Logic VM test vectors for cross-language compatibility",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "tests": [
     {
       "category": "constants",
@@ -227,6 +227,89 @@
           "expected": "2",
           "note": "UTF-16 code-unit key order: 'a' (U+0061) sorts before 'ä' (U+00E4), so a=1 then ä=a+1=2"
         }
+      ]
+    },
+    {
+      "category": "missing",
+      "cases": [
+        { "expr": "{\"missing\": [\"a\", \"b\"]}", "data": "{\"a\": 1}", "expected": "[\"b\"]" },
+        { "expr": "{\"missing\": [\"a\", \"b\"]}", "data": "{\"a\": 1, \"b\": 2}", "expected": "[]" },
+        { "expr": "{\"missing\": [\"a\", \"b\"]}", "data": "{}", "expected": "[\"a\", \"b\"]" },
+        { "expr": "{\"missing\": [[\"x.y\", \"x.z\"]]}", "data": "{\"x\": {\"y\": 1}}", "expected": "[\"x.z\"]", "note": "single array argument with dot paths" }
+      ]
+    },
+    {
+      "category": "missing_some",
+      "cases": [
+        { "expr": "{\"missing_some\": [1, [\"a\", \"b\", \"c\"]]}", "data": "{\"a\": 1}", "expected": "[]", "note": "minimum met -> empty" },
+        { "expr": "{\"missing_some\": [2, [\"a\", \"b\", \"c\"]]}", "data": "{\"a\": 1}", "expected": "[\"b\", \"c\"]", "note": "below minimum -> all missing keys" },
+        { "expr": "{\"missing_some\": [[\"a\", \"b\"]]}", "data": "{}", "expected": "[\"a\", \"b\"]", "note": "single-array form behaves like min=1" }
+      ]
+    },
+    {
+      "category": "reduce_no_initializer",
+      "cases": [
+        {
+          "expr": "{\"reduce\": [{\"var\": \"items\"}, {\"+\": [{\"var\": \"accumulator\"}, {\"var\": \"current\"}]}]}",
+          "data": "{\"items\": [1, 2, 3, 4]}",
+          "expected": "10",
+          "note": "2-arg reduce folds from the first element"
+        },
+        {
+          "expr": "{\"reduce\": [{\"var\": \"items\"}, {\"+\": [{\"var\": \"accumulator\"}, {\"var\": \"current\"}]}]}",
+          "data": "{\"items\": []}",
+          "expected": "null",
+          "note": "2-arg reduce of empty array is null"
+        }
+      ]
+    },
+    {
+      "category": "callback_scope",
+      "note": "Callbacks receive the element as a context OVERLAY; outer data stays visible",
+      "cases": [
+        {
+          "expr": "{\"map\": [{\"var\": \"items\"}, {\"*\": [{\"var\": \"\"}, {\"var\": \"factor\"}]}]}",
+          "data": "{\"items\": [1, 2, 3], \"factor\": 10}",
+          "expected": "[10, 20, 30]",
+          "note": "map callback reads outer var"
+        },
+        {
+          "expr": "{\"filter\": [{\"var\": \"items\"}, {\">\": [{\"var\": \"\"}, {\"var\": \"threshold\"}]}]}",
+          "data": "{\"items\": [1, 5, 10], \"threshold\": 4}",
+          "expected": "[5, 10]",
+          "note": "filter callback reads outer var"
+        },
+        {
+          "expr": "{\"reduce\": [{\"var\": \"items\"}, {\"+\": [{\"var\": \"accumulator\"}, {\"*\": [{\"var\": \"current\"}, {\"var\": \"factor\"}]}]}, 0]}",
+          "data": "{\"items\": [1, 2, 3], \"factor\": 10}",
+          "expected": "60",
+          "note": "reduce callback reads outer var alongside current/accumulator"
+        }
+      ]
+    },
+    {
+      "category": "exact_arithmetic",
+      "note": "Arithmetic is exact rational; no IEEE-754 drift",
+      "cases": [
+        { "expr": "{\"==\": [{\"+\": [0.1, 0.2]}, 0.3]}", "data": "{}", "expected": "true", "note": "0.1 + 0.2 == 0.3 exactly" },
+        { "expr": "{\"+\": [0.1, 0.2]}", "data": "{}", "expected": "0.3" },
+        { "expr": "{\"==\": [{\"*\": [{\"/\": [1, 3]}, 3]}, 1]}", "data": "{}", "expected": "true", "note": "(1/3)*3 == 1 exactly" },
+        { "expr": "{\"typeof\": [{\"/\": [10, 2]}]}", "data": "{}", "expected": "\"int\"", "note": "integral int division stays Int" },
+        { "expr": "{\"typeof\": [{\"/\": [7, 2]}]}", "data": "{}", "expected": "\"float\"" },
+        { "expr": "{\"cat\": [\"x=\", {\"/\": [7, 2]}]}", "data": "{}", "expected": "\"x=3.5\"", "note": "floats render as plain decimal strings" }
+      ]
+    },
+    {
+      "category": "numeric_model",
+      "note": "Unified numeric model: integer-only pow (exact rational for negative exponents), Int at any magnitude, exact division",
+      "cases": [
+        { "expr": "{\"pow\": [2, 0.5]}", "data": "{}", "error": true, "note": "fractional exponent rejected: deterministic exponentiation requires an integer exponent" },
+        { "expr": "{\"pow\": [2, 1000]}", "data": "{}", "error": true, "note": "exponent above max-safe bound 999 rejected" },
+        { "expr": "{\"==\": [{\"*\": [{\"pow\": [3, -1]}, 3]}, 1]}", "data": "{}", "expected": "true", "note": "negative integer exponent is the exact rational inverse: (1/3)*3 == 1" },
+        { "expr": "{\"typeof\": [{\"pow\": [3, -1]}]}", "data": "{}", "expected": "\"float\"", "note": "negative exponent on an int base yields an exact rational Float" },
+        { "expr": "{\"*\": [4611686018427387904, 4]}", "data": "{}", "expected": "18446744073709551616", "note": "2^62 * 4 = 2^64: integral results stay int at any magnitude (no float demotion past i64/Long)" },
+        { "expr": "{\"typeof\": [{\"*\": [4611686018427387904, 4]}]}", "data": "{}", "expected": "\"int\"" },
+        { "expr": "{\">\": [18446744073709551616, 9223372036854775807]}", "data": "{}", "expected": "true", "note": "comparison beyond 2^63 is exact (2^64 > i64::MAX)" }
       ]
     },
     {

--- a/src/test/scala/json_logic/SharedVectorConformanceSuite.scala
+++ b/src/test/scala/json_logic/SharedVectorConformanceSuite.scala
@@ -43,12 +43,22 @@ object SharedVectorConformanceSuite extends SimpleIOSuite {
 
   final case class Vectors(description: String, version: String, tests: List[Category])
   final case class Category(category: String, note: Option[String], cases: List[VecCase])
-  final case class VecCase(expr: String, data: String, expected: String, note: Option[String])
 
-  implicit private val caseDecoder: Decoder[VecCase] = Decoder.forProduct4(
+  final case class VecCase(
+    expr: String,
+    data: String,
+    expected: Option[String],
+    error: Option[Boolean],
+    note: Option[String]
+  ) {
+    def mustError: Boolean = error.contains(true)
+  }
+
+  implicit private val caseDecoder: Decoder[VecCase] = Decoder.forProduct5(
     "expr",
     "data",
     "expected",
+    "error",
     "note"
   )(VecCase.apply)
 
@@ -129,35 +139,60 @@ object SharedVectorConformanceSuite extends SimpleIOSuite {
     def outcome(structPass: Boolean, textPass: Boolean, detail: String): CaseOutcome =
       CaseOutcome(category, c.expr, label, structPass, textPass, detail)
 
-    val parsed: Either[String, (JsonLogicExpression, JsonLogicValue, JsonLogicValue)] =
+    val parsedBase: Either[String, (JsonLogicExpression, JsonLogicValue)] =
       for {
-        exprJson     <- parser.parse(c.expr).left.map(e => s"EXPR-PARSE: ${e.getMessage}")
-        expr         <- exprJson.as[JsonLogicExpression].left.map(e => s"EXPR-DECODE: ${e.getMessage}")
-        dataJson     <- parser.parse(c.data).left.map(e => s"DATA-PARSE: ${e.getMessage}")
-        data         <- dataJson.as[JsonLogicValue].left.map(e => s"DATA-DECODE: ${e.getMessage}")
-        expectedJson <- parser.parse(c.expected).left.map(e => s"EXPECTED-PARSE: ${e.getMessage}")
-        expected     <- expectedJson.as[JsonLogicValue].left.map(e => s"EXPECTED-DECODE: ${e.getMessage}")
-      } yield (expr, data, expected)
+        exprJson <- parser.parse(c.expr).left.map(e => s"EXPR-PARSE: ${e.getMessage}")
+        expr     <- exprJson.as[JsonLogicExpression].left.map(e => s"EXPR-DECODE: ${e.getMessage}")
+        dataJson <- parser.parse(c.data).left.map(e => s"DATA-PARSE: ${e.getMessage}")
+        data     <- dataJson.as[JsonLogicValue].left.map(e => s"DATA-DECODE: ${e.getMessage}")
+      } yield (expr, data)
 
-    parsed match {
-      case Left(err) =>
-        IO.pure(outcome(structPass = false, textPass = false, s"$label\n    $err"))
-      case Right((expr, data, expected)) =>
-        JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, data, None).map {
-          case Left(evalErr) =>
-            outcome(structPass = false, textPass = false, s"$label\n    EVAL-ERR: ${evalErr.getMessage}")
-          case Right(result) =>
-            val sOk = structEq(result, expected)
-            val rendered = showJsonLogicValue.show(result)
-            val tOk = rendered == c.expected
-            val detail =
-              s"""$label
-                 |    data     = ${c.data}
-                 |    expected = ${c.expected}
-                 |    got      = $rendered
-                 |    struct=${if (sOk) "ok" else "FAIL"} text=${if (tOk) "ok" else "FAIL"}""".stripMargin
-            outcome(structPass = sOk, textPass = tOk, detail)
-        }
+    if (c.mustError)
+      // `error: true` cases pin that evaluation MUST fail (same convention as the ZK vectors).
+      parsedBase match {
+        case Left(err) =>
+          // A case the decoder itself rejects still satisfies "evaluation MUST fail".
+          IO.pure(outcome(structPass = true, textPass = true, s"$label\n    failed as required (decode): $err"))
+        case Right((expr, data)) =>
+          JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, data, None).attempt.map {
+            case Left(raised) =>
+              outcome(structPass = true, textPass = true, s"$label\n    failed as required (raised): ${raised.getMessage}")
+            case Right(Left(evalErr)) =>
+              outcome(structPass = true, textPass = true, s"$label\n    failed as required: ${evalErr.getMessage}")
+            case Right(Right(result)) =>
+              val rendered = showJsonLogicValue.show(result)
+              outcome(structPass = false, textPass = false, s"$label\n    expected an error but evaluated to $rendered")
+          }
+      }
+    else {
+      val parsed: Either[String, (JsonLogicExpression, JsonLogicValue, String, JsonLogicValue)] =
+        for {
+          base         <- parsedBase
+          expectedRaw  <- c.expected.toRight("MISSING-EXPECTED: non-error case must define `expected`")
+          expectedJson <- parser.parse(expectedRaw).left.map(e => s"EXPECTED-PARSE: ${e.getMessage}")
+          expected     <- expectedJson.as[JsonLogicValue].left.map(e => s"EXPECTED-DECODE: ${e.getMessage}")
+        } yield (base._1, base._2, expectedRaw, expected)
+
+      parsed match {
+        case Left(err) =>
+          IO.pure(outcome(structPass = false, textPass = false, s"$label\n    $err"))
+        case Right((expr, data, expectedRaw, expected)) =>
+          JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, data, None).map {
+            case Left(evalErr) =>
+              outcome(structPass = false, textPass = false, s"$label\n    EVAL-ERR: ${evalErr.getMessage}")
+            case Right(result) =>
+              val sOk = structEq(result, expected)
+              val rendered = showJsonLogicValue.show(result)
+              val tOk = rendered == expectedRaw
+              val detail =
+                s"""$label
+                   |    data     = ${c.data}
+                   |    expected = $expectedRaw
+                   |    got      = $rendered
+                   |    struct=${if (sOk) "ok" else "FAIL"} text=${if (tOk) "ok" else "FAIL"}""".stripMargin
+              outcome(structPass = sOk, textPass = tOk, detail)
+          }
+      }
     }
   }
 


### PR DESCRIPTION
Implements the 2026-06-10 numeric spec decisions (reject-fractional pow / unbounded Int / exact rational division). Key finding: the exact-rational merge (7b2df41) had already landed nearly all of it — this PR verifies each decision against the Rust reference, closes the residual gaps (Rust-byte-identical pow over-limit error text, stale DECIMAL128 comment), re-syncs the shared vectors to sdk v1.2.0 content, and adds a numeric_model category (v1.3.0, 7 cases) pinning pow-fractional rejection, exact negative powers, unbounded-Int typing at >2^63, and exact division — plus error:true case support in SharedVectorConformanceSuite. **1012/1012 tests green.**

Follow-up (tracked): byte-sync vectors v1.3.0 → metakit-sdk shared/; the Rust and TS vector harnesses need error:true support first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)