### PR TITLE
chore(bls): pin vendored BC 1.85 beta jars (sha256 + CI check) + v1.8.0 release prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify vendored BouncyCastle jar pins
+        # Pinned in lib/README.md — the vendored BC 1.85 beta jars must be the
+        # exact bytes the BLS byte-identity contract was validated against.
+        run: |
+          sha256sum -c <<'EOF'
+          03b4a7656d6aedcff28626e26c1645f4b9956bf0c6d614ee0fba3241a2ced5b8  lib/bcprov-jdk18on-1.85-SNAPSHOT.jar
+          8ec6507c99806587ec739f1e1c710226326f81aecfd8dccad4f6c5753a3e5349  lib/bcpkix-jdk18on-1.85-SNAPSHOT.jar
+          EOF
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify vendored BouncyCastle jar pins
+        # Same pins as ci.yml (source of truth: lib/README.md). This is the
+        # build that compiles the PUBLISHED artifact against these jars, so the
+        # check must run here, not only on PRs.
+        run: |
+          sha256sum -c <<'EOF'
+          03b4a7656d6aedcff28626e26c1645f4b9956bf0c6d614ee0fba3241a2ced5b8  lib/bcprov-jdk18on-1.85-SNAPSHOT.jar
+          8ec6507c99806587ec739f1e1c710226326f81aecfd8dccad4f6c5753a3e5349  lib/bcpkix-jdk18on-1.85-SNAPSHOT.jar
+          EOF
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -71,8 +71,14 @@ Include this paragraph (or equivalent) in the release notes:
 > required because the BLS12-381 API (`org.bouncycastle.crypto.bls.*`) behind
 > metakit's eth2-ciphersuite BLS primitive exists only in the unreleased 1.85
 > line. The exact bytes are sha256-pinned in `lib/README.md` and enforced in
-> CI. The transitive BC 1.70 artifacts from tessellation-sdk are excluded in
-> `build.sbt`, so consumers get the 1.85 classes on the classpath. These jars
+> CI. IMPORTANT for consumers: the vendored `lib/` jars are unmanaged and are
+> NOT part of the published metakit artifact — the published POM excludes the
+> transitive BC 1.70 artifacts but ships no replacement. A consumer that
+> exercises the BLS primitive (`bls_verify` / `bls_aggregate_verify`) MUST
+> vendor the same sha256-pinned jars with the same `build.sbt` exclusion hack
+> (see `lib/README.md`), or those code paths fail with `NoClassDefFoundError`
+> at runtime. Consumers that never touch BLS are unaffected (the classes load
+> lazily on first use). These jars
 > will be replaced with the managed `org.bouncycastle:*:1.85` Maven Central
 > artifacts the moment BC publishes a stable 1.85; see `lib/README.md` for the
 > migration delta and the deferred source-verification checklist.

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -1,0 +1,140 @@
+# Release checklist — next release off `dev`
+
+> Prep document only. Nothing in this file has been executed; no tags have
+> been created or pushed.
+
+## Recommended version: **v1.8.0**
+
+- `build.sbt` declares `versionScheme := "early-semver"`; the last released
+  line is 1.7.x (`v1.7.0`, preceded by `v1.7.0-rc.1`–`rc.9`).
+- Scope on `dev` since `v1.7.0` is feature-dominated: ZK opcode waves 1–3
+  (poseidon, groth16, ecvrf, bn254, bls, schnorr, smt/mpt auth-DB verify),
+  SMT/MPT provers, gas metering contract, RFC-9381-line ECVRF, plus the
+  exact-rational numeric unification. New public API, no removals → **minor
+  bump**, not patch; not a major.
+- The shared cross-language conformance vectors vendored on `dev` are already
+  versioned `v1.8.0`, matching this recommendation.
+- The numeric-model unification (exact-rational arithmetic, #40/7b2df41)
+  changes evaluation *results* for some programs relative to v1.7.0. It is a
+  conformance fix toward the cross-language reference, but call it out
+  prominently in the notes (done below). If the team treats it as breaking,
+  the fallback is `v2.0.0`; the recommendation stays v1.8.0 because the old
+  behavior diverged from the documented JSON Logic contract.
+- Given the v1.7.0 history (9 RCs), consider cutting `v1.8.0-rc.1` first and
+  promoting after ottochain integration passes.
+
+## How publishing works (current config)
+
+- `.github/workflows/release.yml` triggers on **any** tag push (`tags: ["*"]`)
+  and runs `sbt ci-release` (sbt-ci-release 1.9.0, sonatype host
+  `central.sonatype.com`). The version is derived from the git tag by
+  sbt-dynver (`vX.Y.Z` → `X.Y.Z`). Secrets required: `PGP_PASSPHRASE`,
+  `PGP_SECRET`, `SONATYPE_USERNAME`, `SONATYPE_PASSWORD` (already configured
+  upstream).
+- Precedent (v1.7.0): `main` is aligned with `dev` first, then the tag is cut
+  on `main` (`64a7ab9 chore: align main with dev for v1.7.0 release`).
+
+## Exact commands (when ready — DO NOT run as part of this PR)
+
+```bash
+# 0. preconditions: this PR (chore/bls-jar-provenance) merged; CI green on dev
+git fetch upstream
+
+# 1. align main with dev (mirrors the v1.7.0 flow)
+git checkout main && git reset --hard upstream/main
+git merge --no-ff upstream/dev -m "chore: align main with dev for v1.8.0 release"
+git push upstream main
+
+# 2. tag and push — the tag push alone triggers .github/workflows/release.yml
+git tag -a v1.8.0 -m "metakit v1.8.0"
+git push upstream v1.8.0
+
+# (RC variant: git tag -a v1.8.0-rc.1 -m "metakit v1.8.0-rc.1" && git push upstream v1.8.0-rc.1)
+
+# 3. watch the publish
+gh run watch --repo Constellation-Labs/metakit
+
+# 4. GitHub release with the notes below
+gh release create v1.8.0 --repo Constellation-Labs/metakit \
+  --title "metakit v1.8.0" --notes-file <notes>
+```
+
+## Required disclosure: vendored BouncyCastle 1.85 beta jars
+
+Include this paragraph (or equivalent) in the release notes:
+
+> **BouncyCastle 1.85 beta (vendored).** This release ships two unmanaged
+> BouncyCastle jars in `lib/` (`bcprov-jdk18on-1.85-SNAPSHOT.jar`,
+> `bcpkix-jdk18on-1.85-SNAPSHOT.jar`, OSGi build `1.85.0.20603`, JCE-signed by
+> Legion of the Bouncy Castle Inc., snapshot signed 2026-05-31, obtained from
+> BC's official beta channel `downloads.bouncycastle.org/betas/`). They are
+> required because the BLS12-381 API (`org.bouncycastle.crypto.bls.*`) behind
+> metakit's eth2-ciphersuite BLS primitive exists only in the unreleased 1.85
+> line. The exact bytes are sha256-pinned in `lib/README.md` and enforced in
+> CI. The transitive BC 1.70 artifacts from tessellation-sdk are excluded in
+> `build.sbt`, so consumers get the 1.85 classes on the classpath. These jars
+> will be replaced with the managed `org.bouncycastle:*:1.85` Maven Central
+> artifacts the moment BC publishes a stable 1.85; see `lib/README.md` for the
+> migration delta and the deferred source-verification checklist.
+
+Release-blocking sub-items (tracked in `lib/README.md`):
+
+- [ ] Either BC 1.85 stable is out (swap to managed dep before tagging), or
+      perform the documented source verification (pinned `bcgit/bc-java`
+      commit + `./gradlew clean :core:jar :prov:jar :pkix:jar -x test`,
+      per-class content diff) and record the pinned commit in `lib/README.md`.
+- [ ] Confirm CI jar-pin step is green on the release commit.
+
+## DRAFT release notes — v1.8.0 (dev since v1.7.0)
+
+### JSON Logic VM: ZK / crypto opcodes (waves 1–3)
+
+- Wave 1: `poseidon` (circomlib-compatible over BN254 Fr), `pmt_verify`
+  (Poseidon Merkle tree, fixed depth), `groth16_verify` (pure-JVM SP1
+  Groth16-BN254 verifier), `ecvrf_verify` (#28, #21, #22, #24).
+- Wave 2: `bn254_add` / `bn254_mul` / `bn254_pairing`, `bls_verify`,
+  `bls_aggregate_verify`, `schnorr_verify` (#29).
+- Wave 3 auth-DB verify opcodes: `smt_verify`, `mpt_verify`,
+  `mpt_prefix_verify` (#30).
+- Vendored MIRACL Core (ED25519/BN254/BLS12-381) + MIRACL ECVRF; note BN254 ≠
+  alt_bn128 — Besu retained for Groth16 (#25); post-merge hardening: Groth16
+  error discipline, Poseidon input cap, MIRACL prune (#36).
+- Verified a real shielded-transfer SP1 Groth16 proof in the pure-JVM
+  verifier (#26).
+
+### Gas metering
+
+- Gas costs for the ZK/crypto opcodes; each op charged exactly once;
+  size-scaled costs pre-charged (#37).
+- Shared cross-language gas vectors v1.1.0 + conformance suite (#39).
+
+### Authenticated data structures
+
+- Sparse Merkle Tree with membership + non-membership proofs, LevelDB-backed
+  (#18).
+- MPT: deterministic roots (zero-length Extension fix) + batch/prefix provers
+  (#20).
+
+### Numerics & evaluator parity (behavior change — read this)
+
+- Exact-rational numerics for deterministic cross-language arithmetic
+  (7b2df41), completed against the Rust reference (#40). Programs relying on
+  v1.7.0 floating-point artifacts may evaluate differently; results now match
+  the shared cross-language vectors.
+- `get`/`let` base-parity gaps closed vs Rust/TS (#32); `!==` and `all([])`
+  aligned with the JSON Logic reference (bc198fe).
+- Shared cross-language vector conformance suites: base (82b4406), ZK opcode
+  vectors v1.8.0 (#38), gas vectors v1.1.0 (#39).
+
+### Crypto
+
+- BLS12-381 reworked to the eth2 proof-of-possession ciphersuite on
+  BouncyCastle 1.85, byte-matching tessellation-bls (#33). See the BC beta
+  disclosure above.
+
+### Std / hardening
+
+- JSON depth DoS guard; drop-nulls-before-canonicalize restored (#27); stale
+  canonical hash fixed (b87cd1b).
+- CI: scalafmt check + tests on PRs and pushes to dev/main (d2820a6); vendored
+  BC jar sha256 pin check (this PR).

--- a/lib/README.md
+++ b/lib/README.md
@@ -7,10 +7,17 @@ BLS12-381 API metakit's eth2-ciphersuite BLS primitive depends on
 …) exists **only** in the 1.85 line and is not yet published as a stable
 managed artifact.
 
-| jar                                | sha256 prefix | provides |
-|------------------------------------|---------------|----------|
-| `bcprov-jdk18on-1.85-SNAPSHOT.jar` | (beta)        | `org.bouncycastle.crypto.bls.*`, provider |
-| `bcpkix-jdk18on-1.85-SNAPSHOT.jar` | (beta)        | PKIX/CMS (provider companion) |
+## Pinned hashes (enforced in CI)
+
+These exact bytes are pinned; CI (`.github/workflows/ci.yml`, step
+"Verify vendored BouncyCastle jar pins") recomputes the sha256 of both jars on
+every build and fails on any mismatch. If you intentionally replace a jar,
+update this table and the CI step together.
+
+| jar                                | sha256 | provides |
+|------------------------------------|--------|----------|
+| `bcprov-jdk18on-1.85-SNAPSHOT.jar` | `03b4a7656d6aedcff28626e26c1645f4b9956bf0c6d614ee0fba3241a2ced5b8` | `org.bouncycastle.crypto.bls.*`, JCE provider |
+| `bcpkix-jdk18on-1.85-SNAPSHOT.jar` | `8ec6507c99806587ec739f1e1c710226326f81aecfd8dccad4f6c5753a3e5349` | PKIX/CMS (provider companion) |
 
 ## Provenance
 
@@ -19,6 +26,50 @@ Copied verbatim from the canonical Constellation BLS reference,
 jars with the same `build.sbt` hack. metakit's `Bls12381` primitive is a
 byte-for-byte port of tessellation-bls `BlsSigner`, so it must run against the
 *same* BC build to stay byte-identical.
+
+What the jars themselves say (verified 2026-06-10):
+
+- **Upstream channel**: these are builds from BouncyCastle's official beta
+  channel, <https://downloads.bouncycastle.org/betas/>, which publishes
+  `bcprov-jdk18on-1.85-SNAPSHOT.jar` / `bcpkix-jdk18on-1.85-SNAPSHOT.jar` as a
+  *rolling* snapshot (rebuilt regularly). The exact bytes vendored here may no
+  longer be downloadable from that page — hence the sha256 pins above.
+- **Build identity**: OSGi `Bundle-Version: 1.85.0.20603` (both jars; bcpkix
+  imports `org.bouncycastle.asn1;version="[1.85.0.20603,1.86)"`, so the pair is
+  internally consistent). Signature files are dated 2026-05-31; non-signature
+  entries use the reproducible-build epoch timestamp (1980-02-01). Built with
+  Bnd 7.1.0, `Created-By: 25 (Oracle Corporation)`.
+- **Code signature**: both jars are JCE-signed (`META-INF/BCRSA204.{SF,RSA}`)
+  by `CN=Legion of the Bouncy Castle Inc., OU=Java Software Code Signing,
+  O=Oracle Corporation`, issued by Oracle's `JCE Code Signing CA` (signer cert
+  valid 2025-12-17 → 2030-12-17). `jarsigner -verify` reports `jar verified.`
+  (the PKIX-path warning is expected: the JCE Code Signing CA root is not in
+  the default JDK truststore; stable BC releases from Maven Central warn
+  identically).
+- **No source commit embedded**: the manifests carry no git commit hash, and
+  upstream publishes no `r1rv85`-line tag yet (1.85 is still in development on
+  <https://github.com/bcgit/bc-java> `main`). Exact source reproduction is
+  therefore deferred — see the release checklist below.
+
+## Release checklist: source verification (deferred)
+
+Building bc-java from source exceeds the time budget for this change, so the
+verification that *would* pin these bytes to source is recorded here as a
+release-blocking checklist item:
+
+1. Pin the `bcgit/bc-java` `main` commit closest to the snapshot signature
+   date (2026-05-31) whose `build.gradle` version is `1.85-SNAPSHOT`, e.g.
+   `git rev-list -1 --before=2026-05-31T23:59Z main`.
+2. Build the provider + pkix jars from that commit:
+   `./gradlew clean :core:jar :prov:jar :pkix:jar -x test`
+   (artifacts under `prov/build/libs` and `pkix/build/libs`; `./gradlew
+   copyJars` gathers everything into `dist/`).
+3. Compare *class contents* against the vendored jars (the vendored jars are
+   JCE-signed and Bnd-wrapped, so whole-file sha256 will NOT match a local
+   build; diff the extracted `org/bouncycastle/**.class` trees, e.g. with
+   `diffoscope` or per-class sha256 lists).
+4. Better: skip 1–3 entirely by swapping to the stable managed artifact the
+   moment BouncyCastle publishes 1.85 to Maven Central — see below.
 
 ## How they are wired in (build.sbt)
 
@@ -42,9 +93,15 @@ This mirrors the tessellation-bls `build.sbt` hack exactly.
 
 ## Migration delta when BC 1.85 is published as a stable managed dep
 
-1. Delete `lib/*.jar` (and this README).
+The swap target is the managed `org.bouncycastle` 1.85 artifacts on Maven
+Central, as soon as they exist:
+
+1. Delete `lib/*.jar` (and this README), and remove the jar-pin step from
+   `.github/workflows/ci.yml`.
 2. Drop the `excludeDependencies` block in `build.sbt`'s `commonSettings`.
-3. Add a managed `org.bouncycastle %% bcprov-jdk18on % "1.85"` dependency.
+3. Add managed `"org.bouncycastle" % "bcprov-jdk18on" % "1.85"` (and
+   `"org.bouncycastle" % "bcpkix-jdk18on" % "1.85"`) dependencies (plain `%` —
+   these are Java artifacts).
 
 Nothing in `Bls12381.scala` or the BLS tests changes.
 


### PR DESCRIPTION
**Jar provenance**: sha256 pins for both vendored BC 1.85-SNAPSHOT jars recorded in lib/README.md and enforced by a new CI step (fails if the bytes ever change silently). Provenance findings: both jars are JCE-signed by the official Legion of the Bouncy Castle cert (verified with jarsigner), OSGi-stamped 1.85.0.20603 as an internally consistent pair, matching BC's official rolling beta channel — pins matter because upstream snapshots are rebuilt (already newer than ours). No embedded git commit; the reproducible-source verification recipe (pinned bc-java commit + gradle build + per-class diff) is documented as a release-blocking checklist item. Swap target (managed Maven Central 1.85 when published) documented.

**Release prep**: RELEASE-CHECKLIST.md with recommended **v1.8.0** (early-semver minor; matching the shared vector version), exact tag/release commands per the v1.7.0 precedent, BC-beta disclosure paragraph, and draft release notes for the 26 commits since v1.7.0.

**ottochain compat scan (read-only)**: main code compile-compatible against dev (evaluateWithGas/EvaluationResult/codec/lifecycle all shape-identical). One test-only break (FloatValue now Ratio-backed: `f.toLong` → `f.toBigInt` in ScriptStateMachineIntegrationSuite) + two runtime caveats: CommonRules sizes floats via toString (Ratio prints n/d — size-estimate drift only) and gas-sensitive tests need re-baselining under the corrected charging.

sbt test: 1012/1012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)