### PR TITLE
fix(json_logic): wave-2 Rust parity — decimal scale bound, i64 substr/slice saturation, MaxEvalDepth=256

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/CoercionOps.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/CoercionOps.scala
@@ -53,8 +53,14 @@ object CoercionOps {
   private def safeParseBigDecimal(s: String): Option[BigDecimal] =
     if (s.length > MaxNumericStringLength) None
     else
-      try Some(BigDecimal(s))
-      catch { case _: NumberFormatException => None }
+      try {
+        val bd = BigDecimal(s)
+        // Mirror the Rust reference (coercion.rs `safe_parse_decimal` -> `Ratio::parse_decimal`):
+        // an effective decimal scale beyond NumericOps.MaxDecimalScale fails to parse, so the
+        // coerced comparison is simply `false` (never an error, never a 10^|scale| memory bomb).
+        if (math.abs(bd.bigDecimal.scale.toLong) > NumericOps.MaxDecimalScale.toLong) None
+        else Some(bd)
+      } catch { case _: NumberFormatException => None }
 
   def compareCoercedValues(l: CoercedValue, r: CoercedValue): Either[JsonLogicException, Boolean] =
     (l, r) match {

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/NumericOps.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/NumericOps.scala
@@ -19,6 +19,31 @@ import io.constellationnetwork.metagraph_sdk.numerics.RatioOps.implicits._
  */
 object NumericOps {
 
+  /**
+   * Maximum permitted magnitude of the effective decimal scale (fractional digits minus exponent) accepted by string ->
+   * number coercion. Mirrors the Rust reference `Ratio::MAX_DECIMAL_SCALE` (rust/jlvm-core/src/ratio.rs).
+   *
+   * SECURITY: `Ratio.fromBigDecimal` materializes `10^|scale|` as a full BigInt, so an attacker-controlled exponent like
+   * "1e-2000000000" would eagerly allocate a multi-GB integer (memory bomb). Scala's BigDecimal stores such strings
+   * compactly without expansion, so without this shared bound the Scala evaluator would compute an exact tiny value where
+   * Rust/TS reject — a consensus divergence. With it, programs like {"+":["1e-2000000000"]} error in ALL impls.
+   */
+  val MaxDecimalScale: Int = 10000
+
+  /**
+   * Parse a decimal string into an exact Ratio, rejecting any value whose effective decimal scale magnitude exceeds
+   * [[MaxDecimalScale]]. Java BigDecimal's `scale` is exactly `fractionalDigits - exponent`, the same quantity Rust's
+   * `Ratio::parse_decimal` bounds; it is checked BEFORE `Ratio.fromBigDecimal` materializes `10^|scale|`.
+   */
+  def parseDecimalBounded(s: String): Either[Throwable, Ratio] =
+    Either.catchNonFatal(BigDecimal(s)).flatMap { bd =>
+      val scale = bd.bigDecimal.scale
+      if (math.abs(scale.toLong) > MaxDecimalScale.toLong)
+        JsonLogicException(s"Decimal scale $scale exceeds maximum magnitude $MaxDecimalScale").asLeft
+      else
+        Ratio.fromBigDecimal(bd).asRight
+    }
+
   /** Exact rational division (was BigDecimal DECIMAL128 on dev; now lossless). */
   def safeDivide(l: Ratio, r: Ratio): Ratio =
     l / r
@@ -28,6 +53,28 @@ object NumericOps {
       bi.toInt.asRight
     else
       JsonLogicException(s"$name value $bi exceeds Int range").asLeft
+
+  /**
+   * BigInt -> i64 (Long) conversion matching the Rust reference `bigint_to_i64` (eval.rs): values outside the i64 range
+   * are an error. The error text byte-matches Rust's (`"<name> out of range"`).
+   */
+  def safeToI64(bi: BigInt, name: String): Either[JsonLogicException, Long] =
+    if (bi >= Long.MinValue && bi <= Long.MaxValue)
+      bi.toLong.asRight
+    else
+      JsonLogicException(s"$name out of range").asLeft
+
+  /**
+   * Long addition saturating at the i64 bounds, mirroring Rust's `i64::saturating_add` used by `op_substr` / `op_slice`:
+   * the operands are attacker-controlled i64 extremes, and saturation followed by the callers' clamps yields the same
+   * indices as exact (unbounded) arithmetic would.
+   */
+  def saturatingAddI64(a: Long, b: Long): Long = {
+    val r = a + b
+    if (((a ^ r) & (b ^ r)) < 0L) {
+      if (a < 0L) Long.MinValue else Long.MaxValue
+    } else r
+  }
 
   sealed trait NumericResult {
 
@@ -69,7 +116,7 @@ object NumericOps {
           Either
             .catchNonFatal(BigInt(s))
             .map(IntResult(_): NumericResult)
-            .orElse(Either.catchNonFatal(Ratio.fromBigDecimal(BigDecimal(s))).map(FloatResult(_): NumericResult))
+            .orElse(parseDecimalBounded(s).map(FloatResult(_): NumericResult))
             .leftMap(_ => JsonLogicException(s"Cannot convert string '$s' to number"))
         }
       case ArrayValue(List(single)) =>

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/runtime/JsonLogicEvaluator.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/runtime/JsonLogicEvaluator.scala
@@ -47,18 +47,19 @@ object JsonLogicEvaluator {
     ): F[Either[JsonLogicException, JsonLogicValue]] = {
 
       def evalFn: JsonLogicSemantics.EvaluationCallback[F, cats.Id] =
-        (e, c) => evaluateRecursive(e, c, data)
+        (e, c, d) => evaluateRecursive(e, c, data, d)
 
       def evaluateRecursive(
         expression: JsonLogicExpression,
         context: Option[JsonLogicValue],
-        vars: JsonLogicValue
+        vars: JsonLogicValue,
+        baseDepth: Int
       ): F[Either[JsonLogicException, JsonLogicValue]] = {
         val semantics = JsonLogicSemantics.make[F, cats.Id](vars, evalFn)
-        JsonLogicRuntime.evaluate(expression, context)(MonadThrow[F], ResultContext.idContext, semantics)
+        JsonLogicRuntime.evaluate(expression, context, baseDepth)(MonadThrow[F], ResultContext.idContext, semantics)
       }
 
-      evaluateRecursive(expr, ctx, data)
+      evaluateRecursive(expr, ctx, data, 0)
     }
 
     override def evaluateWithGas(
@@ -73,26 +74,28 @@ object JsonLogicEvaluator {
           expression: JsonLogicExpression,
           context: Option[JsonLogicValue],
           depth: Int,
+          recDepth: Int,
           vars: JsonLogicValue
         ): F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] = {
 
           def evalFn(
             e: JsonLogicExpression,
             c: Option[JsonLogicValue],
-            d: Int
+            d: Int,
+            rd: Int
           ): F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] =
-            evaluateGasAware(e, c, d, vars)
+            evaluateGasAware(e, c, d, rd, vars)
 
           val semantics = GasAwareSemantics.makeWithRef[F](vars, gasLimitRef, gasConfig, evalFn, depth)
           JsonLogicRuntime
-            .evaluate(expression, context)(Sync[F], ResultContext.gasContext, semantics)
+            .evaluate(expression, context, recDepth)(Sync[F], ResultContext.gasContext, semantics)
             .map(_.map {
               case (value, metrics) =>
                 (value, metrics.withDepth(depth + 1).incrementOps)
             })
         }
 
-        evaluateGasAware(expr, ctx, 0, data).flatMap {
+        evaluateGasAware(expr, ctx, 0, 0, data).flatMap {
           case Left(err)               => err.asLeft[EvaluationResult[JsonLogicValue]].pure[F]
           case Right((value, metrics)) =>
             // Report gasUsed as the gas-ref delta: the gas that was ACTUALLY consumed
@@ -129,18 +132,19 @@ object JsonLogicEvaluator {
     ): F[Either[JsonLogicException, JsonLogicValue]] = {
 
       def evalFn: JsonLogicSemantics.EvaluationCallback[F, cats.Id] =
-        (e, c) => evaluateRecursive(e, c, data)
+        (e, c, d) => evaluateRecursive(e, c, data, d)
 
       def evaluateRecursive(
         expression: JsonLogicExpression,
         context: Option[JsonLogicValue],
-        vars: JsonLogicValue
+        vars: JsonLogicValue,
+        baseDepth: Int
       ): F[Either[JsonLogicException, JsonLogicValue]] = {
         val semantics = JsonLogicSemantics.make[F, cats.Id](vars, evalFn)
-        JsonLogicRuntime.evaluateDirect(expression, context)(MonadThrow[F], ResultContext.idContext, semantics)
+        JsonLogicRuntime.evaluateDirect(expression, context, baseDepth)(MonadThrow[F], ResultContext.idContext, semantics)
       }
 
-      evaluateRecursive(expr, ctx, data)
+      evaluateRecursive(expr, ctx, data, 0)
     }
 
     override def evaluateWithGas(

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/runtime/JsonLogicRuntime.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/runtime/JsonLogicRuntime.scala
@@ -11,6 +11,23 @@ import ResultContext._
 
 object JsonLogicRuntime {
 
+  /**
+   * Maximum expression-recursion depth, enforced identically by both runtime strategies
+   * ([[evaluate]] and [[evaluateDirect]]) and matching the Rust reference `MAX_EVAL_DEPTH`
+   * (rust/jlvm-core/src/eval.rs) exactly: one unit is consumed per evaluated expression NODE —
+   * nested operator arguments, array/map literal elements, computed var keys, `if`/`let`
+   * children, and callback runs (map/filter/reduce/...) all count, with the root node at
+   * depth 1. Lazily-skipped work (untaken `if` branches) is never evaluated and therefore
+   * never counts. Callback bodies resume from the invoking node's depth via the evaluation
+   * callback, so the count is global across nested runtime runs, exactly like Rust's shared
+   * depth cell. Exceeding the limit is a normal [[JsonLogicException]]
+   * ("Recursion depth limit exceeded (256)"), never a StackOverflowError.
+   */
+  val MaxEvalDepth: Int = 256
+
+  private def depthExceeded[A]: Either[JsonLogicException, A] =
+    JsonLogicException(s"Recursion depth limit exceeded ($MaxEvalDepth)").asLeft
+
   // Shared helper to determine if an argument at a given index is a callback
   private def isCallbackArg(op: JsonLogicOp, argIndex: Int): Boolean = op match {
     case JsonLogicOp.MapOp | JsonLogicOp.FilterOp | JsonLogicOp.AllOp | JsonLogicOp.SomeOp | JsonLogicOp.NoneOp | JsonLogicOp.FindOp |
@@ -87,10 +104,14 @@ object JsonLogicRuntime {
         }
     }
 
-  // Direct recursive evaluation (may cause stack overflow on deep expressions??)
+  // Direct recursive evaluation. Bounded by MaxEvalDepth, so JVM-stack overflow is unreachable
+  // for any accepted program. `baseDepth` is the recursion depth already consumed by enclosing
+  // runs (callback bodies resume from the invoking node's depth); the program root evaluates at
+  // `baseDepth + 1`.
   def evaluateDirect[F[_]: Monad, Result[_]: ResultContext](
     program: JsonLogicExpression,
-    ctx: Option[JsonLogicValue]
+    ctx: Option[JsonLogicValue],
+    baseDepth: Int = 0
   )(implicit sem: JsonLogicSemantics[F, Result]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
     // Same lazy-dispatch base charge as the tail-recursive runtime: if/let never reach
@@ -109,155 +130,167 @@ object JsonLogicRuntime {
 
     def evaluateExpression(
       expr: JsonLogicExpression,
-      currentCtx: Option[JsonLogicValue]
-    ): F[Either[JsonLogicException, Result[JsonLogicValue]]] = expr match {
-      case ConstExpression(value) =>
-        value.pure[Result].asRight[JsonLogicException].pure[F]
+      currentCtx: Option[JsonLogicValue],
+      depth: Int
+    ): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+      if (depth > MaxEvalDepth) depthExceeded[Result[JsonLogicValue]].pure[F]
+      else
+        expr match {
+          case ConstExpression(value) =>
+            value.pure[Result].asRight[JsonLogicException].pure[F]
 
-      case VarExpression(Left(key), defaultOpt) =>
-        lookupVar(key, defaultOpt, currentCtx)
+          case VarExpression(Left(key), defaultOpt) =>
+            lookupVar(key, defaultOpt, currentCtx)
 
-      case VarExpression(Right(keyExpr), defaultOpt) =>
-        evaluateExpression(keyExpr, currentCtx).flatMap {
-          case Right(keyResult) =>
-            keyResult.extractValue match {
-              case StrValue(name)                  => lookupVar(name, defaultOpt, currentCtx)
-              case ArrayValue(StrValue(name) :: _) => lookupVar(name, defaultOpt, currentCtx)
-              case v                               => JsonLogicException(s"Got non-string input: $v").asLeft[Result[JsonLogicValue]].pure[F]
+          case VarExpression(Right(keyExpr), defaultOpt) =>
+            evaluateExpression(keyExpr, currentCtx, depth + 1).flatMap {
+              case Right(keyResult) =>
+                keyResult.extractValue match {
+                  case StrValue(name)                  => lookupVar(name, defaultOpt, currentCtx)
+                  case ArrayValue(StrValue(name) :: _) => lookupVar(name, defaultOpt, currentCtx)
+                  case v => JsonLogicException(s"Got non-string input: $v").asLeft[Result[JsonLogicValue]].pure[F]
+                }
+              case Left(error) =>
+                error.asLeft[Result[JsonLogicValue]].pure[F]
             }
-          case Left(error) =>
-            error.asLeft[Result[JsonLogicValue]].pure[F]
-        }
 
-      case ArrayExpression(elements) =>
-        elements.traverse(el => evaluateExpression(el, currentCtx)).map { evaluatedElements =>
-          evaluatedElements.sequence.map { results =>
-            results.sequence.map(ArrayValue(_): JsonLogicValue)
-          }
-        }
-
-      case MapExpression(map) =>
-        map.toList.traverse {
-          case (k, v) =>
-            evaluateExpression(v, currentCtx).map(_.map(k -> _))
-        }.map { evaluatedPairs =>
-          evaluatedPairs.sequence.map { pairs =>
-            val (keys, vResults) = pairs.unzip
-            vResults.sequence.map(values => MapValue(keys.zip(values).toMap): JsonLogicValue)
-          }
-        }
-
-      case ApplyExpression(JsonLogicOp.IfElseOp, args) =>
-        def evaluateIfElse(argsList: List[JsonLogicExpression]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
-          argsList match {
-            case Nil =>
-              JsonLogicException("If/else requires at least one argument")
-                .asLeft[Result[JsonLogicValue]]
-                .pure[F]
-            case condition :: thenBranch :: rest =>
-              evaluateExpression(condition, currentCtx).flatMap {
-                case Right(condResult) =>
-                  condResult.extractValue.isTruthy
-                    .pure[F]
-                    .ifM(
-                      ifTrue = evaluateExpression(thenBranch, currentCtx),
-                      ifFalse = rest match {
-                        case Nil              => (NullValue: JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
-                        case List(elseBranch) => evaluateExpression(elseBranch, currentCtx)
-                        case moreArgs         => evaluateIfElse(moreArgs)
-                      }
-                    )
-                case Left(error) =>
-                  error.asLeft[Result[JsonLogicValue]].pure[F]
+          case ArrayExpression(elements) =>
+            elements.traverse(el => evaluateExpression(el, currentCtx, depth + 1)).map { evaluatedElements =>
+              evaluatedElements.sequence.map { results =>
+                results.sequence.map(ArrayValue(_): JsonLogicValue)
               }
-            case _ =>
-              JsonLogicException("If/else malformed: condition without then-branch")
-                .asLeft[Result[JsonLogicValue]]
-                .pure[F]
-          }
+            }
 
-        chargeBaseThen(JsonLogicOp.IfElseOp)(evaluateIfElse(args))
+          case MapExpression(map) =>
+            map.toList.traverse {
+              case (k, v) =>
+                evaluateExpression(v, currentCtx, depth + 1).map(_.map(k -> _))
+            }.map { evaluatedPairs =>
+              evaluatedPairs.sequence.map { pairs =>
+                val (keys, vResults) = pairs.unzip
+                vResults.sequence.map(values => MapValue(keys.zip(values).toMap): JsonLogicValue)
+              }
+            }
 
-      case ApplyExpression(JsonLogicOp.LetOp, args) =>
-        // Both surface forms (array of [name, expr] pairs and the object form
-        // {name: expr, ...}) desugar to the same ordered binding list. Bindings are
-        // evaluated sequentially, each in the context of previous bindings, and the
-        // result expression sees all bindings in scope (mirrors Rust `eval_let`).
-        chargeBaseThen(JsonLogicOp.LetOp)(JsonLogicRuntime.normalizeLetArgs(args) match {
-          case Right((bindings, resultExpr)) =>
-            def processBindings(
-              remaining: List[(String, JsonLogicExpression)],
-              accumulatedBindings: Map[String, JsonLogicValue]
-            ): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
-              remaining match {
+          case ApplyExpression(JsonLogicOp.IfElseOp, args) =>
+            def evaluateIfElse(argsList: List[JsonLogicExpression]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+              argsList match {
                 case Nil =>
-                  // All bindings processed, evaluate result with accumulated context
-                  val letCtx = currentCtx match {
-                    case Some(MapValue(existing)) => MapValue(existing ++ accumulatedBindings).some
-                    case Some(other)              => MapValue(accumulatedBindings + ("" -> other)).some
-                    case None                     => MapValue(accumulatedBindings).some
-                  }
-                  evaluateExpression(resultExpr, letCtx)
-
-                case (name, valueExpr) :: rest =>
-                  // Evaluate binding expression in context with accumulated bindings
-                  val bindingCtx = currentCtx match {
-                    case Some(MapValue(existing)) => MapValue(existing ++ accumulatedBindings).some
-                    case Some(other)              => MapValue(accumulatedBindings + ("" -> other)).some
-                    case None                     => if (accumulatedBindings.isEmpty) None else MapValue(accumulatedBindings).some
-                  }
-                  evaluateExpression(valueExpr, bindingCtx).flatMap {
-                    case Right(valueResult) =>
-                      processBindings(rest, accumulatedBindings + (name -> valueResult.extractValue))
+                  JsonLogicException("If/else requires at least one argument")
+                    .asLeft[Result[JsonLogicValue]]
+                    .pure[F]
+                case condition :: thenBranch :: rest =>
+                  evaluateExpression(condition, currentCtx, depth + 1).flatMap {
+                    case Right(condResult) =>
+                      condResult.extractValue.isTruthy
+                        .pure[F]
+                        .ifM(
+                          ifTrue = evaluateExpression(thenBranch, currentCtx, depth + 1),
+                          ifFalse = rest match {
+                            case Nil              => (NullValue: JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
+                            case List(elseBranch) => evaluateExpression(elseBranch, currentCtx, depth + 1)
+                            case moreArgs         => evaluateIfElse(moreArgs)
+                          }
+                        )
                     case Left(error) =>
                       error.asLeft[Result[JsonLogicValue]].pure[F]
                   }
-              }
-
-            processBindings(bindings, Map.empty)
-
-          case Left(error) =>
-            error.asLeft[Result[JsonLogicValue]].pure[F]
-        })
-
-      case ApplyExpression(op, args) =>
-        args.zipWithIndex.traverse {
-          case (arg, idx) =>
-            if (JsonLogicRuntime.isCallbackArg(op, idx)) {
-              arg match {
-                case ConstExpression(fv: FunctionValue) =>
-                  (fv: JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
                 case _ =>
-                  (FunctionValue(arg): JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
+                  JsonLogicException("If/else malformed: condition without then-branch")
+                    .asLeft[Result[JsonLogicValue]]
+                    .pure[F]
               }
-            } else {
-              evaluateExpression(arg, currentCtx)
-            }
-        }.flatMap { evaluatedArgs =>
-          evaluatedArgs.sequence match {
-            case Right(resultArgs) =>
-              sem.applyOp(op)(resultArgs)
-            case Left(error) =>
-              error.asLeft[Result[JsonLogicValue]].pure[F]
-          }
-        }
-    }
 
-    evaluateExpression(program, ctx)
+            chargeBaseThen(JsonLogicOp.IfElseOp)(evaluateIfElse(args))
+
+          case ApplyExpression(JsonLogicOp.LetOp, args) =>
+            // Both surface forms (array of [name, expr] pairs and the object form
+            // {name: expr, ...}) desugar to the same ordered binding list. Bindings are
+            // evaluated sequentially, each in the context of previous bindings, and the
+            // result expression sees all bindings in scope (mirrors Rust `eval_let`).
+            chargeBaseThen(JsonLogicOp.LetOp)(JsonLogicRuntime.normalizeLetArgs(args) match {
+              case Right((bindings, resultExpr)) =>
+                def processBindings(
+                  remaining: List[(String, JsonLogicExpression)],
+                  accumulatedBindings: Map[String, JsonLogicValue]
+                ): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+                  remaining match {
+                    case Nil =>
+                      // All bindings processed, evaluate result with accumulated context
+                      val letCtx = currentCtx match {
+                        case Some(MapValue(existing)) => MapValue(existing ++ accumulatedBindings).some
+                        case Some(other)              => MapValue(accumulatedBindings + ("" -> other)).some
+                        case None                     => MapValue(accumulatedBindings).some
+                      }
+                      evaluateExpression(resultExpr, letCtx, depth + 1)
+
+                    case (name, valueExpr) :: rest =>
+                      // Evaluate binding expression in context with accumulated bindings
+                      val bindingCtx = currentCtx match {
+                        case Some(MapValue(existing)) => MapValue(existing ++ accumulatedBindings).some
+                        case Some(other)              => MapValue(accumulatedBindings + ("" -> other)).some
+                        case None                     => if (accumulatedBindings.isEmpty) None else MapValue(accumulatedBindings).some
+                      }
+                      evaluateExpression(valueExpr, bindingCtx, depth + 1).flatMap {
+                        case Right(valueResult) =>
+                          processBindings(rest, accumulatedBindings + (name -> valueResult.extractValue))
+                        case Left(error) =>
+                          error.asLeft[Result[JsonLogicValue]].pure[F]
+                      }
+                  }
+
+                processBindings(bindings, Map.empty)
+
+              case Left(error) =>
+                error.asLeft[Result[JsonLogicValue]].pure[F]
+            })
+
+          case ApplyExpression(op, args) =>
+            args.zipWithIndex.traverse {
+              case (arg, idx) =>
+                if (JsonLogicRuntime.isCallbackArg(op, idx)) {
+                  arg match {
+                    case ConstExpression(fv: FunctionValue) =>
+                      (fv: JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
+                    case _ =>
+                      (FunctionValue(arg): JsonLogicValue).pure[Result].asRight[JsonLogicException].pure[F]
+                  }
+                } else {
+                  evaluateExpression(arg, currentCtx, depth + 1)
+                }
+            }.flatMap { evaluatedArgs =>
+              evaluatedArgs.sequence match {
+                case Right(resultArgs) =>
+                  // Callback handlers resume nested evaluation from this node's depth.
+                  sem.applyOp(op, depth)(resultArgs)
+                case Left(error) =>
+                  error.asLeft[Result[JsonLogicValue]].pure[F]
+              }
+            }
+        }
+
+    evaluateExpression(program, ctx, baseDepth + 1)
   }
 
   // Tail-recursive stack-machine evaluation using tailRecM (stack-safe)
-  // Default evaluate uses tail-recursive interpret for stack safety
+  // Default evaluate uses tail-recursive interpret for stack safety.
+  // `baseDepth` is the recursion depth already consumed by enclosing runs (callback bodies
+  // resume from the invoking node's depth via the semantics' evaluation callback); the
+  // program root evaluates at `baseDepth + 1` and the MaxEvalDepth guard applies per node.
   def evaluate[F[_]: Monad, Result[_]: ResultContext](
     program: JsonLogicExpression,
-    ctx: Option[JsonLogicValue]
+    ctx: Option[JsonLogicValue],
+    baseDepth: Int = 0
   )(implicit sem: JsonLogicSemantics[F, Result]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
-    // Stack frames for tail-recursive evaluation
+    // Stack frames for tail-recursive evaluation. `depth` on an Eval frame is the recursion
+    // depth at which that expression node evaluates (root = baseDepth + 1).
     sealed trait Frame
-    case class Eval(expr: JsonLogicExpression, contOpt: Option[Continuation]) extends Frame
+    case class Eval(expr: JsonLogicExpression, contOpt: Option[Continuation], depth: Int) extends Frame
     case class ApplyValue(value: Result[JsonLogicValue], cont: Continuation) extends Frame
 
+    // `childDepth` is the depth at which this continuation's pending child expressions
+    // evaluate (= the owning node's depth + 1); the owning node itself sits at childDepth - 1.
     case class Continuation(
       op: JsonLogicOp,
       processed: List[Result[JsonLogicValue]],
@@ -266,17 +299,20 @@ object JsonLogicRuntime {
       isArray: Boolean = false,
       mapKeys: List[String] = List.empty,
       isIfElse: Boolean = false,
-      varDefault: Option[JsonLogicValue] = None
+      varDefault: Option[JsonLogicValue] = None,
+      childDepth: Int = 1
     )
 
-    // Special continuation for let bindings
+    // Special continuation for let bindings. `childDepth` is the depth of the binding /
+    // result expressions (= the let node's depth + 1).
     case class LetContinuation(
       currentName: String,
       remainingBindings: List[JsonLogicExpression],
       resultExpr: JsonLogicExpression,
       accumulatedBindings: Map[String, JsonLogicValue],
       parent: Option[Continuation],
-      originalCtx: Option[JsonLogicValue]
+      originalCtx: Option[JsonLogicValue],
+      childDepth: Int
     )
 
     case class EvalLet(expr: JsonLogicExpression, cont: LetContinuation) extends Frame
@@ -294,7 +330,7 @@ object JsonLogicRuntime {
     }
 
     type Stack = List[Frame]
-    val initStack: Stack = List(Eval(program, None))
+    val initStack: Stack = List(Eval(program, None, baseDepth + 1))
 
     // `if` / `let` are dispatched lazily below and never reach sem.applyOp, so their flat
     // base cost is charged here, once per node, BEFORE any child is evaluated (no depth
@@ -319,10 +355,18 @@ object JsonLogicRuntime {
           .asRight[Stack]
           .pure[F]
 
-      case Eval(ConstExpression(v), contOpt) :: tail =>
+      // MaxEvalDepth guard: one unit per evaluated expression node, exactly like the Rust
+      // reference's per-`eval`-call depth cell. Checked before the node does any work.
+      case Eval(_, _, depth) :: _ if depth > MaxEvalDepth =>
+        depthExceeded[Result[JsonLogicValue]].asRight[Stack].pure[F]
+
+      case EvalLet(_, letCont) :: _ if letCont.childDepth > MaxEvalDepth =>
+        depthExceeded[Result[JsonLogicValue]].asRight[Stack].pure[F]
+
+      case Eval(ConstExpression(v), contOpt, _) :: tail =>
         contOpt.continueOrTerminate(v.pure[Result], tail).pure[F]
 
-      case Eval(VarExpression(Left(key), defaultOpt), contOpt) :: tail =>
+      case Eval(VarExpression(Left(key), defaultOpt), contOpt, _) :: tail =>
         sem.getVar(key, ctx).map {
           case Right(result) =>
             val finalResult = result.extractValue match {
@@ -342,20 +386,24 @@ object JsonLogicRuntime {
             contOpt.continueOrTerminate(finalResult, tail)
         }
 
-      case Eval(VarExpression(Right(keyExpr), defaultOpt), contOpt) :: tail =>
-        (Eval(keyExpr, Some(Continuation(JsonLogicOp.NoOp, Nil, Nil, contOpt, varDefault = defaultOpt))) :: tail)
+      case Eval(VarExpression(Right(keyExpr), defaultOpt), contOpt, depth) :: tail =>
+        (Eval(
+          keyExpr,
+          Some(Continuation(JsonLogicOp.NoOp, Nil, Nil, contOpt, varDefault = defaultOpt, childDepth = depth + 1)),
+          depth + 1
+        ) :: tail)
           .asLeft[Either[JsonLogicException, Result[JsonLogicValue]]]
           .pure[F]
 
-      case Eval(ArrayExpression(elements), contOpt) :: tail =>
+      case Eval(ArrayExpression(elements), contOpt, depth) :: tail =>
         if (elements.isEmpty) {
           contOpt.continueOrTerminate((ArrayValue(List.empty): JsonLogicValue).pure[Result], tail).pure[F]
         } else {
-          val newCont = Continuation(JsonLogicOp.NoOp, Nil, elements.tail, contOpt, isArray = true)
-          (Eval(elements.head, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+          val newCont = Continuation(JsonLogicOp.NoOp, Nil, elements.tail, contOpt, isArray = true, childDepth = depth + 1)
+          (Eval(elements.head, Some(newCont), depth + 1) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
         }
 
-      case Eval(MapExpression(map), contOpt) :: tail =>
+      case Eval(MapExpression(map), contOpt, depth) :: tail =>
         if (map.isEmpty) {
           contOpt.continueOrTerminate((MapValue.empty: JsonLogicValue).pure[Result], tail).pure[F]
         } else {
@@ -368,9 +416,10 @@ object JsonLogicRuntime {
             remaining.map(_._2),
             contOpt,
             isArray = false,
-            mapKeys = List(firstKey) ++ remaining.map(_._1)
+            mapKeys = List(firstKey) ++ remaining.map(_._1),
+            childDepth = depth + 1
           )
-          (Eval(firstExpr, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+          (Eval(firstExpr, Some(newCont), depth + 1) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
         }
 
       // Handle LetOp. Two surface forms, both desugared to the same ordered,
@@ -378,17 +427,17 @@ object JsonLogicRuntime {
       //   - array form : {"let": [[[name, expr], ...], resultExpr]}
       //   - object form: {"let": [{name: expr, ...},   resultExpr]}
       // Each binding is evaluated sequentially with prior bindings already in scope.
-      case Eval(ApplyExpression(JsonLogicOp.LetOp, args), contOpt) :: tail =>
+      case Eval(ApplyExpression(JsonLogicOp.LetOp, args), contOpt, depth) :: tail =>
         chargeBaseThen(JsonLogicOp.LetOp) {
           JsonLogicRuntime.normalizeLetArgs(args) match {
             case Right((bindings, resultExpr)) =>
               bindings match {
                 case Nil =>
-                  // No bindings, just evaluate result.
-                  (Eval(resultExpr, contOpt) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+                  // No bindings, just evaluate result (a child of the let node).
+                  (Eval(resultExpr, contOpt, depth + 1) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
                 case (name, valueExpr) :: rest =>
                   val restPairs = rest.map { case (n, e) => ArrayExpression(ConstExpression(StrValue(n)) :: e :: Nil) }
-                  val letCont = LetContinuation(name, restPairs, resultExpr, Map.empty, contOpt, ctx)
+                  val letCont = LetContinuation(name, restPairs, resultExpr, Map.empty, contOpt, ctx, childDepth = depth + 1)
                   (EvalLet(valueExpr, letCont) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
               }
             case Left(err) =>
@@ -397,7 +446,7 @@ object JsonLogicRuntime {
         }
 
       // Handle IfElseOp with lazy evaluation of branches
-      case Eval(ApplyExpression(JsonLogicOp.IfElseOp, args), contOpt) :: tail =>
+      case Eval(ApplyExpression(JsonLogicOp.IfElseOp, args), contOpt, depth) :: tail =>
         chargeBaseThen(JsonLogicOp.IfElseOp) {
           if (args.length < 2) {
             JsonLogicException(s"Invalid arguments for if/else operation: expected at least 2 args, got ${args.length}")
@@ -412,15 +461,16 @@ object JsonLogicRuntime {
               contOpt,
               isArray = false,
               mapKeys = List.empty,
-              isIfElse = true
+              isIfElse = true,
+              childDepth = depth + 1
             )
-            (Eval(args.head, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+            (Eval(args.head, Some(newCont), depth + 1) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
           }
         }
 
-      case Eval(ApplyExpression(op, args), contOpt) :: tail =>
+      case Eval(ApplyExpression(op, args), contOpt, depth) :: tail =>
         if (args.isEmpty) {
-          sem.applyOp(op)(Nil).map {
+          sem.applyOp(op, depth)(Nil).map {
             case Right(res) => contOpt.continueOrTerminate(res, tail)
             case Left(err)  => err.asLeft[Result[JsonLogicValue]].asRight[Stack]
           }
@@ -430,34 +480,34 @@ object JsonLogicRuntime {
             case ConstExpression(fv: FunctionValue) => (fv: JsonLogicValue).pure[Result]
             case _                                  => (FunctionValue(args.head): JsonLogicValue).pure[Result]
           }
-          val newCont = Continuation(op, List(wrappedCallback), args.tail, contOpt)
+          val newCont = Continuation(op, List(wrappedCallback), args.tail, contOpt, childDepth = depth + 1)
           if (args.tail.isEmpty) {
             // No more args - apply the operation
-            sem.applyOp(op)(List(wrappedCallback)).map {
+            sem.applyOp(op, depth)(List(wrappedCallback)).map {
               case Right(res) => contOpt.continueOrTerminate(res, tail)
               case Left(err)  => err.asLeft[Result[JsonLogicValue]].asRight[Stack]
             }
           } else {
             // More args remain - evaluate next arg
-            (Eval(args.tail.head, Some(newCont.copy(remaining = args.tail.tail))) :: tail)
+            (Eval(args.tail.head, Some(newCont.copy(remaining = args.tail.tail)), depth + 1) :: tail)
               .asLeft[Either[JsonLogicException, Result[JsonLogicValue]]]
               .pure[F]
           }
         } else {
-          val newCont = Continuation(op, Nil, args.tail, contOpt)
-          (Eval(args.head, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+          val newCont = Continuation(op, Nil, args.tail, contOpt, childDepth = depth + 1)
+          (Eval(args.head, Some(newCont), depth + 1) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
         }
 
-      case ApplyValue(value, cont @ Continuation(_, processed, remaining, parentContOpt, true, _, _, _)) :: tail =>
+      case ApplyValue(value, cont @ Continuation(_, processed, remaining, parentContOpt, true, _, _, _, childDepth)) :: tail =>
         if (remaining.isEmpty) {
           val arrayValue: Result[JsonLogicValue] = (processed :+ value).sequence.map(arr => ArrayValue(arr): JsonLogicValue)
           parentContOpt.continueOrTerminate(arrayValue, tail).pure[F]
         } else {
           val newCont = cont.copy(processed = processed :+ value, remaining = remaining.tail)
-          (Eval(remaining.head, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+          (Eval(remaining.head, Some(newCont), childDepth) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
         }
 
-      case ApplyValue(value, cont @ Continuation(_, processed, remaining, parentContOpt, false, mapKeys, _, _)) :: tail
+      case ApplyValue(value, cont @ Continuation(_, processed, remaining, parentContOpt, false, mapKeys, _, _, childDepth)) :: tail
           if mapKeys.nonEmpty =>
         val newProcessed = processed :+ value
         if (remaining.isEmpty) {
@@ -465,19 +515,21 @@ object JsonLogicRuntime {
           parentContOpt.continueOrTerminate((MapValue(pairs): JsonLogicValue).pure[Result], tail).pure[F]
         } else {
           val newCont = cont.copy(processed = newProcessed, remaining = remaining.tail)
-          (Eval(remaining.head, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+          (Eval(remaining.head, Some(newCont), childDepth) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
         }
 
-      // Handle applying a value to IfElse continuation (lazy evaluation)
-      case ApplyValue(condValue, Continuation(JsonLogicOp.IfElseOp, _, remaining, parentContOpt, _, _, true, _)) :: tail =>
+      // Handle applying a value to IfElse continuation (lazy evaluation). Every chained
+      // condition / branch is a direct child of the SAME if node, so they all evaluate at
+      // the node's childDepth (matching the Rust eval_if loop).
+      case ApplyValue(condValue, Continuation(JsonLogicOp.IfElseOp, _, remaining, parentContOpt, _, _, true, _, childDepth)) :: tail =>
         remaining match {
           case thenBranch :: rest =>
             if (condValue.extractValue.isTruthy) {
-              (Eval(thenBranch, parentContOpt) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+              (Eval(thenBranch, parentContOpt, childDepth) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
             } else if (rest.isEmpty) {
               parentContOpt.continueOrTerminate((NullValue: JsonLogicValue).pure[Result], tail).pure[F]
             } else if (rest.length == 1) {
-              (Eval(rest.head, parentContOpt) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+              (Eval(rest.head, parentContOpt, childDepth) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
             } else {
               val newCont = Continuation(
                 JsonLogicOp.IfElseOp,
@@ -486,9 +538,10 @@ object JsonLogicRuntime {
                 parentContOpt,
                 isArray = false,
                 mapKeys = List.empty,
-                isIfElse = true
+                isIfElse = true,
+                childDepth = childDepth
               )
-              (Eval(rest.head, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+              (Eval(rest.head, Some(newCont), childDepth) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
             }
 
           case Nil =>
@@ -498,7 +551,7 @@ object JsonLogicRuntime {
               .pure[F]
         }
 
-      case ApplyValue(value, Continuation(JsonLogicOp.NoOp, _, _, parentContOpt, _, _, _, defaultOpt)) :: tail =>
+      case ApplyValue(value, Continuation(JsonLogicOp.NoOp, _, _, parentContOpt, _, _, _, defaultOpt, _)) :: tail =>
         value.extractValue match {
           case StrValue(name) =>
             sem.getVar(name, ctx).map {
@@ -545,10 +598,12 @@ object JsonLogicRuntime {
               .pure[F]
         }
 
-      case ApplyValue(value, Continuation(op, processed, remaining, parentContOpt, false, _, _, _)) :: tail =>
+      case ApplyValue(value, Continuation(op, processed, remaining, parentContOpt, false, _, _, _, childDepth)) :: tail =>
         val newProcessed = processed :+ value
         if (remaining.isEmpty) {
-          sem.applyOp(op)(newProcessed).map {
+          // Apply at the op node's own depth (childDepth - 1); callback handlers resume
+          // nested evaluation from it.
+          sem.applyOp(op, childDepth - 1)(newProcessed).map {
             case Right(res) => parentContOpt.continueOrTerminate(res, tail)
             case Left(err)  => err.asLeft[Result[JsonLogicValue]].asRight[Stack]
           }
@@ -563,18 +618,20 @@ object JsonLogicRuntime {
             val updatedProcessed: List[Result[JsonLogicValue]] = newProcessed :+ wrappedCallback
             if (remaining.tail.isEmpty) {
               // No more args - apply operation
-              sem.applyOp(op)(updatedProcessed).map {
+              sem.applyOp(op, childDepth - 1)(updatedProcessed).map {
                 case Right(res) => parentContOpt.continueOrTerminate(res, tail)
                 case Left(err)  => err.asLeft[Result[JsonLogicValue]].asRight[Stack]
               }
             } else {
               // More args remain
-              val newCont = Continuation(op, updatedProcessed, remaining.tail.tail, parentContOpt)
-              (Eval(remaining.tail.head, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+              val newCont = Continuation(op, updatedProcessed, remaining.tail.tail, parentContOpt, childDepth = childDepth)
+              (Eval(remaining.tail.head, Some(newCont), childDepth) :: tail)
+                .asLeft[Either[JsonLogicException, Result[JsonLogicValue]]]
+                .pure[F]
             }
           } else {
-            val newCont = Continuation(op, newProcessed, remaining.tail, parentContOpt)
-            (Eval(remaining.head, Some(newCont)) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
+            val newCont = Continuation(op, newProcessed, remaining.tail, parentContOpt, childDepth = childDepth)
+            (Eval(remaining.head, Some(newCont), childDepth) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
           }
         }
 
@@ -607,8 +664,10 @@ object JsonLogicRuntime {
                 (ApplyLetValue(finalResult, letCont) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]]
             }
           case _ =>
-            // For complex expressions, evaluate them and capture result
-            sem.evaluateWith(expr, letCtx).map {
+            // For complex expressions, evaluate them and capture result. The binding
+            // expression is a child of the let node, so the nested run resumes from
+            // childDepth - 1 (its root then evaluates at childDepth).
+            sem.evaluateWith(expr, letCtx, letCont.childDepth - 1).map {
               case Right(result) =>
                 (ApplyLetValue(result, letCont) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]]
               case Left(err) =>
@@ -628,8 +687,9 @@ object JsonLogicRuntime {
               case Some(other)              => MapValue(newBindings + ("" -> other)).some
               case None                     => MapValue(newBindings).some
             }
-            // Evaluate result and return to parent continuation
-            sem.evaluateWith(letCont.resultExpr, resultCtx).map {
+            // Evaluate result and return to parent continuation. The result expression is a
+            // child of the let node (depth = childDepth), so resume from childDepth - 1.
+            sem.evaluateWith(letCont.resultExpr, resultCtx, letCont.childDepth - 1).map {
               case Right(result) =>
                 letCont.parent.continueOrTerminate(result, tail)
               case Left(err) =>
@@ -638,7 +698,8 @@ object JsonLogicRuntime {
 
           case ArrayExpression(ConstExpression(StrValue(nextName)) :: nextValueExpr :: Nil) :: rest =>
             // Process next binding
-            val nextLetCont = LetContinuation(nextName, rest, letCont.resultExpr, newBindings, letCont.parent, letCont.originalCtx)
+            val nextLetCont =
+              LetContinuation(nextName, rest, letCont.resultExpr, newBindings, letCont.parent, letCont.originalCtx, letCont.childDepth)
             (EvalLet(nextValueExpr, nextLetCont) :: tail).asLeft[Either[JsonLogicException, Result[JsonLogicValue]]].pure[F]
 
           case invalid :: _ =>

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/GasAwareSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/GasAwareSemantics.scala
@@ -33,15 +33,26 @@ import io.constellationnetwork.metagraph_sdk.json_logic.runtime.ResultContext
  */
 object GasAwareSemantics {
 
+  /**
+   * Nested-evaluation callback for the gas-aware stack. The third argument is the SEMANTICS
+   * depth (`currentDepth`, advanced only across callback boundaries; feeds the gas metrics);
+   * the fourth is the RUNTIME recursion depth the nested run resumes from (threads the
+   * [[io.constellationnetwork.metagraph_sdk.json_logic.runtime.JsonLogicRuntime.MaxEvalDepth]]
+   * guard across callback boundaries, exactly like the un-metered evaluator).
+   */
+  type GasEvaluationCallback[F[_]] =
+    (
+      JsonLogicExpression,
+      Option[JsonLogicValue],
+      Int,
+      Int
+    ) => F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]]
+
   def make[F[_]: Sync](
     vars: JsonLogicValue,
     gasLimit: GasLimit,
     gasConfig: GasConfig,
-    evaluationStrategy: (
-      JsonLogicExpression,
-      Option[JsonLogicValue],
-      Int
-    ) => F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]],
+    evaluationStrategy: GasEvaluationCallback[F],
     currentDepth: Int = 0
   ): F[JsonLogicSemantics[F, ResultContext.WithGas]] =
     Ref.of[F, GasLimit](gasLimit).map { gasLimitRef =>
@@ -52,19 +63,16 @@ object GasAwareSemantics {
     vars: JsonLogicValue,
     gasLimitRef: Ref[F, GasLimit],
     gasConfig: GasConfig,
-    evaluationStrategy: (
-      JsonLogicExpression,
-      Option[JsonLogicValue],
-      Int
-    ) => F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]],
+    evaluationStrategy: GasEvaluationCallback[F],
     currentDepth: Int = 0
   ): JsonLogicSemantics[F, ResultContext.WithGas] = {
 
     def wrappedEval(
       expr: JsonLogicExpression,
-      ctx: Option[JsonLogicValue]
+      ctx: Option[JsonLogicValue],
+      recDepth: Int
     ): F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] =
-      evaluationStrategy(expr, ctx, currentDepth + 1)
+      evaluationStrategy(expr, ctx, currentDepth + 1, recDepth)
 
     val baseSemantics = JsonLogicSemantics.make[F, ResultContext.WithGas](vars, wrappedEval)
 
@@ -112,7 +120,8 @@ object GasAwareSemantics {
       }
 
       override def applyOp(
-        op: JsonLogicOp
+        op: JsonLogicOp,
+        recDepth: Int
       ): List[ResultContext.WithGas[JsonLogicValue]] => F[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] =
         args => {
           val argValues = args.map { case (value, _) => value }
@@ -129,7 +138,7 @@ object GasAwareSemantics {
           consumeGas(preCost).flatMap {
             case Left(err) => err.asLeft[ResultContext.WithGas[JsonLogicValue]].pure[F]
             case Right(()) =>
-              baseSemantics.applyOp(op)(args).flatMap {
+              baseSemantics.applyOp(op, recDepth)(args).flatMap {
                 case Right((value, metrics)) =>
                   // Residual component only observable on the produced value (e.g. split piece
                   // count); the work it prices is bounded by inputs that were already paid for.

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
@@ -15,7 +15,18 @@ import io.constellationnetwork.metagraph_sdk.numerics.RatioOps.implicits._
 
 trait JsonLogicSemantics[F[_], Result[_]] {
   def getVar(key: String, ctx: Option[JsonLogicValue] = None): F[Either[JsonLogicException, Result[JsonLogicValue]]]
-  def applyOp(op: JsonLogicOp): List[Result[JsonLogicValue]] => F[Either[JsonLogicException, Result[JsonLogicValue]]]
+
+  /**
+   * Apply `op` to its (already evaluated) arguments. `depth` is the runtime recursion depth of
+   * the applying node (see [[JsonLogicRuntime.MaxEvalDepth]]): handlers that run callbacks
+   * (map / filter / reduce / ...) resume nested evaluation FROM it, so the depth guard counts
+   * callback runs exactly like the Rust reference's shared depth cell.
+   */
+  def applyOp(op: JsonLogicOp, depth: Int): List[Result[JsonLogicValue]] => F[Either[JsonLogicException, Result[JsonLogicValue]]]
+
+  /** Depth-less convenience overload: applies at recursion depth 0 (top of tree). */
+  def applyOp(op: JsonLogicOp): List[Result[JsonLogicValue]] => F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+    applyOp(op, 0)
 
   /**
    * Flat per-node charge for ops the runtime dispatches LAZILY (`if` / `let`) without ever
@@ -28,8 +39,13 @@ trait JsonLogicSemantics[F[_], Result[_]] {
 
 object JsonLogicSemantics {
 
+  /**
+   * Nested-evaluation callback. The third argument is the runtime recursion depth the nested
+   * run resumes FROM (its root expression then evaluates at `depth + 1`), threading the
+   * [[JsonLogicRuntime.MaxEvalDepth]] guard across callback boundaries.
+   */
   type EvaluationCallback[F[_], Result[_]] =
-    (JsonLogicExpression, Option[JsonLogicValue]) => F[Either[JsonLogicException, Result[JsonLogicValue]]]
+    (JsonLogicExpression, Option[JsonLogicValue], Int) => F[Either[JsonLogicException, Result[JsonLogicValue]]]
 
   def apply[F[_], Result[_]](implicit ev: JsonLogicSemantics[F, Result]): JsonLogicSemantics[F, Result] = ev
 
@@ -91,13 +107,16 @@ object JsonLogicSemantics {
         }
       }
 
-      override def applyOp(op: JsonLogicOp): List[Result[JsonLogicValue]] => F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+      override def applyOp(
+        op: JsonLogicOp,
+        depth: Int
+      ): List[Result[JsonLogicValue]] => F[Either[JsonLogicException, Result[JsonLogicValue]]] =
         op match {
           case NoOp                 => _ => JsonLogicException("Got unexpected NoOp!").asLeft[Result[JsonLogicValue]].pure[F]
           case MissingNoneOp        => handleMissingNone
           case ExistsOp             => handleExists
           case MissingSomeOp        => handleMissingSome
-          case IfElseOp             => handleIfElseOp
+          case IfElseOp             => handleIfElseOp(_, depth)
           case LetOp                => handleLetOp
           case EqOp                 => handleEqOp
           case EqStrictOp           => handleEqStrictOp
@@ -122,19 +141,19 @@ object JsonLogicSemantics {
           case InOp                 => handleInOp
           case CatOp                => handleCatOp
           case SubStrOp             => handleSubstrOp
-          case MapOp                => handleMapOp
-          case FilterOp             => handleFilterOp
-          case ReduceOp             => handleReduceOp
-          case AllOp                => handleAllOp
-          case NoneOp               => handleNoneOp
-          case SomeOp               => handleSomeOp
+          case MapOp                => handleMapOp(_, depth)
+          case FilterOp             => handleFilterOp(_, depth)
+          case ReduceOp             => handleReduceOp(_, depth)
+          case AllOp                => handleAllOp(_, depth)
+          case NoneOp               => handleNoneOp(_, depth)
+          case SomeOp               => handleSomeOp(_, depth)
           case MapValuesOp          => handleMapValuesOp
           case MapKeysOp            => handleMapKeysOp
           case GetOp                => handleGetOp
           case IntersectOp          => handleIntersectOp
-          case CountOp              => handleCountOp
+          case CountOp              => handleCountOp(_, depth)
           case LengthOp             => handleLengthOp
-          case FindOp               => handleFindOp
+          case FindOp               => handleFindOp(_, depth)
           case LowerOp              => handleLowerOp
           case UpperOp              => handleUpperOp
           case JoinOp               => handleJoinOp
@@ -242,7 +261,7 @@ object JsonLogicSemantics {
         }).map(_.map(v => ResultContext[Result].flatMap(combined)(_ => v.pure[Result])))
       }
 
-      private def handleIfElseOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleIfElseOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
         val combined = ResultContext[Result].sequence(args)
         val values = ResultContext[Result].extract(combined)
 
@@ -258,7 +277,9 @@ object JsonLogicSemantics {
 
           selectedBranch match {
             case Some(branchExpr) =>
-              evaluationStrategy(branchExpr, None).map(_.map(branchResult => ResultContext[Result].flatMap(combined)(_ => branchResult)))
+              evaluationStrategy(branchExpr, None, depth).map(
+                _.map(branchResult => ResultContext[Result].flatMap(combined)(_ => branchResult))
+              )
             case None => JsonLogicException("failed during if/else evaluation").asLeft[Result[JsonLogicValue]].pure[F]
           }
         }
@@ -673,34 +694,39 @@ object JsonLogicSemantics {
 
       private def handleSubstrOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
-        def impl(str: String, start: Int, length: Int): Either[JsonLogicException, Result[JsonLogicValue]] =
+        // i64-saturating index semantics, byte-matching Rust `op_substr` (eval.rs): start/length accept the
+        // full i64 range (values beyond it error via safeToI64), index arithmetic saturates at the i64
+        // bounds, and the clamps below make saturation equivalent to exact (unbounded) arithmetic.
+        def impl(str: String, start: Long, length: Long): Either[JsonLogicException, Result[JsonLogicValue]] =
           for {
             s <- Option(str).toRight(JsonLogicException("substr expects a non-null string"))
-            strLen = s.length
-            rawStart = if (start < 0) strLen + start else start
-            startIdx = Math.max(0, Math.min(rawStart, strLen))
-            endIdx = if (length >= 0) Math.min(startIdx + length, strLen) else Math.max(0, strLen + length)
-            substr = if (startIdx >= strLen || endIdx <= startIdx) "" else s.substring(startIdx, endIdx)
+            strLen = s.length.toLong
+            rawStart = if (start < 0L) saturatingAddI64(strLen, start) else start
+            startIdx = Math.max(0L, Math.min(rawStart, strLen))
+            endIdx =
+              if (length >= 0L) Math.min(saturatingAddI64(startIdx, length), strLen)
+              else Math.max(0L, saturatingAddI64(strLen, length))
+            substr = if (startIdx >= strLen || endIdx <= startIdx) "" else s.substring(startIdx.toInt, endIdx.toInt)
           } yield (StrValue(substr): JsonLogicValue).pure[Result]
 
         args.withMetrics {
           case StrValue(str) :: IntValue(start) :: Nil =>
-            safeToInt(start, "substr start").flatMap(s => impl(str, s, str.length))
+            safeToI64(start, "substr start").flatMap(s => impl(str, s, str.length.toLong))
           case StrValue(str) :: IntValue(start) :: IntValue(length) :: Nil =>
             for {
-              s <- safeToInt(start, "substr start")
-              l <- safeToInt(length, "substr length")
+              s <- safeToI64(start, "substr start")
+              l <- safeToI64(length, "substr length")
               r <- impl(str, s, l)
             } yield r
           case _ => JsonLogicException(s"Unexpected input to `${SubStrOp.tag}` got $values").asLeft[Result[JsonLogicValue]]
         }
       }
 
-      private def handleMapOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleMapOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
         def impl(arr: List[JsonLogicValue], expr: JsonLogicExpression): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
           arr
-            .traverse(el => evaluationStrategy(expr, el.some))
+            .traverse(el => evaluationStrategy(expr, el.some, depth))
             .map(_.sequence.map(_.sequence.map(ArrayValue(_))))
 
         args.extractValues match {
@@ -709,14 +735,14 @@ object JsonLogicSemantics {
         }
       }
 
-      private def handleFilterOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleFilterOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
         def impl(
           arr: List[JsonLogicValue],
           expr: JsonLogicExpression
         ): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
           arr.traverse { el =>
-            evaluationStrategy(expr, el.some).map {
+            evaluationStrategy(expr, el.some, depth).map {
               case Right(result) =>
                 (el, result.extractValue.isTruthy).asRight[JsonLogicException]
               case Left(err) => err.asLeft[(JsonLogicValue, Boolean)]
@@ -734,7 +760,7 @@ object JsonLogicSemantics {
         }
       }
 
-      private def handleReduceOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleReduceOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
         def impl(
           arr: List[JsonLogicValue],
@@ -745,7 +771,7 @@ object JsonLogicSemantics {
             accEither match {
               case Left(err) => err.asLeft[Result[JsonLogicValue]].pure[F]
               case Right(accResult) =>
-                evaluationStrategy(expr, MapValue(Map("current" -> item, "accumulator" -> accResult.extractValue)).some).map {
+                evaluationStrategy(expr, MapValue(Map("current" -> item, "accumulator" -> accResult.extractValue)).some, depth).map {
                   case Right(newResult) =>
                     val RC = ResultContext[Result]
                     val combined = RC.flatMap(accResult)(_ => newResult)
@@ -767,14 +793,14 @@ object JsonLogicSemantics {
         }
       }
 
-      private def handleAllOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleAllOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
         def impl(
           arr: List[JsonLogicValue],
           expr: JsonLogicExpression
         ): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
           arr.traverse { el =>
-            evaluationStrategy(expr, el.some).map {
+            evaluationStrategy(expr, el.some, depth).map {
               case Right(result) => result.map(_.isTruthy).asRight[JsonLogicException]
               case Left(err)     => err.asLeft[Result[Boolean]]
             }
@@ -790,14 +816,14 @@ object JsonLogicSemantics {
         }
       }
 
-      private def handleNoneOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleNoneOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
         def impl(
           arr: List[JsonLogicValue],
           expr: JsonLogicExpression
         ): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
           arr.traverse { el =>
-            evaluationStrategy(expr, el.some).map {
+            evaluationStrategy(expr, el.some, depth).map {
               case Right(result) => result.map(v => !v.isTruthy).asRight[JsonLogicException]
               case Left(err)     => err.asLeft[Result[Boolean]]
             }
@@ -813,7 +839,7 @@ object JsonLogicSemantics {
         }
       }
 
-      private def handleSomeOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleSomeOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
         def impl(
           arr: List[JsonLogicValue],
@@ -821,7 +847,7 @@ object JsonLogicSemantics {
           threshold: Int
         ): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
           arr.traverse { el =>
-            evaluationStrategy(expr, el.some).map {
+            evaluationStrategy(expr, el.some, depth).map {
               case Right(result) =>
                 result.extractValue.isTruthy.asRight[JsonLogicException]
               case Left(err) => err.asLeft[Boolean]
@@ -887,7 +913,7 @@ object JsonLogicSemantics {
         }
       }
 
-      private def handleCountOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleCountOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
         def countSimple(arr: List[JsonLogicValue]): Either[JsonLogicException, Result[JsonLogicValue]] =
           (IntValue(arr.length): JsonLogicValue).pure[Result].asRight[JsonLogicException]
@@ -897,7 +923,7 @@ object JsonLogicSemantics {
           expr: JsonLogicExpression
         ): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
           arr.traverse { el =>
-            evaluationStrategy(expr, el.some).map {
+            evaluationStrategy(expr, el.some, depth).map {
               case Right(result) => result.extractValue.isTruthy.asRight[JsonLogicException]
               case Left(err)     => err.asLeft[Boolean]
             }
@@ -923,7 +949,7 @@ object JsonLogicSemantics {
           }
         }
 
-      private def handleFindOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
+      private def handleFindOp(args: List[Result[JsonLogicValue]], depth: Int): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
 
         def impl(
           arr: List[JsonLogicValue],
@@ -934,7 +960,7 @@ object JsonLogicSemantics {
               case (Right(acc @ Some(_)), _) =>
                 (acc.asRight[JsonLogicException]: Either[JsonLogicException, Option[JsonLogicValue]]).pure[F]
               case (Right(None), el) =>
-                evaluationStrategy(expr, el.some).map {
+                evaluationStrategy(expr, el.some, depth).map {
                   case Right(result) =>
                     (if (result.extractValue.isTruthy) Some(el) else None).asRight[JsonLogicException]
                   case Left(err) => err.asLeft[Option[JsonLogicValue]]
@@ -1030,20 +1056,27 @@ object JsonLogicSemantics {
 
       private def handleSliceOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
         args.withMetrics { values =>
+          // i64-saturating index semantics, byte-matching Rust `op_slice` (eval.rs): start/end accept the
+          // full i64 range (values beyond it error via safeToI64) and the saturating add + clamps yield
+          // the same indices as exact arithmetic (see handleSubstrOp for the same hazard).
+          def clampIndex(idx: Long, len: Long): Long =
+            if (idx < 0L) Math.max(0L, saturatingAddI64(len, idx)) else Math.min(idx, len)
+
           values match {
             case ArrayValue(arr) :: IntValue(start) :: Nil =>
-              safeToInt(start, "slice start").map { s =>
-                val startIdx = if (s < 0) Math.max(0, arr.length + s) else s
-                (ArrayValue(arr.drop(startIdx)): JsonLogicValue).pure[Result]
+              safeToI64(start, "slice start").map { s =>
+                val startIdx = clampIndex(s, arr.length.toLong)
+                (ArrayValue(arr.drop(startIdx.toInt)): JsonLogicValue).pure[Result]
               }
             case ArrayValue(arr) :: IntValue(start) :: IntValue(end) :: Nil =>
               for {
-                s <- safeToInt(start, "slice start")
-                e <- safeToInt(end, "slice end")
+                s <- safeToI64(start, "slice start")
+                e <- safeToI64(end, "slice end")
               } yield {
-                val startIdx = if (s < 0) Math.max(0, arr.length + s) else s
-                val endIdx = if (e < 0) Math.max(0, arr.length + e) else e
-                (ArrayValue(arr.slice(startIdx, endIdx)): JsonLogicValue).pure[Result]
+                val len = arr.length.toLong
+                val startIdx = clampIndex(s, len)
+                val endIdx = clampIndex(e, len)
+                (ArrayValue(arr.slice(startIdx.toInt, endIdx.toInt)): JsonLogicValue).pure[Result]
               }
             case _ => JsonLogicException(s"Unexpected input to ${SliceOp.tag}, got $values").asLeft[Result[JsonLogicValue]]
           }
@@ -1317,10 +1350,11 @@ object JsonLogicSemantics {
 
     def evaluateWith(
       program: JsonLogicExpression,
-      ctx: Option[JsonLogicValue]
+      ctx: Option[JsonLogicValue],
+      baseDepth: Int = 0
     ): F[Either[JsonLogicException, Result[JsonLogicValue]]] = {
       implicit val implicitSem: JsonLogicSemantics[F, Result] = sem
-      JsonLogicRuntime.evaluate(program, ctx)
+      JsonLogicRuntime.evaluate(program, ctx, baseDepth)
     }
   }
 }

--- a/src/test/resources/conformance/json_logic_test_vectors.json
+++ b/src/test/resources/conformance/json_logic_test_vectors.json
@@ -1,6 +1,6 @@
 {
   "description": "JSON Logic VM test vectors for cross-language compatibility",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "tests": [
     {
       "category": "constants",
@@ -309,7 +309,8 @@
         { "expr": "{\"typeof\": [{\"pow\": [3, -1]}]}", "data": "{}", "expected": "\"float\"", "note": "negative exponent on an int base yields an exact rational Float" },
         { "expr": "{\"*\": [4611686018427387904, 4]}", "data": "{}", "expected": "18446744073709551616", "note": "2^62 * 4 = 2^64: integral results stay int at any magnitude (no float demotion past i64/Long)" },
         { "expr": "{\"typeof\": [{\"*\": [4611686018427387904, 4]}]}", "data": "{}", "expected": "\"int\"" },
-        { "expr": "{\">\": [18446744073709551616, 9223372036854775807]}", "data": "{}", "expected": "true", "note": "comparison beyond 2^63 is exact (2^64 > i64::MAX)" }
+        { "expr": "{\">\": [18446744073709551616, 9223372036854775807]}", "data": "{}", "expected": "true", "note": "comparison beyond 2^63 is exact (2^64 > i64::MAX)" },
+        { "expr": "{\"+\": [\"1e-2000000000\"]}", "data": "{}", "error": true, "note": "string->number coercion bounds the effective decimal scale at 10000 (Rust Ratio::MAX_DECIMAL_SCALE): a huge exponent must error in every impl, never materialize 10^|scale|" }
       ]
     },
     {

--- a/src/test/scala/json_logic/GasMeteringSuite.scala
+++ b/src/test/scala/json_logic/GasMeteringSuite.scala
@@ -962,15 +962,17 @@ object GasMeteringSuite extends SimpleIOSuite with Checkers {
     def evalWithRef(ref: Ref[IO, GasLimit])(
       e: JsonLogicExpression,
       c: Option[JsonLogicValue],
-      d: Int
+      d: Int,
+      rd: Int
     ): IO[Either[JsonLogicException, ResultContext.WithGas[JsonLogicValue]]] = {
-      val sem = GasAwareSemantics.makeWithRef[IO](data, ref, config, (e2, c2, d2) => evalWithRef(ref)(e2, c2, d2), d)
-      JsonLogicRuntime.evaluate(e, c)(Sync[IO], ResultContext.gasContext, sem)
+      val sem =
+        GasAwareSemantics.makeWithRef[IO](data, ref, config, (e2, c2, d2, rd2) => evalWithRef(ref)(e2, c2, d2, rd2), d)
+      JsonLogicRuntime.evaluate(e, c, rd)(Sync[IO], ResultContext.gasContext, sem)
     }
 
     for {
       ref       <- Ref.of[IO, GasLimit](limit)
-      _         <- evalWithRef(ref)(expr, None, 0).flatMap(IO.fromEither)
+      _         <- evalWithRef(ref)(expr, None, 0, 0).flatMap(IO.fromEither)
       remaining <- ref.get
       reported <- JsonLogicEvaluator
         .tailRecursive[IO]

--- a/src/test/scala/json_logic/JsonLogicSpec.scala
+++ b/src/test/scala/json_logic/JsonLogicSpec.scala
@@ -3162,29 +3162,43 @@ object JsonLogicSpec extends SimpleIOSuite with Checkers {
   }
 
   // === Safe integer overflow checks ===
+  // Wave-2 parity: substr/slice indices accept the FULL i64 range with the
+  // Rust reference's saturating semantics (eval.rs op_substr / op_slice);
+  // only values beyond i64 are an error. See ParityWave2Suite for the
+  // exhaustive extreme-value pins.
 
-  test("substr with huge start index returns error") {
+  test("substr with i64::MAX start index saturates to the empty string") {
     val exprStr = """{"substr": ["hello", 9223372036854775807]}"""
     val dataStr = """null"""
 
     parseTestJson(exprStr, dataStr).flatMap {
       case (expr, data) =>
-        expectError(expr, data)
+        staticTestRunner(expr, data, StrValue(""))
     }
   }
 
-  test("slice with huge start index returns error") {
+  test("slice with i64::MAX start index saturates to the empty array") {
     val exprStr = """{"slice": [[1,2,3], 9223372036854775807]}"""
     val dataStr = """null"""
 
     parseTestJson(exprStr, dataStr).flatMap {
       case (expr, data) =>
-        expectError(expr, data)
+        staticTestRunner(expr, data, ArrayValue(Nil))
     }
   }
 
-  test("slice with huge end index returns error") {
+  test("slice with i64::MAX end index clamps to the array length") {
     val exprStr = """{"slice": [[1,2,3], 0, 9223372036854775807]}"""
+    val dataStr = """null"""
+
+    parseTestJson(exprStr, dataStr).flatMap {
+      case (expr, data) =>
+        staticTestRunner(expr, data, ArrayValue(List(IntValue(1), IntValue(2), IntValue(3))))
+    }
+  }
+
+  test("substr with a beyond-i64 start index returns error") {
+    val exprStr = """{"substr": ["hello", 9223372036854775808]}"""
     val dataStr = """null"""
 
     parseTestJson(exprStr, dataStr).flatMap {

--- a/src/test/scala/json_logic/ParityWave2Suite.scala
+++ b/src/test/scala/json_logic/ParityWave2Suite.scala
@@ -1,0 +1,202 @@
+package json_logic
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.json_logic.core._
+import io.constellationnetwork.metagraph_sdk.json_logic.gas.{GasExhaustedException, GasLimit}
+import io.constellationnetwork.metagraph_sdk.json_logic.runtime.{JsonLogicEvaluator, JsonLogicRuntime}
+
+import io.circe.parser
+import weaver.{Expectations, SimpleIOSuite}
+
+/**
+ * Wave-2 cross-language parity pins, each matching the Rust reference (`rust/jlvm-core`):
+ *
+ *   1. SCALE BOUND — string -> number coercion rejects any decimal whose effective scale magnitude
+ *      (fractional digits minus exponent) exceeds `NumericOps.MaxDecimalScale` = 10_000, mirroring
+ *      `Ratio::MAX_DECIMAL_SCALE` (ratio.rs). Without the bound, `Ratio.fromBigDecimal` would
+ *      materialize `10^|scale|` (a memory bomb for "1e-2000000000") and Scala would compute an exact
+ *      value where Rust/TS error. Coerced `==` comparisons treat an out-of-bound string as
+ *      unparseable (`false`, not an error), exactly like Rust `coercion.rs::safe_parse_decimal`.
+ *
+ *   2. SUBSTR / SLICE i64 EXTREMES — indices accept the full i64 range with saturating index
+ *      arithmetic (Rust `op_substr` / `op_slice`); values beyond i64 error ("<role> out of range").
+ *
+ *   3. DEPTH CAP — `JsonLogicRuntime.MaxEvalDepth` = 256, one unit per evaluated expression node
+ *      (operator args, literal elements, if/let children, callback runs), enforced by BOTH runtime
+ *      strategies and by the gas-metered path, matching Rust `MAX_EVAL_DEPTH` (eval.rs) exactly.
+ */
+object ParityWave2Suite extends SimpleIOSuite {
+
+  private def parse(exprStr: String): IO[JsonLogicExpression] =
+    IO.fromEither(parser.parse(exprStr).flatMap(_.as[JsonLogicExpression]))
+
+  private def evalTailRec(exprStr: String): IO[Either[JsonLogicException, JsonLogicValue]] =
+    parse(exprStr).flatMap(JsonLogicEvaluator.tailRecursive[IO].evaluate(_, MapValue.empty, None))
+
+  private def evalRecursive(exprStr: String): IO[Either[JsonLogicException, JsonLogicValue]] =
+    parse(exprStr).flatMap(JsonLogicEvaluator.recursive[IO].evaluate(_, MapValue.empty, None))
+
+  private def expectBoth(exprStr: String)(check: Either[JsonLogicException, JsonLogicValue] => Expectations): IO[Expectations] =
+    for {
+      tr  <- evalTailRec(exprStr)
+      rec <- evalRecursive(exprStr)
+    } yield check(tr).and(check(rec))
+
+  private def isOk(label: String): Either[JsonLogicException, JsonLogicValue] => Expectations = {
+    case Right(_)  => success
+    case Left(err) => failure(s"$label: expected success, got error: ${err.getMessage}")
+  }
+
+  private def isError(label: String): Either[JsonLogicException, JsonLogicValue] => Expectations = {
+    case Left(_)  => success
+    case Right(v) => failure(s"$label: expected an error, got $v")
+  }
+
+  private def isValue(label: String, expected: JsonLogicValue): Either[JsonLogicException, JsonLogicValue] => Expectations = {
+    case Right(v)  => expect.same(expected, v)
+    case Left(err) => failure(s"$label: expected $expected, got error: ${err.getMessage}")
+  }
+
+  // --- 1. decimal scale bound -------------------------------------------------------------
+
+  test("string coercion accepts |scale| == 10000 (both bound edges)") {
+    for {
+      a <- expectBoth("""{"+": ["1e-10000"]}""")(isOk("1e-10000"))
+      b <- expectBoth("""{"+": ["1e10000"]}""")(isOk("1e10000"))
+    } yield a.and(b)
+  }
+
+  test("string coercion rejects |scale| == 10001 (one past the bound)") {
+    for {
+      a <- expectBoth("""{"+": ["1e-10001"]}""")(isError("1e-10001"))
+      b <- expectBoth("""{"+": ["1e10001"]}""")(isError("1e10001"))
+    } yield a.and(b)
+  }
+
+  test("string coercion rejects the 1e-2000000000 memory bomb (fast, no 10^|scale| allocation)") {
+    expectBoth("""{"+": ["1e-2000000000"]}""")(isError("1e-2000000000"))
+  }
+
+  test("coerced == treats an out-of-bound decimal string as unparseable: false, not an error") {
+    expectBoth("""{"==": [1.5, "1e-2000000000"]}""")(isValue("== vs 1e-2000000000", BoolValue(false)))
+  }
+
+  // --- 2. substr / slice at i64 extremes ---------------------------------------------------
+
+  test("substr saturates at i64 extremes exactly like Rust op_substr") {
+    for {
+      a <- expectBoth("""{"substr": ["hello", -9223372036854775808]}""")(isValue("substr i64::MIN", StrValue("hello")))
+      b <- expectBoth("""{"substr": ["hello", 1, 9223372036854775807]}""")(isValue("substr len i64::MAX", StrValue("ello")))
+      c <- expectBoth("""{"substr": ["hello", 9223372036854775807]}""")(isValue("substr start i64::MAX", StrValue("")))
+      d <- expectBoth("""{"substr": ["hello", 0, -9223372036854775808]}""")(isValue("substr neg-len i64::MIN", StrValue("")))
+    } yield a.and(b).and(c).and(d)
+  }
+
+  test("substr/slice indices beyond the i64 range are an error (Rust bigint_to_i64 parity)") {
+    for {
+      a <- expectBoth("""{"substr": ["hello", 9223372036854775808]}""")(isError("substr start > i64::MAX"))
+      b <- expectBoth("""{"slice": [[1, 2, 3], -9223372036854775809]}""")(isError("slice start < i64::MIN"))
+    } yield a.and(b)
+  }
+
+  test("slice saturates at i64 extremes exactly like Rust op_slice") {
+    val arr123 = ArrayValue(List(IntValue(1), IntValue(2), IntValue(3)))
+    for {
+      a <- expectBoth("""{"slice": [[1, 2, 3], -9223372036854775808]}""")(isValue("slice i64::MIN", arr123))
+      b <- expectBoth("""{"slice": [[1, 2, 3], 0, 9223372036854775807]}""")(isValue("slice end i64::MAX", arr123))
+      c <- expectBoth("""{"slice": [[1, 2, 3], 9223372036854775807]}""")(isValue("slice start i64::MAX", ArrayValue(Nil)))
+    } yield a.and(b).and(c)
+  }
+
+  // --- 3. MaxEvalDepth --------------------------------------------------------------------
+
+  /** A chain of `n` nested `{"!": [...]}` ops over `true`: max node depth is n + 1 (the constant). */
+  private def nestedNot(n: Int): JsonLogicExpression =
+    (1 to n).foldLeft(ConstExpression(BoolValue(true)): JsonLogicExpression) { (acc, _) =>
+      ApplyExpression(JsonLogicOp.NotOp, List(acc))
+    }
+
+  test("255 nested operators evaluate (max node depth 256 == MaxEvalDepth) in both strategies") {
+    val expr = nestedNot(JsonLogicRuntime.MaxEvalDepth - 1)
+    for {
+      tr  <- JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, MapValue.empty, None)
+      rec <- JsonLogicEvaluator.recursive[IO].evaluate(expr, MapValue.empty, None)
+    } yield
+      isValue("255 nested (tailrec)", BoolValue(false))(tr)
+        .and(isValue("255 nested (recursive)", BoolValue(false))(rec))
+  }
+
+  test("256 nested operators exceed MaxEvalDepth (node depth 257) in both strategies") {
+    val expr = nestedNot(JsonLogicRuntime.MaxEvalDepth)
+    val expectedMsg = s"Recursion depth limit exceeded (${JsonLogicRuntime.MaxEvalDepth})"
+
+    def checkErr(label: String): Either[JsonLogicException, JsonLogicValue] => Expectations = {
+      case Left(err) => expect.same(expectedMsg, err.getMessage)
+      case Right(v)  => failure(s"$label: expected depth error, got $v")
+    }
+
+    for {
+      tr  <- JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, MapValue.empty, None)
+      rec <- JsonLogicEvaluator.recursive[IO].evaluate(expr, MapValue.empty, None)
+    } yield checkErr("256 nested (tailrec)")(tr).and(checkErr("256 nested (recursive)")(rec))
+  }
+
+  test("callback runs count toward the depth cap (map body resumes from the map node's depth)") {
+    // map node at depth 1, callback body root at depth 2: a body of k nested `!` over {"var":""}
+    // has its ops at depths 2..k+1 and the var at k+2. k = 254 -> max 256 (ok);
+    // k = 255 -> 257 (error). Matches Rust, where op_map's callback eval continues from the
+    // shared depth cell.
+    def mapWithBody(k: Int): JsonLogicExpression = {
+      val body = (1 to k).foldLeft(VarExpression(Left(""), None): JsonLogicExpression) { (acc, _) =>
+        ApplyExpression(JsonLogicOp.NotOp, List(acc))
+      }
+      ApplyExpression(JsonLogicOp.MapOp, List(ConstExpression(ArrayValue(List(IntValue(1)))), body))
+    }
+
+    for {
+      ok  <- JsonLogicEvaluator.tailRecursive[IO].evaluate(mapWithBody(254), MapValue.empty, None)
+      err <- JsonLogicEvaluator.tailRecursive[IO].evaluate(mapWithBody(255), MapValue.empty, None)
+    } yield isOk("map body at the cap")(ok).and(isError("map body past the cap")(err))
+  }
+
+  test("let bindings and result count toward the depth cap") {
+    // let node at depth 1; binding/result expressions are children at depth 2.
+    def letWithBinding(k: Int): JsonLogicExpression = {
+      val bound = nestedNot(k)
+      ApplyExpression(
+        JsonLogicOp.LetOp,
+        List(
+          ArrayExpression(List(ArrayExpression(List(ConstExpression(StrValue("x")), bound)))),
+          VarExpression(Left("x"), None)
+        )
+      )
+    }
+    // binding root at depth 2, ops at 2..k+1, const at k+2: k = 254 ok, k = 255 error.
+    for {
+      ok  <- JsonLogicEvaluator.tailRecursive[IO].evaluate(letWithBinding(254), MapValue.empty, None)
+      err <- JsonLogicEvaluator.tailRecursive[IO].evaluate(letWithBinding(255), MapValue.empty, None)
+    } yield isOk("let binding at the cap")(ok).and(isError("let binding past the cap")(err))
+  }
+
+  test("untaken if branches never count toward the depth cap (lazy, like Rust)") {
+    val deepElse = nestedNot(400) // far past the cap, but never evaluated
+    val expr = ApplyExpression(
+      JsonLogicOp.IfElseOp,
+      List(ConstExpression(BoolValue(true)), ConstExpression(IntValue(1)), deepElse)
+    )
+    JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, MapValue.empty, None).map(isValue("lazy else", IntValue(1)))
+  }
+
+  test("the gas-metered evaluator enforces the same depth cap with a non-gas error") {
+    val expr = nestedNot(JsonLogicRuntime.MaxEvalDepth)
+    JsonLogicEvaluator
+      .tailRecursive[IO]
+      .evaluateWithGas(expr, MapValue.empty, None, GasLimit.Unlimited)
+      .map {
+        case Left(_: GasExhaustedException) => failure("expected a depth error, got gas exhaustion")
+        case Left(err) => expect.same(s"Recursion depth limit exceeded (${JsonLogicRuntime.MaxEvalDepth})", err.getMessage)
+        case Right(v)  => failure(s"expected depth error, got ${v.value}")
+      }
+  }
+}


### PR DESCRIPTION
Closes the wave-2 parity items against the Rust reference: (1) |decimal scale| <= 10_000 bound on string→number coercion, checked BEFORE Ratio materializes 10^|scale| (kills the Scala-side memory-bomb path; coerced == returns false out-of-bound, matching coercion.rs); (2) substr/slice index math moved from i32-error to Rust's exact i64 saturating semantics with byte-matching error text (3 stale tests updated); (3) MaxEvalDepth=256 recursion-depth policy bound in BOTH evaluator strategies incl. callback boundaries — boundary behavior (255/256, callback 254/255, lazy branches free) verified identical against the actual Rust evaluator. Shared vectors v1.4.0 (byte-identical with sdk), new ParityWave2Suite. **1026/1026 green.**

Residual flags (follow-up tracked): JSON number LITERALS like 1e-2000000000 still reach Ratio via the circe decode path (Rust decodes to Null); some/missing_some thresholds still i32-bounded; BigDecimal string parse rounds >34 sig digits where Rust/TS are exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)