### PR TITLE
fix(bls): optional JVM BLS backend — runtime gate, no published BC requirement

### DIFF
--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -71,17 +71,24 @@ Include this paragraph (or equivalent) in the release notes:
 > required because the BLS12-381 API (`org.bouncycastle.crypto.bls.*`) behind
 > metakit's eth2-ciphersuite BLS primitive exists only in the unreleased 1.85
 > line. The exact bytes are sha256-pinned in `lib/README.md` and enforced in
-> CI. IMPORTANT for consumers: the vendored `lib/` jars are unmanaged and are
-> NOT part of the published metakit artifact — the published POM excludes the
-> transitive BC 1.70 artifacts but ships no replacement. A consumer that
-> exercises the BLS primitive (`bls_verify` / `bls_aggregate_verify`) MUST
-> vendor the same sha256-pinned jars with the same `build.sbt` exclusion hack
-> (see `lib/README.md`), or those code paths fail with `NoClassDefFoundError`
-> at runtime. Consumers that never touch BLS are unaffected (the classes load
-> lazily on first use). These jars
-> will be replaced with the managed `org.bouncycastle:*:1.85` Maven Central
-> artifacts the moment BC publishes a stable 1.85; see `lib/README.md` for the
-> migration delta and the deferred source-verification checklist.
+> CI. The jars are **build/test-time only**: unmanaged jars are never part of
+> the published metakit artifact, so published metakit has **no BouncyCastle
+> requirement** (the POM excludes the transitive BC 1.70 artifacts and ships
+> no replacement). The JVM BLS backend is therefore OPTIONAL at runtime: a
+> runtime gate (`io.constellationnetwork.metagraph_sdk.crypto.bls.BlsBackend`,
+> probed once on first BLS use, cached) makes the BLS opcodes (`bls_verify` /
+> `bls_aggregate_verify`) gracefully unavailable on a backend-less classpath —
+> they return the deterministic error
+> `"<op> unavailable: BouncyCastle 1.85 BLS backend not on classpath"` instead
+> of throwing `NoClassDefFoundError`. A consumer that wants the BLS opcodes to
+> actually verify supplies the backend: either the same sha256-pinned jars
+> with the same `build.sbt` exclusion hack (see `lib/README.md`), or — once BC
+> publishes a stable 1.85 to Maven Central — the managed
+> `org.bouncycastle:*:1.85` artifacts. Everything else in metakit is
+> unaffected either way, and the Rust (`blst`) / TypeScript (`@noble/curves`)
+> implementations have their own managed BLS backends and are not impacted.
+> See `lib/README.md` for the migration delta and the deferred
+> source-verification checklist.
 
 Release-blocking sub-items (tracked in `lib/README.md`):
 
@@ -137,6 +144,10 @@ Release-blocking sub-items (tracked in `lib/README.md`):
 - BLS12-381 reworked to the eth2 proof-of-possession ciphersuite on
   BouncyCastle 1.85, byte-matching tessellation-bls (#33). See the BC beta
   disclosure above.
+- JVM BLS backend made OPTIONAL at runtime (`BlsBackend` gate): published
+  metakit carries no BC requirement; `bls_verify` / `bls_aggregate_verify`
+  return a deterministic "unavailable" error on a backend-less classpath
+  instead of throwing `NoClassDefFoundError` (this PR).
 
 ### Std / hardening
 

--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,17 @@ lazy val commonSettings = Seq(
   // TRANSITIVELY; we drop that here so only the vendored 1.85 jdk18on jars provide
   // org.bouncycastle on the classpath -- otherwise the 1.70 classes shadow the 1.85 ones and
   // the org.bouncycastle.crypto.bls package is missing at compile time.
+  //
+  // OPTIONAL-BACKEND CONTRACT: the lib/ jars are BUILD- and TEST-time only. Unmanaged jars are
+  // never published and never appear in the POM, so the released metakit artifact carries NO
+  // BouncyCastle 1.85 requirement. The runtime gate
+  // (io.constellationnetwork.metagraph_sdk.crypto.bls.BlsBackend) probes the classpath on first
+  // BLS use: consumers without the jars get a deterministic
+  // "<op> unavailable: BouncyCastle 1.85 BLS backend not on classpath" JsonLogicException from
+  // the bls_verify / bls_aggregate_verify opcodes instead of a NoClassDefFoundError crash.
   // MIGRATION DELTA when 1.85 is published: delete ./lib/*.jar, drop this excludeDependencies
-  // block, and add a managed `org.bouncycastle %% bcprov-jdk18on % 1.85` dependency.
+  // block, and add a managed `org.bouncycastle %% bcprov-jdk18on % 1.85` dependency (the
+  // BlsBackend gate then always reports available and needs no change).
   excludeDependencies ++= Seq(
     ExclusionRule("org.bouncycastle", "bcprov-jdk15on"),
     ExclusionRule("org.bouncycastle", "bcpkix-jdk15on"),

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,4 +1,4 @@
-# Vendored BouncyCastle 1.85 beta (DO NOT MERGE TO A PUBLISHED RELEASE AS-IS)
+# Vendored BouncyCastle 1.85 beta (build/test-time only — never published)
 
 These are **beta / snapshot** BouncyCastle 1.85 jars, vendored because the
 BLS12-381 API metakit's eth2-ciphersuite BLS primitive depends on
@@ -6,6 +6,30 @@ BLS12-381 API metakit's eth2-ciphersuite BLS primitive depends on
 `BLS12_381ProofOfPossession`, `BLS12_381Serialization`, `BLS12_381Aggregation`,
 …) exists **only** in the 1.85 line and is not yet published as a stable
 managed artifact.
+
+## Scope: the BLS backend is OPTIONAL at runtime
+
+The jars in this directory are used to **build and test** metakit only. They
+are sbt *unmanaged* jars: they are never part of the published artifact, never
+appear in the POM, and the published metakit carries **no BouncyCastle 1.85
+requirement**. Whether a consumer's classpath has the backend is checked at
+runtime by `io.constellationnetwork.metagraph_sdk.crypto.bls.BlsBackend`
+(probed once on first BLS use, result cached):
+
+- **Backend absent** (the default for consumers of the published artifact):
+  the JLVM opcodes `bls_verify` / `bls_aggregate_verify` return the
+  deterministic error
+  `"<op> unavailable: BouncyCastle 1.85 BLS backend not on classpath"`
+  as a `Left(JsonLogicException)` — they never throw, never leak a
+  `NoClassDefFoundError`, and the rest of metakit (including every other
+  crypto opcode) is completely unaffected.
+- **Backend present** (this repo's own build/tests; a consumer that vendors
+  the exact sha256-pinned jars below with the same `build.sbt` exclusion hack;
+  or, in the future, the managed BC 1.85 Maven Central artifacts): the BLS
+  opcodes work normally.
+
+The Rust (`blst`) and TypeScript (`@noble/curves`) implementations have their
+own managed BLS backends and are unaffected by any of this.
 
 ## Pinned hashes (enforced in CI)
 
@@ -73,7 +97,9 @@ release-blocking checklist item:
 
 ## How they are wired in (build.sbt)
 
-sbt auto-adds `<project>/lib/*.jar` to the classpath via `unmanagedBase`. The
+sbt auto-adds `<project>/lib/*.jar` to the **local build and test** classpath
+via `unmanagedBase`; unmanaged jars are not published and add nothing to the
+POM (see "Scope" above for the runtime contract consumers get instead). The
 `tessellation-sdk` managed dependency pulls BouncyCastle **1.70**
 (`bcprov`/`bcpkix`/`bcutil-jdk15on`) transitively; that 1.70 line does **not**
 contain the `org.bouncycastle.crypto.bls` package and, left on the classpath,
@@ -103,7 +129,9 @@ Central, as soon as they exist:
    `"org.bouncycastle" % "bcpkix-jdk18on" % "1.85"`) dependencies (plain `%` —
    these are Java artifacts).
 
-Nothing in `Bls12381.scala` or the BLS tests changes.
+Nothing in `Bls12381.scala`, `BlsBackend.scala` (the runtime gate simply
+always reports available once the backend is a managed dependency) or the BLS
+tests changes.
 
 ## Ciphersuite (the byte-identity contract)
 

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/bls/Bls12381.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/bls/Bls12381.scala
@@ -39,6 +39,12 @@ import org.bouncycastle.math.ec.{ECCurve, ECPoint}
  * The verification entry points ([[verify]], [[fastAggregateVerify]]) never throw: malformed or
  * non-canonical inputs (bad point encoding, non-subgroup member, wrong width) return `false`. This
  * is what the JLVM crypto opcodes consume.
+ *
+ * ==Optional backend==
+ * The `org.bouncycastle.crypto.bls` API exists only in the (unpublished) BC 1.85 line, vendored as
+ * build/test-time-only unmanaged jars in `lib/` — the published metakit artifact carries no BC
+ * requirement, so this object may fail to initialize on a consumer classpath. Callers must check
+ * [[BlsBackend.isAvailable]] before first touching this object; the JLVM opcodes do.
  */
 object Bls12381 {
 

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/bls/BlsBackend.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/crypto/bls/BlsBackend.scala
@@ -1,0 +1,59 @@
+package io.constellationnetwork.metagraph_sdk.crypto.bls
+
+/**
+ * Runtime availability gate for the OPTIONAL BouncyCastle 1.85 BLS backend.
+ *
+ * The eth2-ciphersuite BLS primitive ([[Bls12381]]) compiles against
+ * `org.bouncycastle.crypto.bls.*`, which exists ONLY in the (unpublished) BouncyCastle 1.85 line.
+ * metakit builds and tests against the sha256-pinned beta jars vendored in `lib/` (sbt's
+ * `unmanagedBase`), but unmanaged jars are NEVER part of the published artifact or its POM: the
+ * published metakit carries NO BouncyCastle-1.85 linkage requirement.
+ *
+ * This object is the contract that makes that safe. It probes — exactly once, cached — whether
+ * [[Bls12381]] can be initialized on the current classpath:
+ *
+ *   - Backend present (metakit's own build/tests, or a consumer who vendored the pinned jars, or a
+ *     future managed BC 1.85): [[isAvailable]] is `true` and the BLS opcodes work normally.
+ *   - Backend absent (any consumer of the published artifact who did not supply the jars; also a
+ *     classpath where BC 1.70 shadows 1.85): initializing [[Bls12381]] fails with a
+ *     `LinkageError` (`NoClassDefFoundError` / `ExceptionInInitializerError`); the probe catches
+ *     it, [[isAvailable]] is `false`, and the JLVM BLS opcodes (`bls_verify` /
+ *     `bls_aggregate_verify`) return the DETERMINISTIC error [[unavailableMessage]] as a
+ *     `Left(JsonLogicException)` — they never throw and never crash the evaluator.
+ *
+ * Nothing here references `org.bouncycastle` types, so this class always loads. The [[Bls12381]]
+ * methods the gated callers invoke after a successful probe carry no BC types in their signatures
+ * either, so linking them is safe once initialization has succeeded.
+ */
+object BlsBackend {
+
+  /**
+   * Whether the BC 1.85 BLS backend is on the classpath. Computed once on first use (per the JVM
+   * spec a failed class initialization is permanent for the lifetime of the classloader, so
+   * retrying could never succeed anyway).
+   */
+  lazy val isAvailable: Boolean = probe { () =>
+    val _ = Bls12381.SignatureBytes // forces Bls12381 <clinit>, which touches org.bouncycastle.crypto.bls
+  }
+
+  /**
+   * Runs `forceBackendInit` and classifies the outcome: `true` if it completes, `false` on any
+   * `LinkageError` (covers `NoClassDefFoundError` and `ExceptionInInitializerError`). Public so
+   * the absence path stays unit-testable without manipulating the classpath; production code uses
+   * the cached [[isAvailable]].
+   */
+  def probe(forceBackendInit: () => Unit): Boolean =
+    try {
+      forceBackendInit()
+      true
+    } catch {
+      case _: LinkageError => false
+    }
+
+  /**
+   * The deterministic message the BLS opcodes fail with when the backend is absent. Deliberately
+   * environment-independent (no exception details) so the error is byte-stable across consumers.
+   */
+  def unavailableMessage(op: String): String =
+    s"$op unavailable: BouncyCastle 1.85 BLS backend not on classpath"
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/CryptoOps.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/CryptoOps.scala
@@ -6,7 +6,7 @@ import java.security.MessageDigest
 import cats.syntax.either._
 import cats.syntax.traverse._
 
-import io.constellationnetwork.metagraph_sdk.crypto.bls.Bls12381
+import io.constellationnetwork.metagraph_sdk.crypto.bls.{Bls12381, BlsBackend}
 import io.constellationnetwork.metagraph_sdk.crypto.vrf.MiraclEcVrf25519
 import io.constellationnetwork.metagraph_sdk.crypto.zk.merkle.{PoseidonMerkleProof, PoseidonMerkleTree}
 import io.constellationnetwork.metagraph_sdk.crypto.zk.poseidon.Poseidon
@@ -279,12 +279,21 @@ object CryptoOps {
   // ---------------------------------------------------------------------------
   // bls_verify: [pkHex(48B G1), msgHex, sigHex(96B G2)] -> bool.
   //   Eth2 / IETF ProofOfPossession ciphersuite (BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_).
+  //
+  //   OPTIONAL BACKEND: both bls opcodes are gated on BlsBackend (the BC 1.85
+  //   `org.bouncycastle.crypto.bls` jars are build/test-time unmanaged deps, never published).
+  //   When the backend is absent the opcodes return a deterministic Left — they never throw.
+  //   The gate runs FIRST so nothing below it can touch Bls12381 on a backend-less classpath.
   // ---------------------------------------------------------------------------
+
+  private def requireBlsBackend(op: String): Either[JsonLogicException, Unit] =
+    Either.cond(BlsBackend.isAvailable, (), JsonLogicException(BlsBackend.unavailableMessage(op)))
 
   def blsVerify(values: List[JsonLogicValue]): Either[JsonLogicException, JsonLogicValue] =
     values match {
       case pkV :: msgV :: sigV :: Nil =>
         for {
+          _      <- requireBlsBackend("bls_verify")
           pkHex  <- expectStr("bls_verify pk")(pkV)
           msgHex <- expectStr("bls_verify msg")(msgV)
           sigHex <- expectStr("bls_verify sig")(sigV)
@@ -306,6 +315,7 @@ object CryptoOps {
     values match {
       case ArrayValue(pksV) :: msgV :: aggSigV :: Nil =>
         for {
+          _      <- requireBlsBackend("bls_aggregate_verify")
           _      <- Either.cond(pksV.nonEmpty, (), JsonLogicException("bls_aggregate_verify: at least one public key required"))
           msgHex <- expectStr("bls_aggregate_verify msg")(msgV)
           sigHex <- expectStr("bls_aggregate_verify aggSig")(aggSigV)

--- a/src/test/scala/crypto/bls/BlsBackendSuite.scala
+++ b/src/test/scala/crypto/bls/BlsBackendSuite.scala
@@ -1,0 +1,82 @@
+package crypto.bls
+
+import io.constellationnetwork.metagraph_sdk.crypto.bls.{Bls12381, BlsBackend}
+import io.constellationnetwork.metagraph_sdk.json_logic.core.{ArrayValue, StrValue}
+import io.constellationnetwork.metagraph_sdk.json_logic.ops.CryptoOps
+
+import weaver.SimpleIOSuite
+
+/**
+ * Contract suite for the OPTIONAL-backend gate ([[BlsBackend]]).
+ *
+ * metakit's own test classpath carries the vendored BC 1.85 jars, so the backend is PRESENT here
+ * (asserted below; the bls categories of `ZkVectorConformanceSuite` and the `ZkOpsWave2Suite` /
+ * `Bls12381Suite` known-answer tests then exercise the available path normally). The ABSENT path
+ * cannot be reproduced on this classpath — a failed class init is permanent per classloader — so
+ * it is covered by driving the gate's probe function directly with the exact linkage errors a
+ * backend-less consumer JVM raises, plus pinning the deterministic error message the opcodes
+ * surface.
+ */
+object BlsBackendSuite extends SimpleIOSuite {
+
+  pureTest("backend is available on metakit's own (vendored-jar) classpath") {
+    expect(BlsBackend.isAvailable)
+  }
+
+  pureTest("probe -> true when backend init succeeds") {
+    expect(BlsBackend.probe(() => ()))
+  }
+
+  pureTest("probe -> false on NoClassDefFoundError (backend jars absent / BC 1.70 shadowing)") {
+    expect(!BlsBackend.probe(() => throw new NoClassDefFoundError("org/bouncycastle/crypto/bls/BLS12_381G1")))
+  }
+
+  pureTest("probe -> false on ExceptionInInitializerError (backend class init failed)") {
+    expect(!BlsBackend.probe(() => throw new ExceptionInInitializerError(new RuntimeException("boom"))))
+  }
+
+  pureTest("probe does NOT swallow non-linkage failures") {
+    val thrown =
+      try {
+        BlsBackend.probe(() => throw new RuntimeException("not a linkage problem"))
+        false
+      } catch { case _: RuntimeException => true }
+    expect(thrown)
+  }
+
+  pureTest("unavailable message is the deterministic, environment-independent contract string") {
+    expect
+      .eql(
+        "bls_verify unavailable: BouncyCastle 1.85 BLS backend not on classpath",
+        BlsBackend.unavailableMessage("bls_verify")
+      )
+      .and(
+        expect.eql(
+          "bls_aggregate_verify unavailable: BouncyCastle 1.85 BLS backend not on classpath",
+          BlsBackend.unavailableMessage("bls_aggregate_verify")
+        )
+      )
+  }
+
+  pureTest("opcode arity errors gate AFTER availability: with backend present, malformed args still error normally") {
+    // Guards the gate's position in the handler: on this (backend-present) classpath the
+    // pre-existing arity/shape errors must be unchanged by the gate.
+    val r = CryptoOps.blsVerify(List(StrValue("deadbeef")))
+    expect(r.isLeft).and(expect(r.swap.exists(_.getMessage.startsWith("bls_verify: expected"))))
+  }
+
+  pureTest("aggregate opcode shape errors unchanged by the gate") {
+    val r = CryptoOps.blsAggregateVerify(List(ArrayValue(List.empty), StrValue("00"), StrValue("00")))
+    expect(r.isLeft).and(
+      expect(
+        r.swap.exists(_.getMessage == "bls_aggregate_verify: at least one public key required")
+      )
+    )
+  }
+
+  pureTest("gate constants would match the backend's (sanity: probe target is the real init)") {
+    // The probe forces Bls12381's init via SignatureBytes; assert the values it exposes are the
+    // wire sizes the opcodes parse against, so the probe target cannot silently drift.
+    expect.eql(48, Bls12381.PublicKeyBytes).and(expect.eql(96, Bls12381.SignatureBytes))
+  }
+}


### PR DESCRIPTION
Stacked on #41 (this branch includes #41's jar-pin + release.yml commits; merging this **subsumes #41** — close it as merged-via-this). Implements Jim's decision: the JVM BLS backend is OPTIONAL until a valid managed BC 1.85 dependency exists.

- **Runtime gate** (`crypto.bls.BlsBackend`): probes the backend once on first BLS use (cached — a failed class-init is permanent per classloader), catching `LinkageError` (covers NoClassDefFoundError, ExceptionInInitializerError, and BC-1.70-shadowing). `bls_verify`/`bls_aggregate_verify` short-circuit FIRST in their handlers: on a backend-less classpath they return the deterministic `Left(JsonLogicException("<op> unavailable: BouncyCastle 1.85 BLS backend not on classpath"))` — never a thrown error, and `Bls12381` is never even linked.
- **Published metakit carries no BC requirement** — unmanaged jars were never in the POM; the gate makes that reality safe. Jars stay in lib/ for metakit's own build/tests (sha256 pins + ci.yml/release.yml checks from #41 still enforce them).
- **Rust (blst) / TS (@noble) unaffected** — they have valid managed deps and keep BLS live.
- Docs reworded: lib/README.md drops "DO NOT MERGE", gains the optional-backend contract; RELEASE-CHECKLIST.md consumer paragraph now says "gracefully unavailable" instead of "must vendor or NoClassDefFoundError". When stable BC 1.85 publishes: one managed dep line enables BLS for every consumer, delete lib/.
- New BlsBackendSuite (9 tests: probe semantics, deterministic messages, non-linkage rethrow). **1021/1021 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)