### PR TITLE
feat(lifecycle): CommittedState — two-tier state-root commitment (MPT state-dict + SMT root catalog)

### DIFF
--- a/docs/committed-namespaces.md
+++ b/docs/committed-namespaces.md
@@ -1,0 +1,108 @@
+# Committed state: key namespaces and the root catalog
+
+This is the key specification for the `lifecycle/committed` module — the two-tier state-root
+commitment (`CommittedView` → MPT state-dict + SMT root catalog) that `CommittedApp.makeL0` wires
+into a metagraph L0 data application.
+
+## 1. CommitKey grammar (tier 1: the MPT state dictionary)
+
+A `CommitKey` is a validated, namespaced path into the committed dictionary:
+
+```
+key      = segment *( "/" segment )
+segment  = seg-head *seg-tail
+seg-head = %x61-7A / %x30-39              ; [a-z0-9]
+seg-tail = %x61-7A / %x30-39 / "_" / "." / "-"
+```
+
+Limits (enforced by `CommitKey.from`):
+
+| limit               | value |
+|---------------------|-------|
+| max segment length  | 64 characters |
+| max segments        | 16 |
+| max total length    | 256 characters |
+| case                | lowercase only |
+| empty segments      | rejected (no leading/trailing/double `/`) |
+
+### MPT path encoding
+
+The MPT path of a key is the **lowercase hex of its UTF-8 bytes** (`CommitKey.toHex`), giving
+variable-length, byte-aligned trie paths. Because `/` is a single byte (`0x2f`), the hex of
+`"ns/"` is a strict prefix of the hex of every key under `ns` — this is what makes namespace
+prefix proofs segment-exact. `CommitNamespace.prefixHex` is the hex of `value + "/"`, so the
+prefix attestation for namespace `fiber` can never leak keys under `fiberx/`.
+
+The encoding is directly compatible with the JLVM auth-DB opcodes (`mpt_verify`,
+`mpt_prefix_verify`): those take the same lowercase hex with a `0x` prefix added (`"0x" +
+key.toHex.value`), values as JSON, and the proof JSON exactly as the metakit provers emit it.
+See `AuthDbOps` / `HexBytes.parseNibbleHex` — odd nibble counts are legal there, and our
+byte-aligned (even-nibble) paths are a subset. Compatibility is exercised by
+`CommittedProofSuite`.
+
+### Reserved top-level namespaces
+
+| namespace          | contents |
+|--------------------|----------|
+| `fiber/<uuid>`     | state-machine fiber state (uuid lowercase hyphenated) |
+| `registry/<name>`  | registry entries |
+| `oracle/<id>`      | oracle/script state |
+| `meta/...`         | module/system metadata (versioning, schema ids, config digests) |
+
+Applications may add further top-level namespaces, but must not repurpose the reserved ones.
+
+## 2. SMT catalog key scheme (tier 2: the root catalog)
+
+The catalog is a `SparseMerkleTree` of **fixed-length keys**: `sha256(name)` rendered as the
+64-char lowercase hex `Hex` (see `CommitCatalog.catalogKey`). Names are `family:qualifier`
+strings:
+
+| name           | value (32 raw bytes)                      |
+|----------------|-------------------------------------------|
+| `current:mpt`  | the CURRENT state-dict MPT root            |
+| `ordinal:<N>`  | the MPT root committed at snapshot ordinal N (`<N>` decimal, no padding) |
+
+The stored SMT value is the raw 32-byte root digest (`CommitCatalog.rootValueBytes`). The scheme
+is extensible: any other root a metagraph commits (a Poseidon shadow root, a sub-registry root, a
+cross-module index) gets its own family name. SMT absence proofs are first-class, so
+"ordinal `N` was never committed" is provable against `smtRoot`.
+
+## 3. The commitment and `hashCalculatedState`
+
+Per snapshot the module exposes `commitment = (mptRoot, smtRoot)` and defines the single
+consensus-facing hash:
+
+```
+calculatedStateHash = sha256( rawBytes(mptRoot) ++ rawBytes(canonicalSmtRoot) )
+```
+
+where `canonicalSmtRoot` is the root of the **canonical single-entry catalog**
+`{ sha256("current:mpt") → mptRoot }`. Rationale (`CommittedCommitment` scaladoc has the full
+version): `hashCalculatedState` must be a *pure function of the state value* — tessellation calls
+it on freshly downloaded state with no local history — while the live catalog root depends on the
+historical `ordinal:<N>` entries. The canonical catalog keeps the hash pure in the value yet still
+binds tier 2's key scheme and hash discipline. Nothing is lost: each historical `ordinal:<N>` root
+was `current:mpt` at ordinal N and is anchored by snapshot N's own calculated-state proof. The
+live catalog (with history) is a node-local, *verifiable* index served by `/committed/root` and
+SMT proofs.
+
+## 4. Routes (all read one cell value)
+
+```
+GET  /committed/root                 { ordinal, mptRoot, smtRoot, calculatedStateHash }
+GET  /committed/proof/<key...>       single-key inclusion proof
+POST /committed/proofs               batch proof, body { "keys": [ "ns/a", ... ] }
+GET  /committed/proof-prefix/<ns...> complete prefix attestation for a namespace
+GET  /committed/delta/:ordinal       StateDelta (404 after ring-buffer eviction)
+GET  /committed/snapshot             CommittedSnapshot (replication fallback)
+```
+
+## 5. Why a hierarchy: super-registries and cross-metagraph slices
+
+The namespace hierarchy is the unit of *delegated commitment*. A super-registry can commit
+sub-registries as namespaces (`registry/<name>/...`), and later promote a sub-registry to its own
+catalog entry without changing key shapes. Cross-metagraph: ML0_B asks ML0_A for
+`/committed/proof-prefix/registry/tokens` and verifies the returned complete slice against ML0_A's
+`mptRoot` — trust-anchored without trusting the serving node, via gl0's
+`CurrencySnapshotMptRoots` → the snapshot's `calculatedStateProof` (= `hashCalculatedState`
+above) → `mptRoot`. The same path serves JLVM contracts on ML0_B through `mpt_prefix_verify`.

--- a/docs/committed-namespaces.md
+++ b/docs/committed-namespaces.md
@@ -1,8 +1,8 @@
-# Committed state: key namespaces and the root catalog
+# Committed state: key namespaces, the root catalog, and the on-chain breadcrumb
 
 This is the key specification for the `lifecycle/committed` module — the two-tier state-root
-commitment (`CommittedView` → MPT state-dict + SMT root catalog) that `CommittedApp.makeL0` wires
-into a metagraph L0 data application.
+commitment (`CommittedView` → MPT state-dict + epoch-rollup root catalog) that
+`CommittedApp.makeL0` wires into a metagraph L0 data application.
 
 ## 1. CommitKey grammar (tier 1: the MPT state dictionary)
 
@@ -51,58 +51,173 @@ byte-aligned (even-nibble) paths are a subset. Compatibility is exercised by
 
 Applications may add further top-level namespaces, but must not repurpose the reserved ones.
 
-## 2. SMT catalog key scheme (tier 2: the root catalog)
+## 2. Catalog composition (tier 2: the LIVE root catalog, epoch rollup)
 
-The catalog is a `SparseMerkleTree` of **fixed-length keys**: `sha256(name)` rendered as the
-64-char lowercase hex `Hex` (see `CommitCatalog.catalogKey`). Names are `family:qualifier`
-strings:
+The catalog commits the **full root history** — the current state-dict root plus the MPT root of
+every past ordinal — without ever growing the consensus-facing artifacts: historical roots are
+rolled up in a TWO-LEVEL epoch structure (`EpochCatalog`).
 
-| name           | value (32 raw bytes)                      |
-|----------------|-------------------------------------------|
-| `current:mpt`  | the CURRENT state-dict MPT root            |
-| `ordinal:<N>`  | the MPT root committed at snapshot ordinal N (`<N>` decimal, no padding) |
-
-The stored SMT value is the raw 32-byte root digest (`CommitCatalog.rootValueBytes`). The scheme
-is extensible: any other root a metagraph commits (a Poseidon shadow root, a sub-registry root, a
-cross-module index) gets its own family name. SMT absence proofs are first-class, so
-"ordinal `N` was never committed" is provable against `smtRoot`.
-
-## 3. The commitment and `hashCalculatedState`
-
-Per snapshot the module exposes `commitment = (mptRoot, smtRoot)` and defines the single
-consensus-facing hash:
+Every catalog tree is a `SparseMerkleTree` keyed by **fixed-length keys**: `sha256(name)` rendered
+as the 64-char lowercase hex `Hex` (`CommitCatalog.catalogKey`); stored values are the raw
+32 bytes of the committed root digest (`CommitCatalog.rootValueBytes`). Names are
+`family:qualifier` strings. The exact composition at ordinal N:
 
 ```
-calculatedStateHash = sha256( rawBytes(mptRoot) ++ rawBytes(canonicalSmtRoot) )
+catalogRoot_N = SMTroot {                       # the TOP catalog
+  sha256("current:mpt")  -> mptRoot_N           # current state-dict root
+  sha256("epoch:hot")    -> hotRoot_N           # root of the HOT epoch SMT
+  sha256("epoch:sealed") -> level1Root_N        # root of the LEVEL-1 SMT
+}
+
+hotRoot_N    = SMTroot { sha256("ordinal:<M>") -> mptRoot_M           # M in the CURRENT epoch, M ≤ N-1 }
+level1Root_N = SMTroot { sha256("epoch:<E>")   -> sealedEpochRoot_E   # every SEALED epoch E }
 ```
 
-where `canonicalSmtRoot` is the root of the **canonical single-entry catalog**
-`{ sha256("current:mpt") → mptRoot }`. Rationale (`CommittedCommitment` scaladoc has the full
-version): `hashCalculatedState` must be a *pure function of the state value* — tessellation calls
-it on freshly downloaded state with no local history — while the live catalog root depends on the
-historical `ordinal:<N>` entries. The canonical catalog keeps the hash pure in the value yet still
-binds tier 2's key scheme and hash discipline. Nothing is lost: each historical `ordinal:<N>` root
-was `current:mpt` at ordinal N and is anchored by snapshot N's own calculated-state proof. The
-live catalog (with history) is a node-local, *verifiable* index served by `/committed/root` and
-SMT proofs.
+with `epoch(M) = M / epochSize` (`CommittedConfig.epochSize`, default **2^16** ordinals;
+consensus-critical — every node of a metagraph must run the same value). `<M>`, `<E>` are decimal,
+no padding. Empty trees contribute the SMT empty root, so all three TOP entries are always
+present. The TOP scheme is extensible: any other root a metagraph commits (a Poseidon shadow
+root, a sub-registry root) gets its own name family alongside the three above; SMT absence proofs
+make "this family is not committed" provable.
 
-## 4. Routes (all read one cell value)
+### The per-ordinal transition
 
 ```
-GET  /committed/root                 { ordinal, mptRoot, smtRoot, calculatedStateHash }
-GET  /committed/proof/<key...>       single-key inclusion proof
-POST /committed/proofs               batch proof, body { "keys": [ "ns/a", ... ] }
-GET  /committed/proof-prefix/<ns...> complete prefix attestation for a namespace
-GET  /committed/delta/:ordinal       StateDelta (404 after ring-buffer eviction)
-GET  /committed/snapshot             CommittedSnapshot (replication fallback)
+hot/level1 advance:  insert  ordinal:<N-1> -> mptRoot_(N-1)  into the hot tree,
+                     SEALING first if epoch(N-1) > current hot epoch:
+                       level1 += epoch:<E_hot> -> hotRoot ; hot := empty
+catalogRoot_N      = TOP(mptRoot_N, hotRoot_N, level1Root_N)
 ```
 
-## 5. Why a hierarchy: super-registries and cross-metagraph slices
+i.e. the catalog at ordinal N contains the history `ordinal:0 .. ordinal:N-1` plus
+`current:mpt -> mptRoot_N`. Followers recompute this transition locally and reject any proposal
+whose breadcrumb (below) disagrees (`CommittedStateError.BreadcrumbMismatch`).
+
+### Ordinal proofs
+
+`Committed.proveOrdinal` / `GET /committed/proof-ordinal/:ordinal` produce an
+`OrdinalCatalogProof`; `OrdinalCatalogProofVerifier.verify(catalogRoot, proof, epochSize)`
+checks it against the single trusted catalog root:
+
+- **hot ordinal** — TOP inclusion of `epoch:hot` + hot-tree inclusion of `ordinal:<M>`;
+- **ancient ordinal** — TOP inclusion of `epoch:sealed` + **two fixed-depth inclusions**:
+  level-1 inclusion of `epoch:<M/epochSize>` and sealed-epoch-tree inclusion of `ordinal:<M>`;
+- **non-membership** — hot-tree ABSENCE of the ordinal **and** absence on the sealed path
+  (epoch never sealed, or ordinal absent from the sealed tree).
+
+The verifier recomputes every key from `(ordinal, epochSize)` — the prover cannot route the check
+through the wrong tree.
+
+## 3. The commitment, `hashCalculatedState`, and the on-chain breadcrumb
+
+Per snapshot the module commits the pair `roots = (mptRoot, catalogRoot)` and defines the single
+consensus-facing hash (`CommittedRoots.combinedHash`):
+
+```
+calculatedStateHash = sha256( rawBytes(mptRoot) ++ rawBytes(catalogRoot) )
+```
+
+over the **live** catalog — the consensus hash anchors the current state AND its entire root
+history.
+
+### The constant on-chain breadcrumb
+
+`CommittedApp.makeL0` registers the service with on-chain type `CommittedOnChain[PUB]` — the
+dev's `PUB` plus `CommittedBreadcrumb(ordinal, roots)`. Properties:
+
+- **constant size** — exactly the pair for the snapshot's own ordinal; it never accumulates;
+- **correct by construction** — only `combine` (owned by makeL0) builds the wrapper; the dev's
+  combiner sees and returns plain `PUB`, so the breadcrumb can be neither omitted nor forged from
+  application code;
+- **validated** — `combine` checks the incoming state's breadcrumb against the locally committed
+  roots before deriving the next one (the follower-side transition check), and a proposer that
+  tampers with the emitted breadcrumb produces an artifact honest validators cannot reproduce —
+  it cannot gather a majority. `setCalculatedState` additionally cross-checks the locally derived
+  roots against the signed snapshot's breadcrumb when one is available for the same ordinal.
+
+### Sourcing the catalog root at hash time (call-ordering soundness)
+
+`hashCalculatedState(state)` needs `catalogRoot`, which is history, not a function of the value.
+The implementation (`CommittedState.hashFor`) sources it by tessellation's two call orderings:
+
+1. **Steady state** (`DataApplicationSnapshotAcceptanceManager.accept` /
+   `consumeSignedMajorityArtifact`): the hash for snapshot N is computed BEFORE the artifact is
+   prepended to snapshot storage (`StateChannelSnapshotService.consume` calls
+   `consumeSignedMajorityArtifact` first) and the committed cell sits at N-1 (tessellation
+   asserts this via `expectCalculatedStateOrdinal`). The cell is the parent → derive the
+   transition locally. Fully self-computed; nothing is trusted.
+2. **Bootstrap / download** (`currency-l0 Download.fetchAndSetCalculatedState`): tessellation
+   `prepend`s the signed snapshot BEFORE fetching the calculated state, so the latest stored
+   snapshot is the one being verified and is AHEAD of the (genesis) cell. The hash uses the
+   breadcrumb's attested `catalogRoot` directly: **O(1) bootstrap**, no history replay. Trust is
+   the Ethereum-header model — the breadcrumb sits in the majority-SIGNED snapshot, and each
+   per-step transition was validated by the then-current validators.
+3. **Replay** (`DataApplicationTraverse` folds `combine` over cached snapshots without advancing
+   the cell): `combine` derives transitions through a bounded work cache keyed by breadcrumb, so
+   consecutive calls chain deterministically; the hash falls back to the most recent derivation
+   matching the state's mptRoot.
+
+`setCalculatedState` mirrors this: contiguous ordinal → local transition (+ breadcrumb
+cross-check); ordinal jump → **seed** from the attested breadcrumb (verify the downloaded value
+reproduces `mptRoot`, adopt `catalogRoot`).
+
+### Hydration (seeded → live)
+
+A breadcrumb-seeded node knows the catalog ROOT but not its contents. It can verify hashes and
+serve state-dict (MPT) proofs immediately, but deriving the NEXT transition (combine/propose) and
+serving catalog proofs require the contents: the hot epoch (≤ epochSize entries) and the level-1
+roots (one per sealed epoch) — bounded, NOT the chain history. Hydration is **verify-gated**
+(`CommittedState.hydrate` / `POST /committed/hydrate`): the supplied `CatalogContents` must
+recompose to the attested root, so the payload can come from ANY peer
+(`GET /committed/catalog`), an operator, or the node's own `CatalogJournal` (the restart path —
+the journal is LevelDB-backed via metakit's `LevelDbCollection` and written through on every
+transition/seal, so a restarted node re-hydrates locally and immediately).
+
+> FLAGGED (tessellation change, not implemented here): tessellation's download/traverse offers no
+> hook for an app to fetch auxiliary data from peers, so fetching `CatalogContents` over HTTP is
+> wired by the application (ottochain follow-up) — e.g. a sidecar/daemon hitting a peer's
+> `/committed/catalog` and POSTing `/committed/hydrate`. With a first-class "data application
+> download hook" in tessellation this becomes automatic. Until hydrated, a freshly bootstrapped
+> node can verify but not participate in consensus (combine raises
+> `BreadcrumbUnresolvable`/`CatalogNotHydrated`, loudly).
+
+## 4. Retention: serving, not trust
+
+`CommittedConfig.sealedEpochRetention` (node-local; default 4) bounds how many sealed epochs'
+full contents a node keeps. Pruning removes only the SERVING cache:
+
+- the level-1 root of every sealed epoch is kept forever (32 bytes per ~2^16 ordinals), so the
+  catalog root — and therefore every proof ever issued against any committed root — remains
+  verifiable;
+- a pruned node answers `proof-ordinal` for that epoch with `410 Gone`
+  (`CommittedProofError.EpochPruned`); any node retaining the epoch can serve the proof, and it
+  verifies against the same attested roots.
+
+Retention bounds what a node can SERVE, never what the network can TRUST.
+
+## 5. Routes (all reads from one cell value)
+
+```
+GET  /committed/root                   { ordinal, mptRoot, catalogRoot, calculatedStateHash, hydrated }
+GET  /committed/proof/<key...>         single-key inclusion proof
+POST /committed/proofs                 batch proof, body { "keys": [ "ns/a", ... ] }
+GET  /committed/proof-prefix/<ns...>   complete prefix attestation for a namespace
+GET  /committed/proof-ordinal/:ordinal OrdinalCatalogProof (410 Gone if pruned here)
+GET  /committed/catalog                CatalogContents (hydration / replication source)
+GET  /committed/delta/:ordinal         StateDelta (404 after ring-buffer eviction)
+GET  /committed/snapshot               CommittedSnapshot (replication fallback)
+POST /committed/hydrate                install CatalogContents on a seeded cell (verify-gated)
+```
+
+## 6. Why a hierarchy: super-registries and cross-metagraph slices
 
 The namespace hierarchy is the unit of *delegated commitment*. A super-registry can commit
 sub-registries as namespaces (`registry/<name>/...`), and later promote a sub-registry to its own
 catalog entry without changing key shapes. Cross-metagraph: ML0_B asks ML0_A for
 `/committed/proof-prefix/registry/tokens` and verifies the returned complete slice against ML0_A's
 `mptRoot` — trust-anchored without trusting the serving node, via gl0's
-`CurrencySnapshotMptRoots` → the snapshot's `calculatedStateProof` (= `hashCalculatedState`
+`CurrencySnapshotMptRoots` → the snapshot's `calculatedStateProof` (= `calculatedStateHash`
 above) → `mptRoot`. The same path serves JLVM contracts on ML0_B through `mpt_prefix_verify`.
+And because the consensus hash now commits the FULL catalog, the same anchor also proves
+*historical* facts: "ordinal M committed root X" (or provably did not) via a single
+`OrdinalCatalogProof` against the latest signed snapshot.

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CatalogJournal.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CatalogJournal.scala
@@ -39,7 +39,7 @@ final class CatalogJournal[F[_]: MonadThrow] private (store: Collection[F, Strin
   /** Record a seal: persist `epoch:<E> -> root` and prune the sealed ordinals from the hot window. */
   def recordSeal(event: EpochCatalog.SealEvent): F[Unit] =
     store.put(CommitCatalog.epochName(event.epoch), event.root.value.asJson) >>
-      store.removeBatch(event.sealedOrdinals.map(CommitCatalog.ordinalName))
+    store.removeBatch(event.sealedOrdinals.map(CommitCatalog.ordinalName))
 
   /** Replace the journal wholesale (used when hydration installs a fresher catalog). */
   def reset(hot: SortedMap[Long, Hash], level1: SortedMap[Long, Hash]): F[Unit] =
@@ -53,16 +53,14 @@ final class CatalogJournal[F[_]: MonadThrow] private (store: Collection[F, Strin
   /** The persisted `(hot ordinal -> mptRoot, sealed epoch -> root)` maps. */
   def contents: F[(SortedMap[Long, Hash], SortedMap[Long, Hash])] =
     store.dump.flatMap { pairs =>
-      pairs
-        .traverse {
-          case (name, json) =>
-            json.as[Hash].liftTo[F].map(name -> _)
-        }
-        .map { decoded =>
-          val hot = decoded.collect { case (CatalogJournal.OrdinalName(n), h) => n -> h }
-          val level1 = decoded.collect { case (CatalogJournal.EpochName(e), h) => e -> h }
-          (SortedMap.from(hot), SortedMap.from(level1))
-        }
+      pairs.traverse {
+        case (name, json) =>
+          json.as[Hash].liftTo[F].map(name -> _)
+      }.map { decoded =>
+        val hot = decoded.collect { case (CatalogJournal.OrdinalName(n), h) => n -> h }
+        val level1 = decoded.collect { case (CatalogJournal.EpochName(e), h) => e -> h }
+        (SortedMap.from(hot), SortedMap.from(level1))
+      }
     }
 }
 

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CatalogJournal.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CatalogJournal.scala
@@ -1,0 +1,88 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import java.nio.file.Path
+
+import cats.MonadThrow
+import cats.effect.{Async, Resource}
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.metagraph_sdk.storage.Collection
+import io.constellationnetwork.metagraph_sdk.storage.impl.{LevelDbCollection, RefMapCollection}
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+
+/**
+ * Node-local, write-through persistence of the catalog's history entries -- the level-1 sealed
+ * epoch roots (`epoch:<E>`) plus the current hot epoch (`ordinal:<N>`), pruned to the hot window
+ * on each seal. Backed by metakit's existing LevelDB-backed [[Collection]] (or an in-memory map
+ * for tests).
+ *
+ * The journal is the node's OWN data, in the same local trust domain as tessellation's persisted
+ * calculated state: on restart, a cell seeded at ordinal N can hydrate from it immediately (the
+ * rebuilt catalog must still compose to the breadcrumb's attested root, so a stale or corrupt
+ * journal degrades to the unhydrated path rather than to a wrong root).
+ *
+ * Note the journal does NOT persist retained sealed epochs' contents -- those are a serving cache
+ * ([[CommittedConfig.sealedEpochRetention]]); after a restart a node serves ancient proofs again
+ * only for epochs it re-fetches. Verifiability is unaffected.
+ */
+final class CatalogJournal[F[_]: MonadThrow] private (store: Collection[F, String, Json]) {
+
+  /** Record `ordinal:<N> -> mptRoot` (the hot-epoch insert of one transition). */
+  def recordOrdinal(ordinal: Long, mptRoot: Hash): F[Unit] =
+    store.put(CommitCatalog.ordinalName(ordinal), mptRoot.asJson)
+
+  /** Record a seal: persist `epoch:<E> -> root` and prune the sealed ordinals from the hot window. */
+  def recordSeal(event: EpochCatalog.SealEvent): F[Unit] =
+    store.put(CommitCatalog.epochName(event.epoch), event.root.value.asJson) >>
+      store.removeBatch(event.sealedOrdinals.map(CommitCatalog.ordinalName))
+
+  /** Replace the journal wholesale (used when hydration installs a fresher catalog). */
+  def reset(hot: SortedMap[Long, Hash], level1: SortedMap[Long, Hash]): F[Unit] =
+    for {
+      existing <- store.dump
+      _        <- store.removeBatch(existing.map(_._1))
+      _        <- store.putBatch(hot.toList.map { case (o, h) => CommitCatalog.ordinalName(o) -> h.asJson })
+      _        <- store.putBatch(level1.toList.map { case (e, h) => CommitCatalog.epochName(e) -> h.asJson })
+    } yield ()
+
+  /** The persisted `(hot ordinal -> mptRoot, sealed epoch -> root)` maps. */
+  def contents: F[(SortedMap[Long, Hash], SortedMap[Long, Hash])] =
+    store.dump.flatMap { pairs =>
+      pairs
+        .traverse {
+          case (name, json) =>
+            json.as[Hash].liftTo[F].map(name -> _)
+        }
+        .map { decoded =>
+          val hot = decoded.collect { case (CatalogJournal.OrdinalName(n), h) => n -> h }
+          val level1 = decoded.collect { case (CatalogJournal.EpochName(e), h) => e -> h }
+          (SortedMap.from(hot), SortedMap.from(level1))
+        }
+    }
+}
+
+object CatalogJournal {
+
+  private object OrdinalName {
+    def unapply(name: String): Option[Long] =
+      Option.when(name.startsWith("ordinal:"))(name.stripPrefix("ordinal:")).flatMap(_.toLongOption)
+  }
+
+  private object EpochName {
+    def unapply(name: String): Option[Long] =
+      Option.when(name.startsWith("epoch:"))(name.stripPrefix("epoch:")).flatMap(_.toLongOption)
+  }
+
+  /** LevelDB-backed journal at `dbPath` (metakit's existing [[LevelDbCollection]]). */
+  def levelDb[F[_]: Async](dbPath: Path): Resource[F, CatalogJournal[F]] =
+    LevelDbCollection.make[F, String, Json](dbPath).map(new CatalogJournal[F](_))
+
+  /** In-memory journal (tests / ephemeral nodes). */
+  def inMemory[F[_]: Async]: F[CatalogJournal[F]] =
+    RefMapCollection.make[F, String, Json].map(new CatalogJournal[F](_))
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommitCatalog.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommitCatalog.scala
@@ -2,30 +2,53 @@ package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 
 import java.nio.charset.StandardCharsets
 
-import scala.collection.immutable.SortedMap
-
+import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.hex.Hex
 
 /**
- * The SMT root-catalog key scheme (tier 2 of the commitment).
+ * The catalog key scheme (tier 2 of the commitment) -- the LIVE catalog committed by
+ * `hashCalculatedState`.
  *
- * The catalog is a SparseMerkleTree keyed by FIXED-length keys: `sha256(name)` rendered as the
- * 64-char lowercase hex `Hex` the SMT consumes. Names are `family:qualifier` strings:
+ * Every tree in the catalog is a SparseMerkleTree keyed by FIXED-length keys: `sha256(name)`
+ * rendered as the 64-char lowercase hex `Hex` the SMT consumes; values are the 32 RAW bytes of the
+ * committed root digest ([[rootValueBytes]]). Names are `family:qualifier` strings, spread over
+ * three levels (see `docs/committed-namespaces.md` for the full composition):
  *
+ * TOP catalog (root = the breadcrumb's `catalogRoot`):
  *   - `current:mpt`  -> the CURRENT state-dict MPT root
- *   - `ordinal:<N>`  -> the MPT root committed at snapshot ordinal N (historical; N decimal, no padding)
+ *   - `epoch:hot`    -> root of the HOT epoch SMT (this epoch's historical ordinals)
+ *   - `epoch:sealed` -> root of the LEVEL-1 SMT (one entry per sealed epoch)
  *
- * and the scheme is extensible -- any other root a metagraph wants to commit (e.g. a Poseidon
- * shadow root, a sub-registry root) gets its own name family. Values stored in the SMT are the 32
- * RAW bytes of the committed root hash ([[rootValueBytes]]).
+ * LEVEL-1 SMT:
+ *   - `epoch:<E>`    -> the sealed root of epoch E (E decimal, no padding)
+ *
+ * EPOCH SMTs (hot and sealed alike):
+ *   - `ordinal:<N>`  -> the MPT root committed at snapshot ordinal N (N decimal, no padding)
+ *
+ * The TOP scheme is extensible -- any other root a metagraph wants to commit (e.g. a Poseidon
+ * shadow root, a sub-registry root) gets its own name family alongside the three above.
  */
 object CommitCatalog {
 
   val CurrentMptName: String = "current:mpt"
 
-  def ordinalName(ordinal: SnapshotOrdinal): String = s"ordinal:${ordinal.value.value}"
+  /** TOP catalog name of the hot epoch SMT root. */
+  val HotEpochsName: String = "epoch:hot"
+
+  /** TOP catalog name of the level-1 (sealed epochs) SMT root. */
+  val SealedEpochsName: String = "epoch:sealed"
+
+  def ordinalName(ordinal: Long): String = s"ordinal:$ordinal"
+
+  def ordinalName(ordinal: SnapshotOrdinal): String = ordinalName(ordinal.value.value)
+
+  /** Level-1 name of sealed epoch `epoch`'s root. */
+  def epochName(epoch: Long): String = s"epoch:$epoch"
+
+  /** The epoch an ordinal belongs to: `ordinal / epochSize`. */
+  def epochOf(ordinal: Long, epochSize: Int): Long = ordinal / epochSize
 
   /** Catalog key for `name`: sha256(name) as the 64-char lowercase hex `Hex` (fixed-length SMT key). */
   def catalogKey(name: String): Hex =
@@ -33,17 +56,21 @@ object CommitCatalog {
 
   def currentMptKey: Hex = catalogKey(CurrentMptName)
 
-  def ordinalKey(ordinal: SnapshotOrdinal): Hex = catalogKey(ordinalName(ordinal))
+  def hotEpochsKey: Hex = catalogKey(HotEpochsName)
+
+  def sealedEpochsKey: Hex = catalogKey(SealedEpochsName)
+
+  def ordinalKey(ordinal: Long): Hex = catalogKey(ordinalName(ordinal))
+
+  def ordinalKey(ordinal: SnapshotOrdinal): Hex = ordinalKey(ordinal.value.value)
+
+  def epochKey(epoch: Long): Hex = catalogKey(epochName(epoch))
 
   /** The SMT leaf value bound to a committed root: the 32 raw bytes of the root digest. */
   def rootValueBytes(root: Hash): Array[Byte] = Hex(root.value).toBytes
 
-  def rootFromValueBytes(bytes: Array[Byte]): Hash = Hash(Hex.fromBytes(bytes).value)
+  /** The SMT leaf value bound to a committed SUBTREE root (level-1 / epoch roots in the top catalog). */
+  def rootValueBytes(root: SparseMerkleRoot): Array[Byte] = rootValueBytes(root.value)
 
-  /** The catalog upserts a snapshot at `ordinal` with state-dict root `mptRoot` contributes. */
-  def changesFor(ordinal: SnapshotOrdinal, mptRoot: Hash): SortedMap[Hex, Hash] =
-    SortedMap(
-      currentMptKey       -> mptRoot,
-      ordinalKey(ordinal) -> mptRoot
-    )
+  def rootFromValueBytes(bytes: Array[Byte]): Hash = Hash(Hex.fromBytes(bytes).value)
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommitCatalog.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommitCatalog.scala
@@ -1,0 +1,49 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import java.nio.charset.StandardCharsets
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * The SMT root-catalog key scheme (tier 2 of the commitment).
+ *
+ * The catalog is a SparseMerkleTree keyed by FIXED-length keys: `sha256(name)` rendered as the
+ * 64-char lowercase hex `Hex` the SMT consumes. Names are `family:qualifier` strings:
+ *
+ *   - `current:mpt`  -> the CURRENT state-dict MPT root
+ *   - `ordinal:<N>`  -> the MPT root committed at snapshot ordinal N (historical; N decimal, no padding)
+ *
+ * and the scheme is extensible -- any other root a metagraph wants to commit (e.g. a Poseidon
+ * shadow root, a sub-registry root) gets its own name family. Values stored in the SMT are the 32
+ * RAW bytes of the committed root hash ([[rootValueBytes]]).
+ */
+object CommitCatalog {
+
+  val CurrentMptName: String = "current:mpt"
+
+  def ordinalName(ordinal: SnapshotOrdinal): String = s"ordinal:${ordinal.value.value}"
+
+  /** Catalog key for `name`: sha256(name) as the 64-char lowercase hex `Hex` (fixed-length SMT key). */
+  def catalogKey(name: String): Hex =
+    Hex(Hash.fromBytes(name.getBytes(StandardCharsets.UTF_8)).value)
+
+  def currentMptKey: Hex = catalogKey(CurrentMptName)
+
+  def ordinalKey(ordinal: SnapshotOrdinal): Hex = catalogKey(ordinalName(ordinal))
+
+  /** The SMT leaf value bound to a committed root: the 32 raw bytes of the root digest. */
+  def rootValueBytes(root: Hash): Array[Byte] = Hex(root.value).toBytes
+
+  def rootFromValueBytes(bytes: Array[Byte]): Hash = Hash(Hex.fromBytes(bytes).value)
+
+  /** The catalog upserts a snapshot at `ordinal` with state-dict root `mptRoot` contributes. */
+  def changesFor(ordinal: SnapshotOrdinal, mptRoot: Hash): SortedMap[Hex, Hash] =
+    SortedMap(
+      currentMptKey       -> mptRoot,
+      ordinalKey(ordinal) -> mptRoot
+    )
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommitKey.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommitKey.scala
@@ -57,8 +57,8 @@ object CommitKey {
       else if (segments.length > MaxSegments) CommitKeyError.TooManySegments(segments.length).asLeft
       else
         segments.collectFirst {
-          case s if s.length > MaxSegmentLength    => CommitKeyError.SegmentTooLong(s)
-          case s if !SegmentPattern.matches(s)     => CommitKeyError.InvalidSegment(s)
+          case s if s.length > MaxSegmentLength => CommitKeyError.SegmentTooLong(s)
+          case s if !SegmentPattern.matches(s)  => CommitKeyError.InvalidSegment(s)
         } match {
           case Some(err) => err.asLeft
           case None      => ().asRight

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommitKey.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommitKey.scala
@@ -1,0 +1,111 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import java.nio.charset.StandardCharsets
+
+import cats.syntax.either._
+
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
+
+/**
+ * A validated, namespaced path into the committed state dictionary -- the MPT key universe.
+ *
+ * Grammar (see `docs/committed-namespaces.md` for the full spec):
+ *   - `key = segment *( "/" segment )`, 1 to [[CommitKey.MaxSegments]] segments
+ *   - `segment = [a-z0-9] [a-z0-9._-]{0,63}` (lowercase only; no empty segments)
+ *   - total length at most [[CommitKey.MaxKeyLength]] characters
+ *
+ * The MPT path of a key is the lowercase hex encoding of its UTF-8 bytes ([[toHex]]). Because the
+ * encoding is byte-aligned and '/' is a single byte (0x2f), the hex of `"ns/"` is a strict prefix of
+ * the hex of every key under namespace `ns` -- which is what makes namespace prefix proofs work.
+ */
+final case class CommitKey private (value: String) {
+
+  /** The MPT path: lowercase hex of the UTF-8 bytes of [[value]]. */
+  def toHex: Hex = CommitKey.hexOf(value)
+
+  def segments: List[String] = value.split('/').toList
+
+  /** The top-level namespace (first segment). */
+  def namespace: String = segments.head
+}
+
+object CommitKey {
+  val MaxSegmentLength: Int = 64
+  val MaxSegments: Int = 16
+  val MaxKeyLength: Int = 256
+
+  private val SegmentPattern = "^[a-z0-9][a-z0-9._-]*$".r
+
+  def from(value: String): Either[CommitKeyError, CommitKey] =
+    validateSegments(value).map(_ => CommitKey(value))
+
+  def unsafe(value: String): CommitKey =
+    from(value).valueOr(throw _)
+
+  private[committed] def hexOf(s: String): Hex =
+    Hex.fromBytes(s.getBytes(StandardCharsets.UTF_8))
+
+  private[committed] def validateSegments(value: String): Either[CommitKeyError, Unit] =
+    if (value.isEmpty) CommitKeyError.EmptyKey.asLeft
+    else if (value.length > MaxKeyLength) CommitKeyError.KeyTooLong(value.length).asLeft
+    else {
+      val segments = value.split('/').toList
+      if (value.startsWith("/") || value.endsWith("/") || segments.exists(_.isEmpty))
+        CommitKeyError.EmptySegment(value).asLeft
+      else if (segments.length > MaxSegments) CommitKeyError.TooManySegments(segments.length).asLeft
+      else
+        segments.collectFirst {
+          case s if s.length > MaxSegmentLength    => CommitKeyError.SegmentTooLong(s)
+          case s if !SegmentPattern.matches(s)     => CommitKeyError.InvalidSegment(s)
+        } match {
+          case Some(err) => err.asLeft
+          case None      => ().asRight
+        }
+    }
+
+  implicit val ordering: Ordering[CommitKey] = Ordering.by(_.value)
+
+  implicit val encoder: Encoder[CommitKey] = Encoder.encodeString.contramap(_.value)
+  implicit val decoder: Decoder[CommitKey] = Decoder.decodeString.emap(s => from(s).leftMap(_.getMessage))
+  implicit val keyEncoder: KeyEncoder[CommitKey] = KeyEncoder.instance(_.value)
+  implicit val keyDecoder: KeyDecoder[CommitKey] = KeyDecoder.instance(s => from(s).toOption)
+}
+
+/**
+ * A validated namespace -- a key prefix at segment granularity (same segment grammar as
+ * [[CommitKey]], but it denotes the subtree of all keys strictly under `value + "/"`).
+ */
+final case class CommitNamespace private (value: String) {
+
+  /**
+   * The MPT path prefix covering every key strictly under this namespace: hex of the UTF-8 bytes of
+   * `value + "/"`. The trailing separator pins the match to a segment boundary (so namespace
+   * `fiber` cannot match a key under `fiberx/`).
+   */
+  def prefixHex: Hex = CommitKey.hexOf(value + "/")
+}
+
+object CommitNamespace {
+
+  def from(value: String): Either[CommitKeyError, CommitNamespace] =
+    CommitKey.validateSegments(value).map(_ => CommitNamespace(value))
+
+  def unsafe(value: String): CommitNamespace =
+    from(value).valueOr(throw _)
+}
+
+sealed abstract class CommitKeyError(message: String) extends RuntimeException(message)
+
+object CommitKeyError {
+  case object EmptyKey extends CommitKeyError("commit key must not be empty")
+  final case class KeyTooLong(length: Int) extends CommitKeyError(s"commit key exceeds ${CommitKey.MaxKeyLength} chars: $length")
+  final case class TooManySegments(count: Int) extends CommitKeyError(s"commit key exceeds ${CommitKey.MaxSegments} segments: $count")
+  final case class EmptySegment(key: String) extends CommitKeyError(s"commit key has an empty segment: '$key'")
+  final case class SegmentTooLong(segment: String)
+      extends CommitKeyError(s"commit key segment exceeds ${CommitKey.MaxSegmentLength} chars: '$segment'")
+
+  final case class InvalidSegment(segment: String)
+      extends CommitKeyError(s"commit key segment must match ^[a-z0-9][a-z0-9._-]*$$: '$segment'")
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/Committed.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/Committed.scala
@@ -1,11 +1,8 @@
 package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 
 import cats.MonadThrow
-import cats.syntax.bifunctor._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-
-import scala.collection.immutable.SortedMap
+import cats.effect.Sync
+import cats.syntax.all._
 
 import io.constellationnetwork.metagraph_sdk.crypto.mpt.api._
 import io.constellationnetwork.metagraph_sdk.crypto.mpt.{
@@ -14,15 +11,36 @@ import io.constellationnetwork.metagraph_sdk.crypto.mpt.{
   MerklePatriciaTrie
 }
 import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
-import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleProof, SparseMerkleProofError}
+import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleProof, SparseMerkleRoot}
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
 import io.constellationnetwork.schema.SnapshotOrdinal
-import io.constellationnetwork.security.hash.Hash
-import io.constellationnetwork.security.hex.Hex
 
 /**
- * One atomically-consistent committed snapshot: the state value, both tries, their roots, the live
- * catalog entries, and the recent-delta ring buffer -- everything a reader needs, derived from ONE
+ * The node's view of the catalog inside one committed snapshot.
+ *
+ *   - [[LiveCatalog]]: full contents -- the epoch rollup plus the composed TOP tree. Can derive
+ *     the next transition, serve proofs, and emit snapshots.
+ *   - [[SeededCatalog]]: only the consensus-attested ROOT is known (O(1) bootstrap from the
+ *     on-chain breadcrumb). Sufficient to verify `hashCalculatedState` and to serve state-dict
+ *     (MPT) proofs; catalog proofs and further transitions require hydration
+ *     (`CommittedState.hydrate` / `POST /committed/hydrate`).
+ */
+sealed trait CatalogView[F[_]] extends Product with Serializable {
+
+  def live: Option[CatalogView.LiveCatalog[F]] = this match {
+    case l: CatalogView.LiveCatalog[F] => l.some
+    case _                             => none
+  }
+}
+
+object CatalogView {
+  final case class LiveCatalog[F[_]](epochs: EpochCatalog[F], top: InMemorySparseMerkleTree[F]) extends CatalogView[F]
+  final case class SeededCatalog[F[_]](catalogRoot: SparseMerkleRoot) extends CatalogView[F]
+}
+
+/**
+ * One atomically-consistent committed snapshot: the state value, the state-dict trie, the catalog
+ * view, the roots, and the recent-delta ring buffer -- everything a reader needs, derived from ONE
  * read of the `CommittedState` cell. All proof methods on this value attest against the SAME roots
  * by construction.
  *
@@ -33,11 +51,16 @@ final case class Committed[F[_], S] private[committed] (
   ordinal: SnapshotOrdinal,
   state: S,
   trie: MerklePatriciaTrie,
-  catalog: InMemorySparseMerkleTree[F],
-  catalogEntries: SortedMap[Hex, Hash],
+  catalog: CatalogView[F],
   roots: CommittedRoots,
   recentDeltas: Vector[StateDelta]
 ) {
+
+  /** The constant on-chain breadcrumb of this snapshot. */
+  def breadcrumb: CommittedBreadcrumb = CommittedBreadcrumb(ordinal, roots)
+
+  /** Whether the catalog contents are locally known (vs breadcrumb-seeded). */
+  def isHydrated: Boolean = catalog.live.isDefined
 
   /**
    * Inclusion proof for one key against [[CommittedRoots.mptRoot]]. An absent key is a uniform
@@ -73,17 +96,44 @@ final case class Committed[F[_], S] private[committed] (
     MerklePatriciaPrefixProver.make[F](trie).attestPrefix(ns.prefixHex)
 
   /**
-   * SMT proof for a catalog name (e.g. `current:mpt`, `ordinal:42`) against
-   * [[CommittedRoots.smtRoot]] -- inclusion when committed, first-class ABSENCE otherwise.
+   * SMT proof for a TOP catalog name (`current:mpt`, `epoch:hot`, `epoch:sealed`, or an extension
+   * family) against [[CommittedRoots.catalogRoot]] -- inclusion when committed, first-class
+   * ABSENCE otherwise. Requires a hydrated catalog.
    */
-  def proveCatalog(name: String)(implicit F: MonadThrow[F]): F[Either[SparseMerkleProofError, SparseMerkleProof]] =
-    catalog.prover.flatMap(_.prove(CommitCatalog.catalogKey(name)))
+  def proveCatalog(
+    name: String
+  )(implicit F: MonadThrow[F]): F[Either[CommittedProofError, SparseMerkleProof]] =
+    catalog.live match {
+      case None => (CommittedProofError.CatalogNotHydrated: CommittedProofError).asLeft[SparseMerkleProof].pure[F]
+      case Some(l) =>
+        l.top.prover
+          .flatMap(_.prove(CommitCatalog.catalogKey(name)))
+          .map(_.leftMap[CommittedProofError](CommittedProofError.ProofUnavailable(_)))
+    }
+
+  /**
+   * The catalog attestation of `ordinal` (hot inclusion, two-level sealed inclusion, or
+   * non-membership at both levels) against [[CommittedRoots.catalogRoot]]. Requires a hydrated
+   * catalog; sealed epochs beyond the retention window yield
+   * [[CommittedProofError.EpochPruned]].
+   */
+  def proveOrdinal(
+    target: SnapshotOrdinal
+  )(implicit F: Sync[F]): F[Either[CommittedProofError, OrdinalCatalogProof]] =
+    catalog.live match {
+      case None    => (CommittedProofError.CatalogNotHydrated: CommittedProofError).asLeft[OrdinalCatalogProof].pure[F]
+      case Some(l) => l.epochs.proveOrdinal(target.value.value, l.top)
+    }
 
   /** The delta that produced `ordinal`, if still inside the ring buffer. */
   def deltaFor(ordinal: SnapshotOrdinal): Option[StateDelta] =
     recentDeltas.find(_.ordinal == ordinal)
 
-  /** The full-view replication fallback (see [[CommittedSnapshot]]). */
-  def snapshot(implicit view: CommittedView[S]): CommittedSnapshot =
-    CommittedSnapshot(ordinal, roots, view.entries(state), catalogEntries)
+  /** The catalog payload for hydration / replication (None until hydrated). */
+  def catalogContents: Option[CatalogContents] =
+    catalog.live.map(_.epochs.contents)
+
+  /** The full-view replication fallback (see [[CommittedSnapshot]]); None until hydrated. */
+  def snapshot(implicit view: CommittedView[S]): Option[CommittedSnapshot] =
+    catalogContents.map(contents => CommittedSnapshot(ordinal, roots, view.entries(state), contents))
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/Committed.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/Committed.scala
@@ -8,7 +8,11 @@ import cats.syntax.functor._
 import scala.collection.immutable.SortedMap
 
 import io.constellationnetwork.metagraph_sdk.crypto.mpt.api._
-import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaBatchInclusionProof, MerklePatriciaInclusionProof, MerklePatriciaTrie}
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{
+  MerklePatriciaBatchInclusionProof,
+  MerklePatriciaInclusionProof,
+  MerklePatriciaTrie
+}
 import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
 import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleProof, SparseMerkleProofError}
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
@@ -44,10 +48,13 @@ final case class Committed[F[_], S] private[committed] (
   def proveKey(
     key: CommitKey
   )(implicit F: MonadThrow[F], H: JsonBinaryHasher[F]): F[Either[MerklePatriciaProofError, MerklePatriciaInclusionProof]] =
-    MerklePatriciaProver.make[F](trie).attestPath(key.toHex).map(_.leftMap {
-      case InvalidNodeType(_) => PathNotFound(key.value)
-      case other              => other
-    })
+    MerklePatriciaProver
+      .make[F](trie)
+      .attestPath(key.toHex)
+      .map(_.leftMap {
+        case InvalidNodeType(_) => PathNotFound(key.value)
+        case other              => other
+      })
 
   /** One batch proof covering all `keys` against [[CommittedRoots.mptRoot]]. */
   def proveKeys(

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/Committed.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/Committed.scala
@@ -1,0 +1,82 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.MonadThrow
+import cats.syntax.bifunctor._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api._
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaBatchInclusionProof, MerklePatriciaInclusionProof, MerklePatriciaTrie}
+import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
+import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleProof, SparseMerkleProofError}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * One atomically-consistent committed snapshot: the state value, both tries, their roots, the live
+ * catalog entries, and the recent-delta ring buffer -- everything a reader needs, derived from ONE
+ * read of the `CommittedState` cell. All proof methods on this value attest against the SAME roots
+ * by construction.
+ *
+ * Construction is restricted to the `committed` package (`CommittedState` / `CommittedReplica`):
+ * the fields are mutually consistent only because the producing code asserted so.
+ */
+final case class Committed[F[_], S] private[committed] (
+  ordinal: SnapshotOrdinal,
+  state: S,
+  trie: MerklePatriciaTrie,
+  catalog: InMemorySparseMerkleTree[F],
+  catalogEntries: SortedMap[Hex, Hash],
+  roots: CommittedRoots,
+  recentDeltas: Vector[StateDelta]
+) {
+
+  /**
+   * Inclusion proof for one key against [[CommittedRoots.mptRoot]]. An absent key is a uniform
+   * `PathNotFound`: the underlying prover reports a path that diverges mid-edge as
+   * `InvalidNodeType`, but on this trie (built and asserted by the committed layer itself) that can
+   * only mean the key is not present.
+   */
+  def proveKey(
+    key: CommitKey
+  )(implicit F: MonadThrow[F], H: JsonBinaryHasher[F]): F[Either[MerklePatriciaProofError, MerklePatriciaInclusionProof]] =
+    MerklePatriciaProver.make[F](trie).attestPath(key.toHex).map(_.leftMap {
+      case InvalidNodeType(_) => PathNotFound(key.value)
+      case other              => other
+    })
+
+  /** One batch proof covering all `keys` against [[CommittedRoots.mptRoot]]. */
+  def proveKeys(
+    keys: List[CommitKey]
+  )(implicit F: MonadThrow[F], H: JsonBinaryHasher[F]): F[Either[MerklePatriciaProofError, MerklePatriciaBatchInclusionProof]] =
+    MerklePatriciaBatchInclusionProver.make[F](trie).attestPaths(keys.map(_.toHex))
+
+  /**
+   * Prefix attestation for a namespace: a batch proof over EVERY key under `ns/`, suitable for
+   * complete-slice verification (`MerklePatriciaBatchInclusionVerifier` natively, or the JLVM's
+   * `mpt_prefix_verify` with `0x`-prefixed hex).
+   */
+  def attestNamespace(
+    ns: CommitNamespace
+  )(implicit F: MonadThrow[F], H: JsonBinaryHasher[F]): F[Either[MerklePatriciaProofError, MerklePatriciaBatchInclusionProof]] =
+    MerklePatriciaPrefixProver.make[F](trie).attestPrefix(ns.prefixHex)
+
+  /**
+   * SMT proof for a catalog name (e.g. `current:mpt`, `ordinal:42`) against
+   * [[CommittedRoots.smtRoot]] -- inclusion when committed, first-class ABSENCE otherwise.
+   */
+  def proveCatalog(name: String)(implicit F: MonadThrow[F]): F[Either[SparseMerkleProofError, SparseMerkleProof]] =
+    catalog.prover.flatMap(_.prove(CommitCatalog.catalogKey(name)))
+
+  /** The delta that produced `ordinal`, if still inside the ring buffer. */
+  def deltaFor(ordinal: SnapshotOrdinal): Option[StateDelta] =
+    recentDeltas.find(_.ordinal == ordinal)
+
+  /** The full-view replication fallback (see [[CommittedSnapshot]]). */
+  def snapshot(implicit view: CommittedView[S]): CommittedSnapshot =
+    CommittedSnapshot(ordinal, roots, view.entries(state), catalogEntries)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
@@ -11,6 +11,7 @@ import io.constellationnetwork.currency.dataApplication._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 import io.constellationnetwork.metagraph_sdk.MetagraphCommonService
 import io.constellationnetwork.metagraph_sdk.lifecycle.{CombinerService, ValidationService}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryCodec
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
@@ -21,17 +22,24 @@ import org.http4s.HttpRoutes
 /**
  * The single assembly path for a state-root-committed metagraph L0 data application.
  *
- * [[makeL0]] is the ONLY way to wire a `CommittedState` into a `BaseDataApplicationL0Service`
- * (the `CommittedState` constructor and `make` are package-private), which makes the commitment
- * correct by construction:
+ * [[makeL0]] is the ONLY way to wire a `CommittedState` into a `BaseDataApplicationL0Service` (the
+ * `CommittedState` constructor and `make` are package-private), which makes the commitment correct
+ * by construction:
  *
- *   - `hashCalculatedState` is the PURE derivation `CommittedCommitment.deriveHash` -- a function
- *     of the state value alone (see that object's scaladoc for why the catalog in the hash is the
- *     canonical single-entry one).
- *   - `setCalculatedState` routes through `CommittedState.setCommitted`, which applies the view's
- *     delta incrementally and ASSERTS the resulting trie root equals the value-derived root,
- *     raising [[CommittedStateError.RootDivergence]] (failing the snapshot loudly) on any mismatch
- *     -- a divergence is a wiring bug, never something to paper over.
+ *   - the service's on-chain type is [[CommittedOnChain]]`[PUB]` -- makeL0 owns the on-chain
+ *     serializers, so EVERY snapshot's on-chain state carries the constant breadcrumb
+ *     `(ordinal, mptRoot, catalogRoot)`; the dev cannot omit it, and `combine` (below) rejects a
+ *     forged one.
+ *   - `combine` validates the incoming breadcrumb against the locally committed roots
+ *     ([[CommittedStateError.BreadcrumbMismatch]] -- the follower-side transition check
+ *     `catalogRoot_N = insert(catalogRoot_(N-1), ordinal:<N-1> -> mptRoot_(N-1))`), runs the dev
+ *     combiner on the UNWRAPPED state, and emits the next breadcrumb derived from the local
+ *     catalog.
+ *   - `hashCalculatedState` is `sha256(mptRoot || liveCatalogRoot)` with the catalog root sourced
+ *     per tessellation's call ordering (steady-state transition vs O(1) bootstrap from the latest
+ *     signed snapshot's breadcrumb) -- see `CommittedState.hashFor`.
+ *   - `setCalculatedState` routes through `CommittedState.setCommitted` (delta-apply +
+ *     full-rebuild assert + epoch advance; or breadcrumb seed on bootstrap).
  *   - the `/committed/...` routes and any `extraRoutes` read the SAME private cell.
  */
 object CommittedApp {
@@ -46,34 +54,69 @@ object CommittedApp {
     combiner: CombinerService[F, TX, PUB, PRV],
     validator: ValidationService[F, TX, PUB, PRV],
     extraRoutes: Option[CommittedReader[F, PRV] => HttpRoutes[F]] = None,
-    maxRecentDeltas: Int = CommittedState.DefaultMaxRecentDeltas
-  ): F[BaseDataApplicationL0Service[F]] =
-    CommittedState.make[F, PRV](genesisState.calculated, maxRecentDeltas).map { committedState =>
-      BaseDataApplicationL0Service[F, TX, PUB, PRV](
-        new MetagraphCommonService[F, TX, PUB, PRV, L0NodeContext[F]] with DataApplicationL0Service[F, TX, PUB, PRV] {
+    config: CommittedConfig = CommittedConfig.default,
+    journal: Option[CatalogJournal[F]] = None
+  ): F[BaseDataApplicationL0Service[F]] = {
+    implicit val wrappedEncoder: Encoder[CommittedOnChain[PUB]] = CommittedOnChain.encoder[PUB]
+    implicit val wrappedDecoder: Decoder[CommittedOnChain[PUB]] = CommittedOnChain.decoder[PUB]
+    val view = CommittedView[PRV]
 
-          override def genesis: DataState[PUB, PRV] = genesisState
+    for {
+      committedState   <- CommittedState.make[F, PRV](genesisState.calculated, config, journal)
+      genesisCommitted <- committedState.committed
+      genesisData = DataState(
+        CommittedOnChain(genesisState.onChain, genesisCommitted.breadcrumb),
+        genesisState.calculated,
+        genesisState.sharedArtifacts
+      )
+    } yield {
+
+      /**
+       * The latest SIGNED snapshot's on-chain breadcrumb, when a context (and snapshot) exists.
+       * Consensus-attested: the on-chain bytes are part of the signed artifact.
+       */
+      def contextBreadcrumb(implicit context: L0NodeContext[F]): F[Option[CommittedBreadcrumb]] =
+        Option(context)
+          .flatTraverse(_.getLastCurrencySnapshot.handleError(_ => none))
+          .flatMap {
+            _.flatTraverse { hashed =>
+              hashed.signed.value.dataApplication.flatTraverse { part =>
+                JsonBinaryCodec
+                  .fromBinary[F, CommittedOnChain[PUB]](part.onChainState)
+                  .map(_.toOption.map(_.breadcrumb).filter(_.ordinal == hashed.signed.value.ordinal))
+              }
+            }
+          }
+
+      BaseDataApplicationL0Service[F, TX, CommittedOnChain[PUB], PRV](
+        new MetagraphCommonService[F, TX, CommittedOnChain[PUB], PRV, L0NodeContext[F]]
+          with DataApplicationL0Service[F, TX, CommittedOnChain[PUB], PRV] {
+
+          override def genesis: DataState[CommittedOnChain[PUB], PRV] = genesisData
 
           override def validateData(
-            state: DataState[PUB, PRV],
+            state: DataState[CommittedOnChain[PUB], PRV],
             updates: NonEmptyList[Signed[TX]]
           )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
-            validator.validateData(state, updates)
+            validator.validateData(DataState(state.onChain.inner, state.calculated, state.sharedArtifacts), updates)
 
           override def combine(
-            state: DataState[PUB, PRV],
+            state: DataState[CommittedOnChain[PUB], PRV],
             updates: List[Signed[TX]]
-          )(implicit context: L0NodeContext[F]): F[DataState[PUB, PRV]] =
-            combiner.foldLeft(state, updates)
+          )(implicit context: L0NodeContext[F]): F[DataState[CommittedOnChain[PUB], PRV]] =
+            for {
+              combined <- combiner.foldLeft(DataState(state.onChain.inner, state.calculated, state.sharedArtifacts), updates)
+              next     <- committedState.advanceWork(state.onChain.breadcrumb, view.entries(combined.calculated))
+            } yield DataState(CommittedOnChain(combined.onChain, next), combined.calculated, combined.sharedArtifacts)
 
           override def getCalculatedState(implicit context: L0NodeContext[F]): F[(SnapshotOrdinal, PRV)] =
             committedState.committed.map(c => c.ordinal -> c.state)
 
           override def setCalculatedState(ordinal: SnapshotOrdinal, state: PRV)(implicit context: L0NodeContext[F]): F[Boolean] =
-            committedState.setCommitted(ordinal, state).as(true)
+            contextBreadcrumb.flatMap(bc => committedState.setCommitted(ordinal, state, bc)).as(true)
 
           override def hashCalculatedState(state: PRV)(implicit context: L0NodeContext[F]): F[Hash] =
-            CommittedCommitment.deriveHash[F, PRV](state)
+            contextBreadcrumb.flatMap(bc => committedState.hashFor(state, bc))
 
           override def routes(implicit context: L0NodeContext[F]): HttpRoutes[F] =
             new CommittedRoutes[F, PRV](committedState).public <+>
@@ -81,4 +124,5 @@ object CommittedApp {
         }
       )
     }
+  }
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
@@ -69,9 +69,7 @@ object CommittedApp {
           override def getCalculatedState(implicit context: L0NodeContext[F]): F[(SnapshotOrdinal, PRV)] =
             committedState.committed.map(c => c.ordinal -> c.state)
 
-          override def setCalculatedState(ordinal: SnapshotOrdinal, state: PRV)(implicit
-            context: L0NodeContext[F]
-          ): F[Boolean] =
+          override def setCalculatedState(ordinal: SnapshotOrdinal, state: PRV)(implicit context: L0NodeContext[F]): F[Boolean] =
             committedState.setCommitted(ordinal, state).as(true)
 
           override def hashCalculatedState(state: PRV)(implicit context: L0NodeContext[F]): F[Hash] =

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
@@ -1,0 +1,86 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.Parallel
+import cats.data.NonEmptyList
+import cats.effect.Async
+import cats.syntax.all._
+
+import scala.reflect.ClassTag
+
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.metagraph_sdk.MetagraphCommonService
+import io.constellationnetwork.metagraph_sdk.lifecycle.{CombinerService, ValidationService}
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
+
+import io.circe.{Decoder, Encoder}
+import org.http4s.HttpRoutes
+
+/**
+ * The single assembly path for a state-root-committed metagraph L0 data application.
+ *
+ * [[makeL0]] is the ONLY way to wire a `CommittedState` into a `BaseDataApplicationL0Service`
+ * (the `CommittedState` constructor and `make` are package-private), which makes the commitment
+ * correct by construction:
+ *
+ *   - `hashCalculatedState` is the PURE derivation `CommittedCommitment.deriveHash` -- a function
+ *     of the state value alone (see that object's scaladoc for why the catalog in the hash is the
+ *     canonical single-entry one).
+ *   - `setCalculatedState` routes through `CommittedState.setCommitted`, which applies the view's
+ *     delta incrementally and ASSERTS the resulting trie root equals the value-derived root,
+ *     raising [[CommittedStateError.RootDivergence]] (failing the snapshot loudly) on any mismatch
+ *     -- a divergence is a wiring bug, never something to paper over.
+ *   - the `/committed/...` routes and any `extraRoutes` read the SAME private cell.
+ */
+object CommittedApp {
+
+  def makeL0[
+    F[+_]: Async: Parallel,
+    TX <: DataUpdate: Encoder: Decoder: ClassTag,
+    PUB <: DataOnChainState: Encoder: Decoder: ClassTag,
+    PRV <: DataCalculatedState: Encoder: Decoder: ClassTag: CommittedView
+  ](
+    genesisState: DataState[PUB, PRV],
+    combiner: CombinerService[F, TX, PUB, PRV],
+    validator: ValidationService[F, TX, PUB, PRV],
+    extraRoutes: Option[CommittedReader[F, PRV] => HttpRoutes[F]] = None,
+    maxRecentDeltas: Int = CommittedState.DefaultMaxRecentDeltas
+  ): F[BaseDataApplicationL0Service[F]] =
+    CommittedState.make[F, PRV](genesisState.calculated, maxRecentDeltas).map { committedState =>
+      BaseDataApplicationL0Service[F, TX, PUB, PRV](
+        new MetagraphCommonService[F, TX, PUB, PRV, L0NodeContext[F]] with DataApplicationL0Service[F, TX, PUB, PRV] {
+
+          override def genesis: DataState[PUB, PRV] = genesisState
+
+          override def validateData(
+            state: DataState[PUB, PRV],
+            updates: NonEmptyList[Signed[TX]]
+          )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
+            validator.validateData(state, updates)
+
+          override def combine(
+            state: DataState[PUB, PRV],
+            updates: List[Signed[TX]]
+          )(implicit context: L0NodeContext[F]): F[DataState[PUB, PRV]] =
+            combiner.foldLeft(state, updates)
+
+          override def getCalculatedState(implicit context: L0NodeContext[F]): F[(SnapshotOrdinal, PRV)] =
+            committedState.committed.map(c => c.ordinal -> c.state)
+
+          override def setCalculatedState(ordinal: SnapshotOrdinal, state: PRV)(implicit
+            context: L0NodeContext[F]
+          ): F[Boolean] =
+            committedState.setCommitted(ordinal, state).as(true)
+
+          override def hashCalculatedState(state: PRV)(implicit context: L0NodeContext[F]): F[Hash] =
+            CommittedCommitment.deriveHash[F, PRV](state)
+
+          override def routes(implicit context: L0NodeContext[F]): HttpRoutes[F] =
+            new CommittedRoutes[F, PRV](committedState).public <+>
+            extraRoutes.fold(HttpRoutes.empty[F])(f => f(committedState))
+        }
+      )
+    }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedCommitment.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedCommitment.scala
@@ -1,36 +1,37 @@
 package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 
 import cats.MonadThrow
-import cats.effect.Sync
 import cats.syntax.all._
 
 import scala.collection.immutable.SortedMap
 
 import io.constellationnetwork.metagraph_sdk.crypto.mpt.impl.StatelessMerklePatriciaProducer
 import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaNode, MerklePatriciaTrie}
-import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot
-import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
-import io.constellationnetwork.security.hash.Hash
 
 import io.circe.Json
 
 /**
- * Pure derivations for the two-tier commitment -- everything here is a function of the entry set
- * (or of an existing trie plus a delta), with NO dependence on node-local history.
+ * Pure derivations for tier 1 of the commitment -- the state-dict MPT is a function of the entry
+ * set (or of an existing trie plus a delta) alone.
  *
  * ==The `hashCalculatedState` decision==
- * `hashCalculatedState(state)` must be a PURE function of the state VALUE: tessellation calls it on
- * freshly deserialized state during snapshot download, where the node has no local history yet, and
- * every node must agree on the hash. The live SMT catalog, however, accumulates HISTORICAL
- * `ordinal:<N>` entries, so its root is a function of history, not of the value.
+ * `hashCalculatedState = sha256(mptRoot || liveCatalogRoot)` where the live catalog commits the
+ * FULL root history (epoch rollup, [[EpochCatalog]]). The catalog root is NOT derivable from the
+ * state value -- it is history -- so the hash implementation sources it from one of two places,
+ * matching tessellation's two call orderings:
  *
- * Resolution: [[deriveHash]] = `CommittedRoots.combine(mptRoot, canonicalCatalogRoot)` where the
- * CANONICAL catalog contains exactly one entry, `sha256("current:mpt") -> mptRoot`. That is pure in
- * the value, still binds tier 2's key scheme and hashing discipline into the consensus hash, and
- * loses nothing: each historical `ordinal:<N>` root was the `current:mpt` root at ordinal N and is
- * therefore anchored by snapshot N's own calculated-state proof. The LIVE catalog (with history) is
- * a node-local, verifiable index exposed via `/committed/root` and SMT proofs.
+ *   - STEADY STATE (consensus accept/consume: the snapshot being hashed is NOT yet in the local
+ *     snapshot storage, and the committed cell sits at its parent): derive the TRANSITION from the
+ *     cell -- `catalogRoot_N = compose(advance(catalog_{N-1}, ordinal:<N-1> -> mptRoot_{N-1}),
+ *     current:mpt -> mptRoot(state))`.
+ *   - BOOTSTRAP/DOWNLOAD (the snapshot IS already stored -- tessellation prepends it before
+ *     fetching calculated state -- and the cell is behind): read the CONSTANT on-chain BREADCRUMB
+ *     from that signed snapshot and use its attested `catalogRoot` directly. O(1), no replay: the
+ *     Ethereum-header trust model.
+ *
+ * See `CommittedApp` for the wiring and `docs/committed-namespaces.md` for the full soundness
+ * argument over tessellation's call orderings.
  */
 object CommittedCommitment {
 
@@ -70,21 +71,4 @@ object CommittedCommitment {
         else producer.insert(afterRemoves, upserts).rethrow
     } yield result
   }
-
-  /** Root of the CANONICAL (single-entry) catalog: `{ sha256("current:mpt") -> mptRoot }`. */
-  def canonicalCatalogRoot[F[_]: Sync: JsonBinaryHasher](mptRoot: Hash): F[SparseMerkleRoot] =
-    InMemorySparseMerkleTree
-      .make[F](Map(CommitCatalog.currentMptKey -> CommitCatalog.rootValueBytes(mptRoot)))
-      .flatMap(_.root)
-
-  /** The canonical commitment pair, derived purely from the state value. */
-  def deriveRoots[F[_]: Sync: JsonBinaryHasher, S: CommittedView](state: S): F[CommittedRoots] =
-    for {
-      trie    <- buildTrie[F](CommittedView[S].entries(state))
-      smtRoot <- canonicalCatalogRoot[F](trie.rootNode.digest)
-    } yield CommittedRoots(trie.rootNode.digest, smtRoot)
-
-  /** The consensus-facing calculated-state hash: `combine(mptRoot, canonicalCatalogRoot)`. Pure in the value. */
-  def deriveHash[F[_]: Sync: JsonBinaryHasher, S: CommittedView](state: S): F[Hash] =
-    deriveRoots[F, S](state).map(_.combinedHash)
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedCommitment.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedCommitment.scala
@@ -1,0 +1,90 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.MonadThrow
+import cats.effect.Sync
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.impl.StatelessMerklePatriciaProducer
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.{MerklePatriciaNode, MerklePatriciaTrie}
+import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot
+import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+
+import io.circe.Json
+
+/**
+ * Pure derivations for the two-tier commitment -- everything here is a function of the entry set
+ * (or of an existing trie plus a delta), with NO dependence on node-local history.
+ *
+ * ==The `hashCalculatedState` decision==
+ * `hashCalculatedState(state)` must be a PURE function of the state VALUE: tessellation calls it on
+ * freshly deserialized state during snapshot download, where the node has no local history yet, and
+ * every node must agree on the hash. The live SMT catalog, however, accumulates HISTORICAL
+ * `ordinal:<N>` entries, so its root is a function of history, not of the value.
+ *
+ * Resolution: [[deriveHash]] = `CommittedRoots.combine(mptRoot, canonicalCatalogRoot)` where the
+ * CANONICAL catalog contains exactly one entry, `sha256("current:mpt") -> mptRoot`. That is pure in
+ * the value, still binds tier 2's key scheme and hashing discipline into the consensus hash, and
+ * loses nothing: each historical `ordinal:<N>` root was the `current:mpt` root at ordinal N and is
+ * therefore anchored by snapshot N's own calculated-state proof. The LIVE catalog (with history) is
+ * a node-local, verifiable index exposed via `/committed/root` and SMT proofs.
+ */
+object CommittedCommitment {
+
+  /** The canonical empty trie: an empty Branch root (what removing every key also collapses to). */
+  def emptyTrie[F[_]: MonadThrow: JsonBinaryHasher]: F[MerklePatriciaTrie] =
+    MerklePatriciaNode.Branch[F](Map.empty).map(MerklePatriciaTrie(_))
+
+  def isEmpty(trie: MerklePatriciaTrie): Boolean =
+    trie.rootNode match {
+      case MerklePatriciaNode.Branch(paths, _) => paths.isEmpty
+      case _                                   => false
+    }
+
+  /** Build the state-dict MPT over the full entry set (full rebuild -- the pure derivation path). */
+  def buildTrie[F[_]: MonadThrow: JsonBinaryHasher](entries: SortedMap[CommitKey, Json]): F[MerklePatriciaTrie] =
+    if (entries.isEmpty) emptyTrie[F]
+    else StatelessMerklePatriciaProducer[F].create(entries.toList.map { case (k, v) => k.toHex -> v }.toMap)
+
+  /**
+   * Apply a [[CommitDelta]] to an existing trie: removals first, then upserts. If the removals
+   * empty the trie, the upserts rebuild from scratch (the canonical single-leaf/extension collapse
+   * does not apply when growing out of the empty Branch root, so a fresh `create` keeps the result
+   * byte-identical to the full rebuild).
+   */
+  def applyDelta[F[_]: MonadThrow: JsonBinaryHasher](trie: MerklePatriciaTrie, delta: CommitDelta): F[MerklePatriciaTrie] = {
+    val producer = StatelessMerklePatriciaProducer[F]
+    val removeKeys = delta.removes.toList.map(_.toHex)
+    val upserts = delta.upserts.toList.map { case (k, v) => k.toHex -> v }.toMap
+
+    for {
+      afterRemoves <-
+        if (removeKeys.isEmpty) trie.pure[F]
+        else producer.remove(trie, removeKeys).rethrow
+      result <-
+        if (upserts.isEmpty) afterRemoves.pure[F]
+        else if (isEmpty(afterRemoves)) producer.create(upserts)
+        else producer.insert(afterRemoves, upserts).rethrow
+    } yield result
+  }
+
+  /** Root of the CANONICAL (single-entry) catalog: `{ sha256("current:mpt") -> mptRoot }`. */
+  def canonicalCatalogRoot[F[_]: Sync: JsonBinaryHasher](mptRoot: Hash): F[SparseMerkleRoot] =
+    InMemorySparseMerkleTree
+      .make[F](Map(CommitCatalog.currentMptKey -> CommitCatalog.rootValueBytes(mptRoot)))
+      .flatMap(_.root)
+
+  /** The canonical commitment pair, derived purely from the state value. */
+  def deriveRoots[F[_]: Sync: JsonBinaryHasher, S: CommittedView](state: S): F[CommittedRoots] =
+    for {
+      trie    <- buildTrie[F](CommittedView[S].entries(state))
+      smtRoot <- canonicalCatalogRoot[F](trie.rootNode.digest)
+    } yield CommittedRoots(trie.rootNode.digest, smtRoot)
+
+  /** The consensus-facing calculated-state hash: `combine(mptRoot, canonicalCatalogRoot)`. Pure in the value. */
+  def deriveHash[F[_]: Sync: JsonBinaryHasher, S: CommittedView](state: S): F[Hash] =
+    deriveRoots[F, S](state).map(_.combinedHash)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedConfig.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedConfig.scala
@@ -1,0 +1,40 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+/**
+ * Chain-wide and node-local configuration of the committed-state module.
+ *
+ *   - [[epochSize]] -- CONSENSUS-CRITICAL: the number of ordinals per catalog epoch (the hot epoch
+ *     SMT is sealed into the level-1 SMT every `epochSize` ordinals). Every node of a metagraph
+ *     must run the same value: it determines which epoch tree an `ordinal:<N>` entry lands in and
+ *     therefore the catalog root itself.
+ *   - [[sealedEpochRetention]] -- NODE-LOCAL serving policy: how many sealed epoch trees (their
+ *     full `ordinal -> mptRoot` contents) a node keeps for SERVING ancient-ordinal proofs. The
+ *     level-1 roots of pruned epochs are kept forever (32 bytes per epoch), so every proof ever
+ *     issued stays VERIFIABLE against the committed catalog root -- retention bounds what a node
+ *     can serve, never what the network can verify ("retention is serving, not trust").
+ *   - [[maxRecentDeltas]] -- NODE-LOCAL: ring-buffer depth for recent [[StateDelta]]s (older
+ *     ordinals fall back to the snapshot route).
+ */
+final case class CommittedConfig(
+  epochSize: Int = CommittedConfig.DefaultEpochSize,
+  sealedEpochRetention: Int = CommittedConfig.DefaultSealedEpochRetention,
+  maxRecentDeltas: Int = CommittedConfig.DefaultMaxRecentDeltas
+) {
+  require(epochSize > 0, "epochSize must be positive")
+  require(sealedEpochRetention >= 0, "sealedEpochRetention must be non-negative")
+  require(maxRecentDeltas >= 0, "maxRecentDeltas must be non-negative")
+}
+
+object CommittedConfig {
+
+  /** 2^16 ordinals per epoch: ~45 days of 1-minute snapshots per sealed tree. */
+  val DefaultEpochSize: Int = 65536
+
+  /** Keep the last 4 sealed epoch trees' contents for serving ancient proofs. */
+  val DefaultSealedEpochRetention: Int = 4
+
+  /** Default ring-buffer depth for recent deltas. */
+  val DefaultMaxRecentDeltas: Int = 64
+
+  val default: CommittedConfig = CommittedConfig()
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedOnChain.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedOnChain.scala
@@ -1,0 +1,37 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import io.constellationnetwork.currency.dataApplication.DataOnChainState
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+/**
+ * The on-chain state type `CommittedApp.makeL0` actually registers with tessellation: the dev's
+ * own `PUB` plus the [[CommittedBreadcrumb]] for the snapshot being produced.
+ *
+ * This is what makes the breadcrumb CORRECT BY CONSTRUCTION: the service's on-chain
+ * encoder/decoder and `combine` are typed over `CommittedOnChain[PUB]`, and only the committed
+ * layer ever constructs the wrapper -- the dev's combiner sees and returns plain `PUB`, so the
+ * breadcrumb can neither be omitted nor forged from application code. A proposer that tampers
+ * with it produces an artifact honest validators cannot reproduce (their own `combine` emits the
+ * locally derived breadcrumb), so the proposal cannot gather a majority; and the next round's
+ * `combine` re-validates the persisted breadcrumb against the local committed roots
+ * ([[CommittedStateError.BreadcrumbMismatch]]).
+ */
+final case class CommittedOnChain[PUB <: DataOnChainState](inner: PUB, breadcrumb: CommittedBreadcrumb) extends DataOnChainState
+
+object CommittedOnChain {
+
+  implicit def encoder[PUB <: DataOnChainState: Encoder]: Encoder[CommittedOnChain[PUB]] =
+    (s: CommittedOnChain[PUB]) =>
+      Json.obj(
+        "inner"      -> s.inner.asJson,
+        "breadcrumb" -> s.breadcrumb.asJson
+      )
+
+  implicit def decoder[PUB <: DataOnChainState: Decoder]: Decoder[CommittedOnChain[PUB]] = (c: HCursor) =>
+    for {
+      inner      <- c.downField("inner").as[PUB]
+      breadcrumb <- c.downField("breadcrumb").as[CommittedBreadcrumb]
+    } yield CommittedOnChain(inner, breadcrumb)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedReader.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedReader.scala
@@ -1,0 +1,12 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+/**
+ * Read-only view over a `CommittedState`'s cell. One call to [[committed]] is ONE atomic read; all
+ * derived data (roots, proofs, deltas, snapshot) should be taken from that single [[Committed]]
+ * value so they are mutually consistent.
+ */
+trait CommittedReader[F[_], S] {
+
+  /** The current committed snapshot (a single atomic read of the cell). */
+  def committed: F[Committed[F, S]]
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedReplica.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedReplica.scala
@@ -3,39 +3,40 @@ package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 import cats.effect.Async
 import cats.syntax.all._
 
-import scala.collection.immutable.SortedMap
-
 import io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaTrie
-import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.hash.Hash
-import io.constellationnetwork.security.hex.Hex
 
 /**
- * A verifying follower of a committed state: seeded from a [[CommittedSnapshot]] (rebuilding both
- * tries and CHECKING they reproduce the snapshot's roots), then advanced by [[applyDelta]], which
- * recomputes both roots LOCALLY from the delta's change-set and rejects the delta unless they equal
- * the roots it claims. Nothing is trusted from the wire beyond what the local recomputation proves.
+ * A verifying follower of a committed state: seeded from a [[CommittedSnapshot]] (rebuilding the
+ * trie AND the epoch catalog, checking they reproduce the snapshot's roots), then advanced by
+ * [[applyDelta]], which recomputes both roots LOCALLY from the delta's change-set -- replaying the
+ * same epoch-rollup transition the source performed (hot insert, boundary seal, recompose) -- and
+ * rejects the delta unless they equal the roots it claims. Nothing is trusted from the wire beyond
+ * what the local recomputation proves.
  *
- * This is the consumer-side half of the `/committed/delta/:ordinal` + `/committed/snapshot` routes;
- * the ottochain follow-up wires it to HTTP.
+ * This is the consumer-side half of the `/committed/delta/:ordinal` + `/committed/snapshot`
+ * routes; the ottochain follow-up wires it to HTTP.
  */
 final case class CommittedReplica[F[_]] private (
   ordinal: SnapshotOrdinal,
   trie: MerklePatriciaTrie,
-  catalog: InMemorySparseMerkleTree[F],
-  catalogEntries: SortedMap[Hex, Hash],
+  epochs: EpochCatalog[F],
   roots: CommittedRoots
 ) {
 
   /**
-   * Apply one [[StateDelta]]: requires `delta.parentRoots == roots`, recomputes the MPT and catalog
-   * roots locally, and accepts only if both match `delta.roots`.
+   * Apply one [[StateDelta]]: requires `delta.parentRoots == roots` (and contiguity), recomputes
+   * the MPT and catalog roots locally, and accepts only if both match `delta.roots`.
    */
   def applyDelta(delta: StateDelta)(implicit F: Async[F], H: JsonBinaryHasher[F]): F[Either[ReplicationError, CommittedReplica[F]]] =
     if (delta.parentRoots != roots)
       (ReplicationError.ParentRootsMismatch(delta.ordinal, roots, delta.parentRoots): ReplicationError)
+        .asLeft[CommittedReplica[F]]
+        .pure[F]
+    else if (delta.ordinal.value.value != ordinal.value.value + 1)
+      (ReplicationError.NonContiguousDelta(ordinal, delta.ordinal): ReplicationError)
         .asLeft[CommittedReplica[F]]
         .pure[F]
     else
@@ -47,21 +48,16 @@ final case class CommittedReplica[F[_]] private (
             (ReplicationError.MptRootMismatch(delta.ordinal, mptRoot, delta.roots.mptRoot): ReplicationError)
               .asLeft[CommittedReplica[F]]
               .pure[F]
-          else {
-            val catalogChanges = CommitCatalog.changesFor(delta.ordinal, mptRoot)
+          else
             for {
-              nextCatalog <- catalog
-                .withChanges(catalogChanges.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap, Set.empty)
-                .flatMap(CommittedState.requireInMemory[F](_))
-              smtRoot <- nextCatalog.root
+              advanced <- epochs.advance(ordinal.value.value, roots.mptRoot)
+              composed <- advanced._1.compose(mptRoot)
             } yield
-              if (smtRoot != delta.roots.smtRoot)
-                (ReplicationError.SmtRootMismatch(delta.ordinal, smtRoot.value, delta.roots.smtRoot.value): ReplicationError)
+              if (composed._2 != delta.roots.catalogRoot)
+                (ReplicationError.CatalogRootMismatch(delta.ordinal, composed._2.value, delta.roots.catalogRoot.value): ReplicationError)
                   .asLeft[CommittedReplica[F]]
               else
-                CommittedReplica(delta.ordinal, applied, nextCatalog, catalogEntries ++ catalogChanges, delta.roots)
-                  .asRight[ReplicationError]
-          }
+                CommittedReplica(delta.ordinal, applied, advanced._1, delta.roots).asRight[ReplicationError]
       } yield result
 }
 
@@ -69,24 +65,32 @@ object CommittedReplica {
 
   /**
    * Seed a replica from a full snapshot (the ring-buffer-eviction fallback), verifying that the
-   * rebuilt tries reproduce the snapshot's claimed roots.
+   * rebuilt trie and catalog reproduce the snapshot's claimed roots.
    */
   def fromSnapshot[F[_]: Async: JsonBinaryHasher](
-    snapshot: CommittedSnapshot
+    snapshot: CommittedSnapshot,
+    config: CommittedConfig = CommittedConfig.default
   ): F[Either[ReplicationError, CommittedReplica[F]]] =
     for {
-      trie <- CommittedCommitment.buildTrie[F](snapshot.entries)
-      catalog <- InMemorySparseMerkleTree.make[F](
-        snapshot.catalog.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap
-      )
-      smtRoot <- catalog.root
-      rebuilt = CommittedRoots(trie.rootNode.digest, smtRoot)
-    } yield
-      if (rebuilt != snapshot.roots)
-        (ReplicationError.SnapshotRootsMismatch(snapshot.ordinal, rebuilt, snapshot.roots): ReplicationError)
-          .asLeft[CommittedReplica[F]]
-      else
-        CommittedReplica(snapshot.ordinal, trie, catalog, snapshot.catalog, snapshot.roots).asRight[ReplicationError]
+      trie    <- CommittedCommitment.buildTrie[F](snapshot.entries)
+      catalog <- EpochCatalog.fromContents[F](config, snapshot.catalog)
+      result <- catalog match {
+        case Left(err) =>
+          (ReplicationError.MalformedSnapshot(snapshot.ordinal, err.getMessage): ReplicationError)
+            .asLeft[CommittedReplica[F]]
+            .pure[F]
+        case Right(epochs) =>
+          epochs.compose(trie.rootNode.digest).map {
+            case (_, catalogRoot) =>
+              val rebuilt = CommittedRoots(trie.rootNode.digest, catalogRoot)
+              if (rebuilt != snapshot.roots)
+                (ReplicationError.SnapshotRootsMismatch(snapshot.ordinal, rebuilt, snapshot.roots): ReplicationError)
+                  .asLeft[CommittedReplica[F]]
+              else
+                CommittedReplica(snapshot.ordinal, trie, epochs, snapshot.roots).asRight[ReplicationError]
+          }
+      }
+    } yield result
 }
 
 sealed abstract class ReplicationError(message: String) extends RuntimeException(message)
@@ -99,13 +103,18 @@ object ReplicationError {
         s"(local mpt ${local.mptRoot.value}, claimed parent mpt ${claimed.mptRoot.value})"
       )
 
+  final case class NonContiguousDelta(replicaOrdinal: SnapshotOrdinal, deltaOrdinal: SnapshotOrdinal)
+      extends ReplicationError(
+        s"delta for ordinal ${deltaOrdinal.value.value} is not contiguous with the replica at ${replicaOrdinal.value.value}"
+      )
+
   final case class MptRootMismatch(ordinal: SnapshotOrdinal, recomputed: Hash, claimed: Hash)
       extends ReplicationError(
         s"delta for ordinal ${ordinal.value.value} is tampered or inconsistent: " +
         s"locally recomputed MPT root ${recomputed.value} != claimed ${claimed.value}"
       )
 
-  final case class SmtRootMismatch(ordinal: SnapshotOrdinal, recomputed: Hash, claimed: Hash)
+  final case class CatalogRootMismatch(ordinal: SnapshotOrdinal, recomputed: Hash, claimed: Hash)
       extends ReplicationError(
         s"delta for ordinal ${ordinal.value.value} is tampered or inconsistent: " +
         s"locally recomputed catalog root ${recomputed.value} != claimed ${claimed.value}"
@@ -116,4 +125,7 @@ object ReplicationError {
         s"snapshot for ordinal ${ordinal.value.value} does not reproduce its claimed roots " +
         s"(rebuilt mpt ${rebuilt.mptRoot.value}, claimed mpt ${claimed.mptRoot.value})"
       )
+
+  final case class MalformedSnapshot(ordinal: SnapshotOrdinal, reason: String)
+      extends ReplicationError(s"snapshot for ordinal ${ordinal.value.value} carries malformed catalog contents: $reason")
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedReplica.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedReplica.scala
@@ -75,7 +75,7 @@ object CommittedReplica {
     snapshot: CommittedSnapshot
   ): F[Either[ReplicationError, CommittedReplica[F]]] =
     for {
-      trie    <- CommittedCommitment.buildTrie[F](snapshot.entries)
+      trie <- CommittedCommitment.buildTrie[F](snapshot.entries)
       catalog <- InMemorySparseMerkleTree.make[F](
         snapshot.catalog.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap
       )

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedReplica.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedReplica.scala
@@ -1,0 +1,119 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.MerklePatriciaTrie
+import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+/**
+ * A verifying follower of a committed state: seeded from a [[CommittedSnapshot]] (rebuilding both
+ * tries and CHECKING they reproduce the snapshot's roots), then advanced by [[applyDelta]], which
+ * recomputes both roots LOCALLY from the delta's change-set and rejects the delta unless they equal
+ * the roots it claims. Nothing is trusted from the wire beyond what the local recomputation proves.
+ *
+ * This is the consumer-side half of the `/committed/delta/:ordinal` + `/committed/snapshot` routes;
+ * the ottochain follow-up wires it to HTTP.
+ */
+final case class CommittedReplica[F[_]] private (
+  ordinal: SnapshotOrdinal,
+  trie: MerklePatriciaTrie,
+  catalog: InMemorySparseMerkleTree[F],
+  catalogEntries: SortedMap[Hex, Hash],
+  roots: CommittedRoots
+) {
+
+  /**
+   * Apply one [[StateDelta]]: requires `delta.parentRoots == roots`, recomputes the MPT and catalog
+   * roots locally, and accepts only if both match `delta.roots`.
+   */
+  def applyDelta(delta: StateDelta)(implicit F: Async[F], H: JsonBinaryHasher[F]): F[Either[ReplicationError, CommittedReplica[F]]] =
+    if (delta.parentRoots != roots)
+      (ReplicationError.ParentRootsMismatch(delta.ordinal, roots, delta.parentRoots): ReplicationError)
+        .asLeft[CommittedReplica[F]]
+        .pure[F]
+    else
+      for {
+        applied <- CommittedCommitment.applyDelta[F](trie, CommitDelta(delta.upserts, delta.removes))
+        mptRoot = applied.rootNode.digest
+        result <-
+          if (mptRoot != delta.roots.mptRoot)
+            (ReplicationError.MptRootMismatch(delta.ordinal, mptRoot, delta.roots.mptRoot): ReplicationError)
+              .asLeft[CommittedReplica[F]]
+              .pure[F]
+          else {
+            val catalogChanges = CommitCatalog.changesFor(delta.ordinal, mptRoot)
+            for {
+              nextCatalog <- catalog
+                .withChanges(catalogChanges.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap, Set.empty)
+                .flatMap(CommittedState.requireInMemory[F](_))
+              smtRoot <- nextCatalog.root
+            } yield
+              if (smtRoot != delta.roots.smtRoot)
+                (ReplicationError.SmtRootMismatch(delta.ordinal, smtRoot.value, delta.roots.smtRoot.value): ReplicationError)
+                  .asLeft[CommittedReplica[F]]
+              else
+                CommittedReplica(delta.ordinal, applied, nextCatalog, catalogEntries ++ catalogChanges, delta.roots)
+                  .asRight[ReplicationError]
+          }
+      } yield result
+}
+
+object CommittedReplica {
+
+  /**
+   * Seed a replica from a full snapshot (the ring-buffer-eviction fallback), verifying that the
+   * rebuilt tries reproduce the snapshot's claimed roots.
+   */
+  def fromSnapshot[F[_]: Async: JsonBinaryHasher](
+    snapshot: CommittedSnapshot
+  ): F[Either[ReplicationError, CommittedReplica[F]]] =
+    for {
+      trie    <- CommittedCommitment.buildTrie[F](snapshot.entries)
+      catalog <- InMemorySparseMerkleTree.make[F](
+        snapshot.catalog.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap
+      )
+      smtRoot <- catalog.root
+      rebuilt = CommittedRoots(trie.rootNode.digest, smtRoot)
+    } yield
+      if (rebuilt != snapshot.roots)
+        (ReplicationError.SnapshotRootsMismatch(snapshot.ordinal, rebuilt, snapshot.roots): ReplicationError)
+          .asLeft[CommittedReplica[F]]
+      else
+        CommittedReplica(snapshot.ordinal, trie, catalog, snapshot.catalog, snapshot.roots).asRight[ReplicationError]
+}
+
+sealed abstract class ReplicationError(message: String) extends RuntimeException(message)
+
+object ReplicationError {
+
+  final case class ParentRootsMismatch(ordinal: SnapshotOrdinal, local: CommittedRoots, claimed: CommittedRoots)
+      extends ReplicationError(
+        s"delta for ordinal ${ordinal.value.value} does not chain from the replica's roots " +
+        s"(local mpt ${local.mptRoot.value}, claimed parent mpt ${claimed.mptRoot.value})"
+      )
+
+  final case class MptRootMismatch(ordinal: SnapshotOrdinal, recomputed: Hash, claimed: Hash)
+      extends ReplicationError(
+        s"delta for ordinal ${ordinal.value.value} is tampered or inconsistent: " +
+        s"locally recomputed MPT root ${recomputed.value} != claimed ${claimed.value}"
+      )
+
+  final case class SmtRootMismatch(ordinal: SnapshotOrdinal, recomputed: Hash, claimed: Hash)
+      extends ReplicationError(
+        s"delta for ordinal ${ordinal.value.value} is tampered or inconsistent: " +
+        s"locally recomputed catalog root ${recomputed.value} != claimed ${claimed.value}"
+      )
+
+  final case class SnapshotRootsMismatch(ordinal: SnapshotOrdinal, rebuilt: CommittedRoots, claimed: CommittedRoots)
+      extends ReplicationError(
+        s"snapshot for ordinal ${ordinal.value.value} does not reproduce its claimed roots " +
+        s"(rebuilt mpt ${rebuilt.mptRoot.value}, claimed mpt ${claimed.mptRoot.value})"
+      )
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoots.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoots.scala
@@ -1,6 +1,7 @@
 package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 
 import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot
+import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.hex.Hex
 
@@ -8,35 +9,60 @@ import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor, Json}
 
 /**
- * The two-tier commitment of a snapshot: the state-dict MPT root (tier 1) and the root-catalog SMT
- * root (tier 2).
+ * The two-tier commitment of a snapshot: the state-dict MPT root (tier 1) and the LIVE catalog
+ * root (tier 2 -- the full-history epoch rollup, see [[EpochCatalog]]).
  *
  * [[combinedHash]] is the single hash binding the pair: `sha256(rawBytes(mptRoot) ++
- * rawBytes(smtRoot))` -- 64 bytes of raw digest material, mpt first. This (computed over the
- * CANONICAL pair derived purely from the state value, see `CommittedCommitment.deriveHash`) is what
- * `hashCalculatedState` returns, so the on-chain calculated-state proof anchors both tiers and the
- * catalog key scheme in one hash.
+ * rawBytes(catalogRoot))` -- 64 bytes of raw digest material, mpt first. This is exactly what
+ * `hashCalculatedState` returns, so the snapshot's on-chain calculated-state proof anchors the
+ * current state AND its entire root history in one hash.
  */
-final case class CommittedRoots(mptRoot: Hash, smtRoot: SparseMerkleRoot) {
-  def combinedHash: Hash = CommittedRoots.combine(mptRoot, smtRoot)
+final case class CommittedRoots(mptRoot: Hash, catalogRoot: SparseMerkleRoot) {
+  def combinedHash: Hash = CommittedRoots.combine(mptRoot, catalogRoot)
 }
 
 object CommittedRoots {
 
-  /** `sha256(rawBytes(mptRoot) ++ rawBytes(smtRoot))`, both roots as their 32 raw digest bytes. */
-  def combine(mptRoot: Hash, smtRoot: SparseMerkleRoot): Hash =
-    Hash.fromBytes(Hex(mptRoot.value).toBytes ++ Hex(smtRoot.value.value).toBytes)
+  /** `sha256(rawBytes(mptRoot) ++ rawBytes(catalogRoot))`, both roots as their 32 raw digest bytes. */
+  def combine(mptRoot: Hash, catalogRoot: SparseMerkleRoot): Hash =
+    Hash.fromBytes(Hex(mptRoot.value).toBytes ++ Hex(catalogRoot.value.value).toBytes)
 
   implicit val encoder: Encoder[CommittedRoots] =
     (roots: CommittedRoots) =>
       Json.obj(
-        "mptRoot" -> roots.mptRoot.asJson,
-        "smtRoot" -> roots.smtRoot.asJson
+        "mptRoot"     -> roots.mptRoot.asJson,
+        "catalogRoot" -> roots.catalogRoot.asJson
       )
 
   implicit val decoder: Decoder[CommittedRoots] = (c: HCursor) =>
     for {
-      mptRoot <- c.downField("mptRoot").as[Hash]
-      smtRoot <- c.downField("smtRoot").as[SparseMerkleRoot]
-    } yield CommittedRoots(mptRoot, smtRoot)
+      mptRoot     <- c.downField("mptRoot").as[Hash]
+      catalogRoot <- c.downField("catalogRoot").as[SparseMerkleRoot]
+    } yield CommittedRoots(mptRoot, catalogRoot)
+}
+
+/**
+ * The CONSTANT-SIZE on-chain breadcrumb: the [[CommittedRoots]] pair committed at one ordinal.
+ * Every snapshot's on-chain state carries exactly one of these (via [[CommittedOnChain]]) -- it
+ * never accumulates. It is what lets a freshly syncing node obtain the (consensus-attested)
+ * catalog root in O(1), without replaying history: the Ethereum-header model -- each per-step
+ * transition was validated by the then-current validators, so the latest signed breadcrumb
+ * transitively commits the whole history.
+ */
+final case class CommittedBreadcrumb(ordinal: SnapshotOrdinal, roots: CommittedRoots)
+
+object CommittedBreadcrumb {
+
+  implicit val encoder: Encoder[CommittedBreadcrumb] =
+    (b: CommittedBreadcrumb) =>
+      Json.obj(
+        "ordinal" -> b.ordinal.asJson,
+        "roots"   -> b.roots.asJson
+      )
+
+  implicit val decoder: Decoder[CommittedBreadcrumb] = (c: HCursor) =>
+    for {
+      ordinal <- c.downField("ordinal").as[SnapshotOrdinal]
+      roots   <- c.downField("roots").as[CommittedRoots]
+    } yield CommittedBreadcrumb(ordinal, roots)
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoots.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoots.scala
@@ -1,0 +1,42 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+/**
+ * The two-tier commitment of a snapshot: the state-dict MPT root (tier 1) and the root-catalog SMT
+ * root (tier 2).
+ *
+ * [[combinedHash]] is the single hash binding the pair: `sha256(rawBytes(mptRoot) ++
+ * rawBytes(smtRoot))` -- 64 bytes of raw digest material, mpt first. This (computed over the
+ * CANONICAL pair derived purely from the state value, see `CommittedCommitment.deriveHash`) is what
+ * `hashCalculatedState` returns, so the on-chain calculated-state proof anchors both tiers and the
+ * catalog key scheme in one hash.
+ */
+final case class CommittedRoots(mptRoot: Hash, smtRoot: SparseMerkleRoot) {
+  def combinedHash: Hash = CommittedRoots.combine(mptRoot, smtRoot)
+}
+
+object CommittedRoots {
+
+  /** `sha256(rawBytes(mptRoot) ++ rawBytes(smtRoot))`, both roots as their 32 raw digest bytes. */
+  def combine(mptRoot: Hash, smtRoot: SparseMerkleRoot): Hash =
+    Hash.fromBytes(Hex(mptRoot.value).toBytes ++ Hex(smtRoot.value.value).toBytes)
+
+  implicit val encoder: Encoder[CommittedRoots] =
+    (roots: CommittedRoots) =>
+      Json.obj(
+        "mptRoot" -> roots.mptRoot.asJson,
+        "smtRoot" -> roots.smtRoot.asJson
+      )
+
+  implicit val decoder: Decoder[CommittedRoots] = (c: HCursor) =>
+    for {
+      mptRoot <- c.downField("mptRoot").as[Hash]
+      smtRoot <- c.downField("smtRoot").as[SparseMerkleRoot]
+    } yield CommittedRoots(mptRoot, smtRoot)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoutes.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoutes.scala
@@ -13,19 +13,24 @@ import org.http4s.circe.CirceEntityCodec.{circeEntityDecoder, circeEntityEncoder
 import org.http4s.{HttpRoutes, Response, Uri}
 
 /**
- * Drop-in read-only routes over a [[CommittedReader]]. Every handler performs exactly ONE read of
- * the committed cell and derives its whole response (roots + proof + metadata) from that single
- * [[Committed]] value, so each response is internally consistent.
+ * Drop-in read-only routes over a [[CommittedReader]] (plus the verify-gated hydration hook).
+ * Every read handler performs exactly ONE read of the committed cell and derives its whole
+ * response (roots + proof + metadata) from that single [[Committed]] value, so each response is
+ * internally consistent.
  *
- *   - `GET  /committed/root`               -> { ordinal, mptRoot, smtRoot, calculatedStateHash }
- *   - `GET  /committed/proof/<key...>`     -> single-key inclusion proof (key segments in the path)
- *   - `POST /committed/proofs`             -> batch proof; body `{ "keys": ["ns/a", ...] }`
- *   - `GET  /committed/proof-prefix/<ns...>` -> complete prefix attestation for a namespace
- *   - `GET  /committed/delta/:ordinal`     -> the [[StateDelta]] for that ordinal (404 once evicted)
- *   - `GET  /committed/snapshot`           -> the [[CommittedSnapshot]] replication fallback
+ *   - `GET  /committed/root`                  -> { ordinal, mptRoot, catalogRoot, calculatedStateHash, hydrated }
+ *   - `GET  /committed/proof/<key...>`        -> single-key inclusion proof (key segments in the path)
+ *   - `POST /committed/proofs`                -> batch proof; body `{ "keys": ["ns/a", ...] }`
+ *   - `GET  /committed/proof-prefix/<ns...>`  -> complete prefix attestation for a namespace
+ *   - `GET  /committed/proof-ordinal/:ordinal`-> [[OrdinalCatalogProof]] (404 never; absence is provable;
+ *                                                410 Gone when the sealed epoch was pruned here)
+ *   - `GET  /committed/catalog`               -> [[CatalogContents]] (hydration/replication source)
+ *   - `GET  /committed/delta/:ordinal`        -> the [[StateDelta]] for that ordinal (404 once evicted)
+ *   - `GET  /committed/snapshot`              -> the [[CommittedSnapshot]] replication fallback
+ *   - `POST /committed/hydrate`               -> install [[CatalogContents]] on a seeded cell (rejected
+ *                                                unless they recompose to the attested catalog root)
  */
-final class CommittedRoutes[F[_]: Async, S](reader: CommittedReader[F, S])(implicit view: CommittedView[S])
-    extends MetagraphPublicRoutes[F] {
+final class CommittedRoutes[F[_]: Async, S](state: CommittedState[F, S])(implicit view: CommittedView[S]) extends MetagraphPublicRoutes[F] {
 
   private def pathString(path: Uri.Path): String =
     path.segments.map(_.decoded()).mkString("/")
@@ -36,27 +41,54 @@ final class CommittedRoutes[F[_]: Async, S](reader: CommittedReader[F, S])(impli
       case other           => BadRequest(Json.obj("error" -> other.getMessage.asJson))
     }
 
+  private def catalogError(err: CommittedProofError): F[Response[F]] =
+    err match {
+      case CommittedProofError.EpochPruned(_)     => Gone(Json.obj("error" -> err.getMessage.asJson))
+      case CommittedProofError.CatalogNotHydrated => ServiceUnavailable(Json.obj("error" -> err.getMessage.asJson))
+      case other                                  => BadRequest(Json.obj("error" -> other.getMessage.asJson))
+    }
+
   protected val routes: HttpRoutes[F] = HttpRoutes.of[F] {
 
     case GET -> Root / "committed" / "root" =>
-      reader.committed.flatMap { c =>
-        CommittedCommitment.canonicalCatalogRoot[F](c.roots.mptRoot).flatMap { canonical =>
-          Ok(
-            Json.obj(
-              "ordinal"             -> c.ordinal.asJson,
-              "mptRoot"             -> c.roots.mptRoot.asJson,
-              "smtRoot"             -> c.roots.smtRoot.asJson,
-              "calculatedStateHash" -> CommittedRoots.combine(c.roots.mptRoot, canonical).asJson
-            )
+      state.committed.flatMap { c =>
+        Ok(
+          Json.obj(
+            "ordinal"             -> c.ordinal.asJson,
+            "mptRoot"             -> c.roots.mptRoot.asJson,
+            "catalogRoot"         -> c.roots.catalogRoot.asJson,
+            "calculatedStateHash" -> c.roots.combinedHash.asJson,
+            "hydrated"            -> c.isHydrated.asJson
           )
-        }
+        )
       }
 
     case GET -> Root / "committed" / "snapshot" =>
-      reader.committed.flatMap(c => Ok(c.snapshot.asJson))
+      state.committed.flatMap { c =>
+        c.snapshot match {
+          case Some(s) => Ok(s.asJson)
+          case None    => ServiceUnavailable(Json.obj("error" -> "catalog not hydrated; no snapshot to serve".asJson))
+        }
+      }
+
+    case GET -> Root / "committed" / "catalog" =>
+      state.committed.flatMap { c =>
+        c.catalogContents match {
+          case Some(contents) => Ok(contents.asJson)
+          case None           => ServiceUnavailable(Json.obj("error" -> "catalog not hydrated; no contents to serve".asJson))
+        }
+      }
+
+    case req @ POST -> Root / "committed" / "hydrate" =>
+      req.decode[CatalogContents] { contents =>
+        state.hydrate(contents).flatMap {
+          case Right(c)  => Ok(Json.obj("ordinal" -> c.ordinal.asJson, "catalogRoot" -> c.roots.catalogRoot.asJson))
+          case Left(err) => BadRequest(Json.obj("error" -> err.getMessage.asJson))
+        }
+      }
 
     case GET -> Root / "committed" / "delta" / LongVar(ordinal) if ordinal >= 0L =>
-      reader.committed.flatMap { c =>
+      state.committed.flatMap { c =>
         c.deltaFor(SnapshotOrdinal.unsafeApply(ordinal)) match {
           case Some(delta) => Ok(delta.asJson)
           case None =>
@@ -64,11 +96,27 @@ final class CommittedRoutes[F[_]: Async, S](reader: CommittedReader[F, S])(impli
         }
       }
 
+    case GET -> Root / "committed" / "proof-ordinal" / LongVar(ordinal) if ordinal >= 0L =>
+      state.committed.flatMap { c =>
+        c.proveOrdinal(SnapshotOrdinal.unsafeApply(ordinal)).flatMap {
+          case Left(err) => catalogError(err)
+          case Right(proof) =>
+            Ok(
+              Json.obj(
+                "ordinal"     -> c.ordinal.asJson,
+                "catalogRoot" -> c.roots.catalogRoot.asJson,
+                "epochSize"   -> state.config.epochSize.asJson,
+                "proof"       -> proof.asJson
+              )
+            )
+        }
+      }
+
     case GET -> "committed" /: "proof" /: keyPath =>
       CommitKey.from(pathString(keyPath)) match {
         case Left(err) => BadRequest(Json.obj("error" -> err.getMessage.asJson))
         case Right(key) =>
-          reader.committed.flatMap { c =>
+          state.committed.flatMap { c =>
             c.proveKey(key).flatMap {
               case Left(err) => proofError(err)
               case Right(proof) =>
@@ -90,7 +138,7 @@ final class CommittedRoutes[F[_]: Async, S](reader: CommittedReader[F, S])(impli
         body.keys.traverse(CommitKey.from) match {
           case Left(err) => BadRequest(Json.obj("error" -> err.getMessage.asJson))
           case Right(keys) =>
-            reader.committed.flatMap { c =>
+            state.committed.flatMap { c =>
               c.proveKeys(keys).flatMap {
                 case Left(err) => proofError(err)
                 case Right(proof) =>
@@ -111,7 +159,7 @@ final class CommittedRoutes[F[_]: Async, S](reader: CommittedReader[F, S])(impli
       CommitNamespace.from(pathString(nsPath)) match {
         case Left(err) => BadRequest(Json.obj("error" -> err.getMessage.asJson))
         case Right(ns) =>
-          reader.committed.flatMap { c =>
+          state.committed.flatMap { c =>
             c.attestNamespace(ns).flatMap {
               case Left(err) => proofError(err)
               case Right(proof) =>

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoutes.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoutes.scala
@@ -1,0 +1,142 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.MetagraphPublicRoutes
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{MerklePatriciaProofError, PathNotFound}
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, HCursor, Json}
+import org.http4s.circe.CirceEntityCodec.{circeEntityDecoder, circeEntityEncoder}
+import org.http4s.{HttpRoutes, Response, Uri}
+
+/**
+ * Drop-in read-only routes over a [[CommittedReader]]. Every handler performs exactly ONE read of
+ * the committed cell and derives its whole response (roots + proof + metadata) from that single
+ * [[Committed]] value, so each response is internally consistent.
+ *
+ *   - `GET  /committed/root`               -> { ordinal, mptRoot, smtRoot, calculatedStateHash }
+ *   - `GET  /committed/proof/<key...>`     -> single-key inclusion proof (key segments in the path)
+ *   - `POST /committed/proofs`             -> batch proof; body `{ "keys": ["ns/a", ...] }`
+ *   - `GET  /committed/proof-prefix/<ns...>` -> complete prefix attestation for a namespace
+ *   - `GET  /committed/delta/:ordinal`     -> the [[StateDelta]] for that ordinal (404 once evicted)
+ *   - `GET  /committed/snapshot`           -> the [[CommittedSnapshot]] replication fallback
+ */
+final class CommittedRoutes[F[_]: Async, S](reader: CommittedReader[F, S])(implicit view: CommittedView[S])
+    extends MetagraphPublicRoutes[F] {
+
+  private def pathString(path: Uri.Path): String =
+    path.segments.map(_.decoded()).mkString("/")
+
+  private def proofError(err: MerklePatriciaProofError): F[Response[F]] =
+    err match {
+      case PathNotFound(p) => NotFound(Json.obj("error" -> s"key not found: $p".asJson))
+      case other           => BadRequest(Json.obj("error" -> other.getMessage.asJson))
+    }
+
+  protected val routes: HttpRoutes[F] = HttpRoutes.of[F] {
+
+    case GET -> Root / "committed" / "root" =>
+      reader.committed.flatMap { c =>
+        CommittedCommitment.canonicalCatalogRoot[F](c.roots.mptRoot).flatMap { canonical =>
+          Ok(
+            Json.obj(
+              "ordinal"             -> c.ordinal.asJson,
+              "mptRoot"             -> c.roots.mptRoot.asJson,
+              "smtRoot"             -> c.roots.smtRoot.asJson,
+              "calculatedStateHash" -> CommittedRoots.combine(c.roots.mptRoot, canonical).asJson
+            )
+          )
+        }
+      }
+
+    case GET -> Root / "committed" / "snapshot" =>
+      reader.committed.flatMap(c => Ok(c.snapshot.asJson))
+
+    case GET -> Root / "committed" / "delta" / LongVar(ordinal) if ordinal >= 0L =>
+      reader.committed.flatMap { c =>
+        c.deltaFor(SnapshotOrdinal.unsafeApply(ordinal)) match {
+          case Some(delta) => Ok(delta.asJson)
+          case None =>
+            NotFound(Json.obj("error" -> s"no delta retained for ordinal $ordinal; fall back to /committed/snapshot".asJson))
+        }
+      }
+
+    case GET -> "committed" /: "proof" /: keyPath =>
+      CommitKey.from(pathString(keyPath)) match {
+        case Left(err) => BadRequest(Json.obj("error" -> err.getMessage.asJson))
+        case Right(key) =>
+          reader.committed.flatMap { c =>
+            c.proveKey(key).flatMap {
+              case Left(err) => proofError(err)
+              case Right(proof) =>
+                Ok(
+                  Json.obj(
+                    "ordinal" -> c.ordinal.asJson,
+                    "mptRoot" -> c.roots.mptRoot.asJson,
+                    "key"     -> key.asJson,
+                    "keyHex"  -> key.toHex.asJson,
+                    "proof"   -> proof.asJson
+                  )
+                )
+            }
+          }
+      }
+
+    case req @ POST -> Root / "committed" / "proofs" =>
+      req.decode[CommittedRoutes.BatchProofRequest] { body =>
+        body.keys.traverse(CommitKey.from) match {
+          case Left(err) => BadRequest(Json.obj("error" -> err.getMessage.asJson))
+          case Right(keys) =>
+            reader.committed.flatMap { c =>
+              c.proveKeys(keys).flatMap {
+                case Left(err) => proofError(err)
+                case Right(proof) =>
+                  Ok(
+                    Json.obj(
+                      "ordinal" -> c.ordinal.asJson,
+                      "mptRoot" -> c.roots.mptRoot.asJson,
+                      "keys"    -> keys.asJson,
+                      "proof"   -> proof.asJson
+                    )
+                  )
+              }
+            }
+        }
+      }
+
+    case GET -> "committed" /: "proof-prefix" /: nsPath =>
+      CommitNamespace.from(pathString(nsPath)) match {
+        case Left(err) => BadRequest(Json.obj("error" -> err.getMessage.asJson))
+        case Right(ns) =>
+          reader.committed.flatMap { c =>
+            c.attestNamespace(ns).flatMap {
+              case Left(err) => proofError(err)
+              case Right(proof) =>
+                Ok(
+                  Json.obj(
+                    "ordinal"   -> c.ordinal.asJson,
+                    "mptRoot"   -> c.roots.mptRoot.asJson,
+                    "namespace" -> ns.value.asJson,
+                    "prefixHex" -> ns.prefixHex.asJson,
+                    "proof"     -> proof.asJson
+                  )
+                )
+            }
+          }
+      }
+  }
+}
+
+object CommittedRoutes {
+
+  final case class BatchProofRequest(keys: List[String])
+
+  object BatchProofRequest {
+
+    implicit val decoder: Decoder[BatchProofRequest] = (c: HCursor) =>
+      c.downField("keys").as[List[String]].map(BatchProofRequest(_))
+  }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoutes.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedRoutes.scala
@@ -136,7 +136,6 @@ object CommittedRoutes {
 
   object BatchProofRequest {
 
-    implicit val decoder: Decoder[BatchProofRequest] = (c: HCursor) =>
-      c.downField("keys").as[List[String]].map(BatchProofRequest(_))
+    implicit val decoder: Decoder[BatchProofRequest] = (c: HCursor) => c.downField("keys").as[List[String]].map(BatchProofRequest(_))
   }
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedSnapshot.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedSnapshot.scala
@@ -3,23 +3,22 @@ package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 import scala.collection.immutable.SortedMap
 
 import io.constellationnetwork.schema.SnapshotOrdinal
-import io.constellationnetwork.security.hash.Hash
-import io.constellationnetwork.security.hex.Hex
 
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor, Json}
 
 /**
- * The full committed view at one snapshot: the entire entry dictionary plus the live catalog
- * entries. This is the replication FALLBACK -- a replica that has missed more deltas than the
- * source's ring buffer retains rebuilds from a snapshot (verifying it reproduces `roots`) and then
- * resumes the delta stream.
+ * The full committed view at one snapshot: the entire entry dictionary plus the catalog contents
+ * (hot epoch, level-1 roots, retained sealed epochs). This is the replication FALLBACK -- a
+ * replica that has missed more deltas than the source's ring buffer retains rebuilds from a
+ * snapshot (verifying it reproduces `roots`) and then resumes the delta stream. The same
+ * `catalog` payload is what a breadcrumb-seeded node feeds to `CommittedState.hydrate`.
  */
 final case class CommittedSnapshot(
   ordinal: SnapshotOrdinal,
   roots: CommittedRoots,
   entries: SortedMap[CommitKey, Json],
-  catalog: SortedMap[Hex, Hash]
+  catalog: CatalogContents
 )
 
 object CommittedSnapshot {
@@ -30,7 +29,7 @@ object CommittedSnapshot {
         "ordinal" -> s.ordinal.asJson,
         "roots"   -> s.roots.asJson,
         "entries" -> Encoder.encodeMap[CommitKey, Json].apply(s.entries),
-        "catalog" -> Encoder.encodeMap[Hex, Hash].apply(s.catalog)
+        "catalog" -> s.catalog.asJson
       )
 
   implicit val decoder: Decoder[CommittedSnapshot] = (c: HCursor) =>
@@ -38,6 +37,6 @@ object CommittedSnapshot {
       ordinal <- c.downField("ordinal").as[SnapshotOrdinal]
       roots   <- c.downField("roots").as[CommittedRoots]
       entries <- c.downField("entries").as[Map[CommitKey, Json]].map(SortedMap.from(_))
-      catalog <- c.downField("catalog").as[Map[Hex, Hash]].map(SortedMap.from(_))
+      catalog <- c.downField("catalog").as[CatalogContents]
     } yield CommittedSnapshot(ordinal, roots, entries, catalog)
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedSnapshot.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedSnapshot.scala
@@ -1,0 +1,43 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+/**
+ * The full committed view at one snapshot: the entire entry dictionary plus the live catalog
+ * entries. This is the replication FALLBACK -- a replica that has missed more deltas than the
+ * source's ring buffer retains rebuilds from a snapshot (verifying it reproduces `roots`) and then
+ * resumes the delta stream.
+ */
+final case class CommittedSnapshot(
+  ordinal: SnapshotOrdinal,
+  roots: CommittedRoots,
+  entries: SortedMap[CommitKey, Json],
+  catalog: SortedMap[Hex, Hash]
+)
+
+object CommittedSnapshot {
+
+  implicit val encoder: Encoder[CommittedSnapshot] =
+    (s: CommittedSnapshot) =>
+      Json.obj(
+        "ordinal" -> s.ordinal.asJson,
+        "roots"   -> s.roots.asJson,
+        "entries" -> Encoder.encodeMap[CommitKey, Json].apply(s.entries),
+        "catalog" -> Encoder.encodeMap[Hex, Hash].apply(s.catalog)
+      )
+
+  implicit val decoder: Decoder[CommittedSnapshot] = (c: HCursor) =>
+    for {
+      ordinal <- c.downField("ordinal").as[SnapshotOrdinal]
+      roots   <- c.downField("roots").as[CommittedRoots]
+      entries <- c.downField("entries").as[Map[CommitKey, Json]].map(SortedMap.from(_))
+      catalog <- c.downField("catalog").as[Map[Hex, Hash]].map(SortedMap.from(_))
+    } yield CommittedSnapshot(ordinal, roots, entries, catalog)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedState.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedState.scala
@@ -1,99 +1,332 @@
 package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 
-import cats.effect.Async
 import cats.effect.std.AtomicCell
+import cats.effect.{Async, Ref}
 import cats.syntax.all._
 
 import scala.collection.immutable.SortedMap
 
-import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleTree
-import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
+import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.hash.Hash
+
+import io.circe.Json
 
 /**
  * The single writable holder of the committed view -- a PRIVATE `AtomicCell[F, Committed[F, S]]`
  * behind a private constructor. The only way to obtain one wired into a data-application service is
  * `CommittedApp.makeL0` (correct-by-construction: `hashCalculatedState` / `setCalculatedState` /
- * routes all close over the same instance).
+ * `combine` / routes all close over the same instance).
  *
- * [[setCommitted]] is the `setCalculatedState` path: it applies the view's delta to the live trie
- * (incremental `insert`/`remove`), REBUILDS the trie purely from the new value, and ASSERTS the two
- * roots are identical -- a divergence means the view's `delta`/`entries` disagree or the wiring is
- * broken, and it fails loudly ([[CommittedStateError.RootDivergence]]) rather than committing a root
- * other nodes cannot reproduce.
+ * ==Transitions==
+ * [[setCommitted]] is the `setCalculatedState` path:
+ *
+ *   - CONTIGUOUS (`ordinal == cell+1`, hydrated): applies the view's delta to the live trie,
+ *     REBUILDS the trie purely from the new value and ASSERTS the two roots are identical (a
+ *     divergence means the view's `delta`/`entries` disagree -- it fails loudly,
+ *     [[CommittedStateError.RootDivergence]], rather than committing a root other nodes cannot
+ *     reproduce), then advances the epoch catalog and recomposes the catalog root. If the caller
+ *     supplies the consensus breadcrumb for the same ordinal, the locally derived roots must match
+ *     it ([[CommittedStateError.BreadcrumbMismatch]]).
+ *   - SEED (any ordinal jump, or an unhydrated cell): O(1) bootstrap. Requires the attested
+ *     breadcrumb of exactly that ordinal (from the latest SIGNED snapshot's on-chain state);
+ *     verifies the value reproduces the breadcrumb's `mptRoot` and adopts its `catalogRoot`
+ *     sight-unseen -- consensus attested. The catalog itself starts [[CatalogView.SeededCatalog]];
+ *     if a [[CatalogJournal]] is configured and its persisted entries recompose to the attested
+ *     root, the cell hydrates immediately (the restart path). Otherwise hydration arrives later
+ *     via [[hydrate]].
+ *
+ * ==The work cache==
+ * `combine` runs BEFORE `setCalculatedState` and must emit the NEXT breadcrumb without mutating
+ * the cell; replay paths (e.g. tessellation's `DataApplicationTraverse`) even fold `combine` over
+ * many ordinals with the cell untouched. [[advanceWork]] therefore derives transitions against a
+ * bounded breadcrumb-indexed cache seeded from the cell, so consecutive `combine` calls chain off
+ * each other's results deterministically.
  */
 final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
   view: CommittedView[S],
-  maxRecentDeltas: Int,
-  cell: AtomicCell[F, Committed[F, S]]
+  val config: CommittedConfig,
+  journal: Option[CatalogJournal[F]],
+  cell: AtomicCell[F, Committed[F, S]],
+  work: Ref[F, Vector[(CommittedBreadcrumb, EpochCatalog[F])]]
 ) extends CommittedReader[F, S] {
 
   def committed: F[Committed[F, S]] = cell.get
 
-  /** Advance the committed view to (`ordinal`, `nextState`). Returns the new committed snapshot. */
-  def setCommitted(ordinal: SnapshotOrdinal, nextState: S): F[Committed[F, S]] =
+  // ---------------------------------------------------------------------------------------------
+  // combine-side: breadcrumb validation + next-breadcrumb derivation (cell is NOT mutated)
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Validate an incoming on-chain breadcrumb and derive the transition to the next ordinal for
+   * entry set `nextEntries`. The parent breadcrumb must be RESOLVABLE -- the committed cell, a
+   * recent [[advanceWork]] result, or (restart) the journal -- and where it overlaps the cell it
+   * must MATCH ([[CommittedStateError.BreadcrumbMismatch]]): this is the follower-side rejection
+   * of forged breadcrumbs.
+   */
+  def advanceWork(parent: CommittedBreadcrumb, nextEntries: SortedMap[CommitKey, Json]): F[CommittedBreadcrumb] =
+    for {
+      prev <- cell.get
+      _ <- CommittedStateError
+        .BreadcrumbMismatch(parent, prev.breadcrumb.some)
+        .raiseError[F, Unit]
+        .whenA(parent.ordinal == prev.ordinal && parent.roots != prev.roots)
+      parentCatalog <- resolveCatalog(parent).flatMap {
+        case Some(c) => c.pure[F]
+        case None    => CommittedStateError.BreadcrumbUnresolvable(parent).raiseError[F, EpochCatalog[F]]
+      }
+      nextTrie <- CommittedCommitment.buildTrie[F](nextEntries)
+      mptRoot = nextTrie.rootNode.digest
+      advanced <- parentCatalog.advance(parent.ordinal.value.value, parent.roots.mptRoot)
+      (nextCatalog, _) = advanced
+      composed <- nextCatalog.compose(mptRoot)
+      next = CommittedBreadcrumb(
+        SnapshotOrdinal.unsafeApply(parent.ordinal.value.value + 1),
+        CommittedRoots(mptRoot, composed._2)
+      )
+      _ <- work.update(w =>
+        ((parent, parentCatalog) +: (next, nextCatalog) +: w.filterNot(e => e._1 == parent || e._1 == next))
+          .take(CommittedState.WorkCacheDepth)
+      )
+    } yield next
+
+  /**
+   * The catalog behind a breadcrumb, if this node knows it: the cell (hydrated, matching roots), a
+   * recent [[advanceWork]] derivation, or a journal whose recomposition reproduces the
+   * breadcrumb's attested catalog root.
+   */
+  private def resolveCatalog(bc: CommittedBreadcrumb): F[Option[EpochCatalog[F]]] =
+    for {
+      prev <- cell.get
+      fromCell = prev.catalog.live.collect {
+        case l if prev.breadcrumb == bc => l.epochs
+      }
+      fromWork <- fromCell match {
+        case s @ Some(_) => (s: Option[EpochCatalog[F]]).pure[F]
+        case None        => work.get.map(_.collectFirst { case (b, c) if b == bc => c })
+      }
+      result <- fromWork match {
+        case s @ Some(_) => (s: Option[EpochCatalog[F]]).pure[F]
+        case None        => journalCatalogMatching(bc.roots)
+      }
+    } yield result
+
+  /** Rebuild from the journal and accept ONLY if it recomposes to the attested roots. */
+  private def journalCatalogMatching(roots: CommittedRoots): F[Option[EpochCatalog[F]]] =
+    journal.flatTraverse { j =>
+      j.contents.flatMap {
+        case (hot, level1) =>
+          EpochCatalog
+            .fromContents[F](config, CatalogContents(config.epochSize, hot, level1, SortedMap.empty))
+            .flatMap {
+              case Left(_) => none[EpochCatalog[F]].pure[F]
+              case Right(catalog) =>
+                catalog.compose(roots.mptRoot).map {
+                  case (_, composedRoot) => Option.when(composedRoot == roots.catalogRoot)(catalog)
+                }
+            }
+      }
+    }
+
+  // ---------------------------------------------------------------------------------------------
+  // hash-side: the consensus hash for a state value (cell is NOT mutated)
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * `hashCalculatedState`: `sha256(mptRoot(state) || catalogRoot)`. The catalog root is sourced by
+   * call ordering (see `CommittedCommitment` scaladoc):
+   *
+   *   1. BOOTSTRAP/DOWNLOAD -- `contextBreadcrumb` (the latest SIGNED snapshot's on-chain
+   *      breadcrumb) is AHEAD of the cell: use its attested catalog root directly (O(1)).
+   *   2. STEADY STATE -- the cell is the parent: derive the transition's catalog root.
+   *   3. REPLAY -- fall back to the most recent [[advanceWork]] derivation whose mptRoot matches.
+   */
+  def hashFor(state: S, contextBreadcrumb: Option[CommittedBreadcrumb]): F[Hash] =
+    for {
+      prev <- cell.get
+      trie <- CommittedCommitment.buildTrie[F](view.entries(state))
+      mptRoot = trie.rootNode.digest
+      catalogRoot <- contextBreadcrumb.filter(_.ordinal.value.value > prev.ordinal.value.value) match {
+        case Some(b) => b.roots.catalogRoot.pure[F]
+        case None =>
+          prev.catalog.live match {
+            case Some(l) =>
+              l.epochs
+                .advance(prev.ordinal.value.value, prev.roots.mptRoot)
+                .flatMap { case (next, _) => next.compose(mptRoot) }
+                .map(_._2)
+            case None =>
+              work.get
+                .map(_.collectFirst { case (b, _) if b.roots.mptRoot == mptRoot => b.roots.catalogRoot })
+                .flatMap {
+                  case Some(root) => root.pure[F]
+                  case None       => CommittedStateError.CatalogNotHydrated(prev.ordinal).raiseError[F, SparseMerkleRoot]
+                }
+          }
+      }
+    } yield CommittedRoots.combine(mptRoot, catalogRoot)
+
+  // ---------------------------------------------------------------------------------------------
+  // setCalculatedState-side: advancing / seeding the cell
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Advance the committed view to (`ordinal`, `nextState`). `contextBreadcrumb` is the latest
+   * SIGNED snapshot's on-chain breadcrumb, when available -- the transition cross-check and the
+   * bootstrap seed. Returns the new committed snapshot.
+   */
+  def setCommitted(
+    ordinal: SnapshotOrdinal,
+    nextState: S,
+    contextBreadcrumb: Option[CommittedBreadcrumb] = None
+  ): F[Committed[F, S]] =
     cell.evalModify { prev =>
-      for {
-        delta   <- view.delta(prev.state, nextState).pure[F]
-        applied <- CommittedCommitment.applyDelta[F](prev.trie, delta)
-        derived <- CommittedCommitment.buildTrie[F](view.entries(nextState))
-        _ <- CommittedStateError
-          .RootDivergence(ordinal, applied.rootNode.digest, derived.rootNode.digest)
+      val next: F[Committed[F, S]] =
+        if (ordinal == prev.ordinal) recommit(prev, nextState)
+        else if (ordinal.value.value == prev.ordinal.value.value + 1 && prev.isHydrated)
+          transition(prev, ordinal, nextState, contextBreadcrumb)
+        else seed(ordinal, nextState, contextBreadcrumb)
+      next.map(c => (c, c))
+    }
+
+  /** Re-committing the SAME ordinal is legal only if it is byte-identical (genesis is set twice). */
+  private def recommit(prev: Committed[F, S], state: S): F[Committed[F, S]] =
+    CommittedCommitment.buildTrie[F](view.entries(state)).flatMap { trie =>
+      if (trie.rootNode.digest == prev.roots.mptRoot) prev.pure[F]
+      else
+        CommittedStateError
+          .CommitRewrite(prev.ordinal, prev.roots.mptRoot, trie.rootNode.digest)
+          .raiseError[F, Committed[F, S]]
+    }
+
+  private def transition(
+    prev: Committed[F, S],
+    ordinal: SnapshotOrdinal,
+    nextState: S,
+    contextBreadcrumb: Option[CommittedBreadcrumb]
+  ): F[Committed[F, S]] = {
+    val epochs = prev.catalog.live.map(_.epochs).get // guarded by isHydrated
+    for {
+      delta   <- view.delta(prev.state, nextState).pure[F]
+      applied <- CommittedCommitment.applyDelta[F](prev.trie, delta)
+      derived <- CommittedCommitment.buildTrie[F](view.entries(nextState))
+      _ <- CommittedStateError
+        .RootDivergence(ordinal, applied.rootNode.digest, derived.rootNode.digest)
+        .raiseError[F, Unit]
+        .whenA(applied.rootNode.digest != derived.rootNode.digest)
+      mptRoot = applied.rootNode.digest
+      advanced <- epochs.advance(prev.ordinal.value.value, prev.roots.mptRoot)
+      (nextEpochs, sealEvent) = advanced
+      composed <- nextEpochs.compose(mptRoot)
+      (top, catalogRoot) = composed
+      roots = CommittedRoots(mptRoot, catalogRoot)
+      _ <- contextBreadcrumb.filter(_.ordinal == ordinal).traverse_ { b =>
+        CommittedStateError
+          .BreadcrumbMismatch(b, CommittedBreadcrumb(ordinal, roots).some)
           .raiseError[F, Unit]
-          .whenA(applied.rootNode.digest != derived.rootNode.digest)
-        mptRoot = applied.rootNode.digest
-        catalogChanges = CommitCatalog.changesFor(ordinal, mptRoot)
-        catalog <- prev.catalog
-          .withChanges(catalogChanges.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap, Set.empty)
-          .flatMap(CommittedState.requireInMemory[F](_))
-        smtRoot <- catalog.root
-        roots = CommittedRoots(mptRoot, smtRoot)
-        stateDelta = StateDelta(ordinal, prev.roots, roots, delta.upserts, delta.removes)
-        deltas = (prev.recentDeltas :+ stateDelta).takeRight(maxRecentDeltas)
-        next = Committed(ordinal, nextState, applied, catalog, prev.catalogEntries ++ catalogChanges, roots, deltas)
-      } yield (next, next)
+          .whenA(b.roots != roots)
+      }
+      _ <- journal.traverse_ { j =>
+        j.recordOrdinal(prev.ordinal.value.value, prev.roots.mptRoot) >>
+        sealEvent.traverse_(j.recordSeal)
+      }
+      stateDelta = StateDelta(ordinal, prev.roots, roots, delta.upserts, delta.removes)
+      deltas = (prev.recentDeltas :+ stateDelta).takeRight(config.maxRecentDeltas)
+    } yield Committed(ordinal, nextState, applied, CatalogView.LiveCatalog(nextEpochs, top), roots, deltas)
+  }
+
+  /** O(1) bootstrap: adopt the attested breadcrumb; hydrate from the journal if it still matches. */
+  private def seed(
+    ordinal: SnapshotOrdinal,
+    state: S,
+    contextBreadcrumb: Option[CommittedBreadcrumb]
+  ): F[Committed[F, S]] =
+    contextBreadcrumb match {
+      case Some(b) if b.ordinal == ordinal =>
+        for {
+          trie <- CommittedCommitment.buildTrie[F](view.entries(state))
+          mptRoot = trie.rootNode.digest
+          _ <- CommittedStateError
+            .SeedStateMismatch(ordinal, b.roots.mptRoot, mptRoot)
+            .raiseError[F, Unit]
+            .whenA(mptRoot != b.roots.mptRoot)
+          fromJournal <- journalCatalogMatching(b.roots)
+          catalogView <- fromJournal match {
+            case Some(epochs) => epochs.compose(mptRoot).map(c => CatalogView.LiveCatalog(epochs, c._1): CatalogView[F])
+            case None         => (CatalogView.SeededCatalog[F](b.roots.catalogRoot): CatalogView[F]).pure[F]
+          }
+          _ <- work.set(Vector.empty)
+        } yield Committed(ordinal, state, trie, catalogView, b.roots, Vector.empty)
+      case other =>
+        CommittedStateError.CannotSeed(ordinal, other.map(_.ordinal)).raiseError[F, Committed[F, S]]
+    }
+
+  // ---------------------------------------------------------------------------------------------
+  // hydration
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Install full catalog contents on a SEEDED cell. Trustless: the rebuilt rollup must recompose
+   * to the breadcrumb-attested catalog root, so any peer (or operator) can supply the payload. A
+   * hydrated cell is returned unchanged. On success the journal (if any) is rewritten to match.
+   */
+  def hydrate(contents: CatalogContents): F[Either[CommittedStateError, Committed[F, S]]] =
+    cell.evalModify { prev =>
+      prev.catalog match {
+        case CatalogView.LiveCatalog(_, _) => (prev, prev.asRight[CommittedStateError]).pure[F]
+        case CatalogView.SeededCatalog(attestedRoot) =>
+          EpochCatalog.fromContents[F](config, contents).flatMap {
+            case Left(err) => (prev, (err: CommittedStateError).asLeft[Committed[F, S]]).pure[F]
+            case Right(epochs) =>
+              epochs.compose(prev.roots.mptRoot).flatMap {
+                case (top, composedRoot) =>
+                  if (composedRoot != attestedRoot)
+                    (
+                      prev,
+                      (CommittedStateError.HydrationRootMismatch(attestedRoot, composedRoot): CommittedStateError)
+                        .asLeft[Committed[F, S]]
+                    ).pure[F]
+                  else {
+                    val hydrated = prev.copy(catalog = CatalogView.LiveCatalog(epochs, top))
+                    journal.traverse_(_.reset(contents.hot, contents.level1)).as((hydrated, hydrated.asRight[CommittedStateError]))
+                  }
+              }
+          }
+      }
     }
 }
 
 object CommittedState {
 
-  /** Default ring-buffer depth for recent [[StateDelta]]s (older ordinals fall back to the snapshot route). */
-  val DefaultMaxRecentDeltas: Int = 64
+  /** Bounded depth of the combine-side work cache (breadcrumb -> derived catalog). */
+  val WorkCacheDepth: Int = 16
 
   /**
    * Assemble the genesis cell. Package-private: the public assembly path is `CommittedApp.makeL0`.
    */
   private[committed] def make[F[_]: Async: JsonBinaryHasher, S](
     genesisState: S,
-    maxRecentDeltas: Int = DefaultMaxRecentDeltas
+    config: CommittedConfig = CommittedConfig.default,
+    journal: Option[CatalogJournal[F]] = None
   )(implicit view: CommittedView[S]): F[CommittedState[F, S]] =
     for {
-      trie <- CommittedCommitment.buildTrie[F](view.entries(genesisState))
+      trie   <- CommittedCommitment.buildTrie[F](view.entries(genesisState))
+      epochs <- EpochCatalog.empty[F](config)
       mptRoot = trie.rootNode.digest
-      catalogChanges = CommitCatalog.changesFor(SnapshotOrdinal.MinValue, mptRoot)
-      catalog <- InMemorySparseMerkleTree.make[F](
-        catalogChanges.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap
-      )
-      smtRoot <- catalog.root
+      composed <- epochs.compose(mptRoot)
+      (top, catalogRoot) = composed
       genesis = Committed[F, S](
         SnapshotOrdinal.MinValue,
         genesisState,
         trie,
-        catalog,
-        SortedMap.from(catalogChanges),
-        CommittedRoots(mptRoot, smtRoot),
+        CatalogView.LiveCatalog(epochs, top),
+        CommittedRoots(mptRoot, catalogRoot),
         Vector.empty
       )
       cell <- AtomicCell[F].of(genesis)
-    } yield new CommittedState[F, S](view, maxRecentDeltas, cell)
-
-  private[committed] def requireInMemory[F[_]: Async](tree: SparseMerkleTree[F]): F[InMemorySparseMerkleTree[F]] =
-    tree match {
-      case t: InMemorySparseMerkleTree[F] => t.pure[F]
-      case other                          => CommittedStateError.CatalogImplementationMismatch(other.getClass.getName).raiseError
-    }
+      work <- Ref.of[F, Vector[(CommittedBreadcrumb, EpochCatalog[F])]](Vector.empty)
+    } yield new CommittedState[F, S](view, config, journal, cell, work)
 }
 
 sealed abstract class CommittedStateError(message: String) extends RuntimeException(message)
@@ -109,4 +342,52 @@ object CommittedStateError {
 
   final case class CatalogImplementationMismatch(className: String)
       extends CommittedStateError(s"catalog withChanges returned an unexpected SparseMerkleTree implementation: $className")
+
+  final case class BreadcrumbMismatch(claimed: CommittedBreadcrumb, local: Option[CommittedBreadcrumb])
+      extends CommittedStateError(
+        s"on-chain breadcrumb for ordinal ${claimed.ordinal.value.value} does not match the locally derived commitment " +
+        s"(claimed mpt ${claimed.roots.mptRoot.value}, catalog ${claimed.roots.catalogRoot.value.value}; " +
+        s"local ${local.map(l => s"mpt ${l.roots.mptRoot.value}, catalog ${l.roots.catalogRoot.value.value}").getOrElse("<none>")}) " +
+        "-- rejecting the proposal/transition"
+      )
+
+  final case class BreadcrumbUnresolvable(claimed: CommittedBreadcrumb)
+      extends CommittedStateError(
+        s"cannot resolve the catalog behind breadcrumb ordinal ${claimed.ordinal.value.value}: " +
+        "not the committed cell, not a recent combine derivation, and the journal does not recompose to it " +
+        "(unhydrated bootstrap? hydrate via /committed/hydrate before participating in consensus)"
+      )
+
+  final case class CatalogNotHydrated(ordinal: SnapshotOrdinal)
+      extends CommittedStateError(
+        s"catalog at ordinal ${ordinal.value.value} is breadcrumb-seeded but not hydrated; " +
+        "transitions and catalog proofs require contents (POST /committed/hydrate)"
+      )
+
+  final case class CommitRewrite(ordinal: SnapshotOrdinal, committed: Hash, attempted: Hash)
+      extends CommittedStateError(
+        s"refusing to rewrite committed ordinal ${ordinal.value.value}: mpt ${committed.value} -> ${attempted.value}"
+      )
+
+  final case class SeedStateMismatch(ordinal: SnapshotOrdinal, attested: Hash, rebuilt: Hash)
+      extends CommittedStateError(
+        s"downloaded state at ordinal ${ordinal.value.value} does not reproduce the attested on-chain mptRoot " +
+        s"(attested ${attested.value}, rebuilt ${rebuilt.value})"
+      )
+
+  final case class CannotSeed(ordinal: SnapshotOrdinal, breadcrumbOrdinal: Option[SnapshotOrdinal])
+      extends CommittedStateError(
+        s"cannot seed committed state at ordinal ${ordinal.value.value}: " +
+        breadcrumbOrdinal.fold("no on-chain breadcrumb available from the node context")(b =>
+          s"latest signed breadcrumb is for ordinal ${b.value.value}"
+        )
+      )
+
+  final case class HydrationRootMismatch(attested: SparseMerkleRoot, composed: SparseMerkleRoot)
+      extends CommittedStateError(
+        s"hydration contents recompose to catalog root ${composed.value.value}, " +
+        s"but the consensus-attested root is ${attested.value.value} -- rejecting"
+      )
+
+  final case class MalformedCatalogContents(reason: String) extends CommittedStateError(s"malformed catalog contents: $reason")
 }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedState.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedState.scala
@@ -1,0 +1,112 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.Async
+import cats.effect.std.AtomicCell
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleTree
+import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+
+/**
+ * The single writable holder of the committed view -- a PRIVATE `AtomicCell[F, Committed[F, S]]`
+ * behind a private constructor. The only way to obtain one wired into a data-application service is
+ * `CommittedApp.makeL0` (correct-by-construction: `hashCalculatedState` / `setCalculatedState` /
+ * routes all close over the same instance).
+ *
+ * [[setCommitted]] is the `setCalculatedState` path: it applies the view's delta to the live trie
+ * (incremental `insert`/`remove`), REBUILDS the trie purely from the new value, and ASSERTS the two
+ * roots are identical -- a divergence means the view's `delta`/`entries` disagree or the wiring is
+ * broken, and it fails loudly ([[CommittedStateError.RootDivergence]]) rather than committing a root
+ * other nodes cannot reproduce.
+ */
+final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
+  view: CommittedView[S],
+  maxRecentDeltas: Int,
+  cell: AtomicCell[F, Committed[F, S]]
+) extends CommittedReader[F, S] {
+
+  def committed: F[Committed[F, S]] = cell.get
+
+  /** Advance the committed view to (`ordinal`, `nextState`). Returns the new committed snapshot. */
+  def setCommitted(ordinal: SnapshotOrdinal, nextState: S): F[Committed[F, S]] =
+    cell.evalModify { prev =>
+      for {
+        delta   <- view.delta(prev.state, nextState).pure[F]
+        applied <- CommittedCommitment.applyDelta[F](prev.trie, delta)
+        derived <- CommittedCommitment.buildTrie[F](view.entries(nextState))
+        _ <- CommittedStateError
+          .RootDivergence(ordinal, applied.rootNode.digest, derived.rootNode.digest)
+          .raiseError[F, Unit]
+          .whenA(applied.rootNode.digest != derived.rootNode.digest)
+        mptRoot = applied.rootNode.digest
+        catalogChanges = CommitCatalog.changesFor(ordinal, mptRoot)
+        catalog <- prev.catalog
+          .withChanges(catalogChanges.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap, Set.empty)
+          .flatMap(CommittedState.requireInMemory[F](_))
+        smtRoot <- catalog.root
+        roots = CommittedRoots(mptRoot, smtRoot)
+        stateDelta = StateDelta(ordinal, prev.roots, roots, delta.upserts, delta.removes)
+        deltas = (prev.recentDeltas :+ stateDelta).takeRight(maxRecentDeltas)
+        next = Committed(ordinal, nextState, applied, catalog, prev.catalogEntries ++ catalogChanges, roots, deltas)
+      } yield (next, next)
+    }
+}
+
+object CommittedState {
+
+  /** Default ring-buffer depth for recent [[StateDelta]]s (older ordinals fall back to the snapshot route). */
+  val DefaultMaxRecentDeltas: Int = 64
+
+  /**
+   * Assemble the genesis cell. Package-private: the public assembly path is `CommittedApp.makeL0`.
+   */
+  private[committed] def make[F[_]: Async: JsonBinaryHasher, S](
+    genesisState: S,
+    maxRecentDeltas: Int = DefaultMaxRecentDeltas
+  )(implicit view: CommittedView[S]): F[CommittedState[F, S]] =
+    for {
+      trie <- CommittedCommitment.buildTrie[F](view.entries(genesisState))
+      mptRoot = trie.rootNode.digest
+      catalogChanges = CommitCatalog.changesFor(SnapshotOrdinal.MinValue, mptRoot)
+      catalog <- InMemorySparseMerkleTree.make[F](
+        catalogChanges.toList.map { case (k, h) => k -> CommitCatalog.rootValueBytes(h) }.toMap
+      )
+      smtRoot <- catalog.root
+      genesis = Committed[F, S](
+        SnapshotOrdinal.MinValue,
+        genesisState,
+        trie,
+        catalog,
+        SortedMap.from(catalogChanges),
+        CommittedRoots(mptRoot, smtRoot),
+        Vector.empty
+      )
+      cell <- AtomicCell[F].of(genesis)
+    } yield new CommittedState[F, S](view, maxRecentDeltas, cell)
+
+  private[committed] def requireInMemory[F[_]: Async](tree: SparseMerkleTree[F]): F[InMemorySparseMerkleTree[F]] =
+    tree match {
+      case t: InMemorySparseMerkleTree[F] => t.pure[F]
+      case other                          => CommittedStateError.CatalogImplementationMismatch(other.getClass.getName).raiseError
+    }
+}
+
+sealed abstract class CommittedStateError(message: String) extends RuntimeException(message)
+
+object CommittedStateError {
+
+  final case class RootDivergence(ordinal: SnapshotOrdinal, applied: Hash, derived: Hash)
+      extends CommittedStateError(
+        s"committed-state wiring bug at ordinal ${ordinal.value.value}: " +
+        s"delta-applied MPT root ${applied.value} != value-derived MPT root ${derived.value} " +
+        "(the CommittedView's delta/entries disagree)"
+      )
+
+  final case class CatalogImplementationMismatch(className: String)
+      extends CommittedStateError(s"catalog withChanges returned an unexpected SparseMerkleTree implementation: $className")
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedView.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedView.scala
@@ -1,0 +1,47 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.circe.Json
+
+/**
+ * Projects an application state `S` into the committed state dictionary: the canonical, namespaced
+ * `CommitKey -> Json` entry set that the two-tier commitment (MPT state-dict + SMT root catalog) is
+ * built over.
+ *
+ * `SortedMap` is REQUIRED -- entries must enumerate in a single canonical order so that diffs,
+ * serialized deltas, and route responses are deterministic across nodes regardless of how `S` was
+ * constructed in memory. (The MPT root itself is insertion-order independent, but determinism of the
+ * surrounding artifacts -- `StateDelta`, `/committed/snapshot` -- rides on the sorted enumeration.)
+ */
+trait CommittedView[S] {
+
+  /** The canonical entry set of `s`. Values should be canonical JSON projections of the state's leaves. */
+  def entries(s: S): SortedMap[CommitKey, Json]
+
+  /**
+   * The change-set turning `entries(prev)` into `entries(next)`. The default is a full structural
+   * diff; override when the application can produce the delta cheaper (e.g. from its own update
+   * stream).
+   */
+  def delta(prev: S, next: S): CommitDelta = {
+    val p = entries(prev)
+    val n = entries(next)
+    val upserts = n.filter { case (k, v) => !p.get(k).contains(v) }
+    val removes = p.keySet.diff(n.keySet)
+    CommitDelta(upserts, SortedSet.from(removes))
+  }
+}
+
+object CommittedView {
+  def apply[S](implicit ev: CommittedView[S]): CommittedView[S] = ev
+}
+
+/** A canonical change-set over the committed dictionary: removals applied first, then upserts (upsert wins). */
+final case class CommitDelta(upserts: SortedMap[CommitKey, Json], removes: SortedSet[CommitKey]) {
+  def isEmpty: Boolean = upserts.isEmpty && removes.isEmpty
+}
+
+object CommitDelta {
+  def empty: CommitDelta = CommitDelta(SortedMap.empty, SortedSet.empty)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/EpochCatalog.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/EpochCatalog.scala
@@ -73,19 +73,20 @@ final case class EpochCatalog[F[_]] private (
             .insert(epochKey(epochIndex), rootValueBytes(hotRoot))
             .flatMap(EpochCatalog.requireInMemory[F])
           emptyHot <- InMemorySparseMerkleTree.empty[F]
-          retained = (sealedTrees + (epochIndex -> EpochCatalog.SealedEpoch(hotEntries, hotTree)))
+          retained = sealedTrees + (epochIndex -> EpochCatalog.SealedEpoch(hotEntries, hotTree))
           pruned = retained.drop((retained.size - retention).max(0))
-        } yield (
-          copy(
-            epochIndex = targetEpoch,
-            hotEntries = SortedMap.empty[Long, Hash],
-            hotTree = emptyHot,
-            level1Entries = level1Entries + (epochIndex -> hotRoot.value),
-            level1Tree = newLevel1,
-            sealedTrees = pruned
-          ),
-          EpochCatalog.SealEvent(epochIndex, hotRoot, hotEntries.keySet.toList).some
-        )
+        } yield
+          (
+            copy(
+              epochIndex = targetEpoch,
+              hotEntries = SortedMap.empty[Long, Hash],
+              hotTree = emptyHot,
+              level1Entries = level1Entries + (epochIndex -> hotRoot.value),
+              level1Tree = newLevel1,
+              sealedTrees = pruned
+            ),
+            EpochCatalog.SealEvent(epochIndex, hotRoot, hotEntries.keySet.toList).some
+          )
 
     sealedStep.flatMap {
       case (catalog, seal) =>
@@ -178,16 +179,17 @@ object EpochCatalog {
     for {
       hot    <- InMemorySparseMerkleTree.empty[F]
       level1 <- InMemorySparseMerkleTree.empty[F]
-    } yield EpochCatalog(
-      config.epochSize,
-      config.sealedEpochRetention,
-      0L,
-      SortedMap.empty,
-      hot,
-      SortedMap.empty,
-      level1,
-      SortedMap.empty
-    )
+    } yield
+      EpochCatalog(
+        config.epochSize,
+        config.sealedEpochRetention,
+        0L,
+        SortedMap.empty,
+        hot,
+        SortedMap.empty,
+        level1,
+        SortedMap.empty
+      )
 
   /**
    * Rebuild a catalog from transported [[CatalogContents]] (hydration / replication). Validates
@@ -231,21 +233,24 @@ object EpochCatalog {
         mismatch = rebuiltSealed.collectFirst {
           case (epoch, _, root) if !contents.level1.get(epoch).contains(root.value) => epoch
         }
-      } yield mismatch match {
-        case Some(epoch) =>
-          (CommittedStateError.MalformedCatalogContents(s"sealed epoch $epoch contents do not reproduce its level-1 root"): CommittedStateError).asLeft
-        case None =>
-          EpochCatalog(
-            epochSize,
-            config.sealedEpochRetention,
-            epochIndex,
-            contents.hot,
-            hot,
-            contents.level1,
-            level1,
-            SortedMap.from(rebuiltSealed.map { case (e, s, _) => e -> s })
-          ).asRight[CommittedStateError]
-      }
+      } yield
+        mismatch match {
+          case Some(epoch) =>
+            (CommittedStateError.MalformedCatalogContents(
+              s"sealed epoch $epoch contents do not reproduce its level-1 root"
+            ): CommittedStateError).asLeft
+          case None =>
+            EpochCatalog(
+              epochSize,
+              config.sealedEpochRetention,
+              epochIndex,
+              contents.hot,
+              hot,
+              contents.level1,
+              level1,
+              SortedMap.from(rebuiltSealed.map { case (e, s, _) => e -> s })
+            ).asRight[CommittedStateError]
+        }
     }
   }
 

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/EpochCatalog.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/EpochCatalog.scala
@@ -1,0 +1,305 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.data.EitherT
+import cats.effect.Sync
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt.impl.InMemorySparseMerkleTree
+import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleProof, SparseMerkleRoot, SparseMerkleTree}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe._
+import io.circe.syntax.EncoderOps
+
+/**
+ * The TWO-LEVEL EPOCH ROLLUP behind the live catalog root.
+ *
+ * Historical `ordinal:<N> -> mptRoot_N` entries are not kept in one ever-growing tree. They are
+ * rolled up in epochs of [[CommittedConfig.epochSize]] ordinals:
+ *
+ *   - the HOT epoch SMT holds the ordinals of the CURRENT epoch;
+ *   - at each epoch boundary the hot tree is SEALED: its root becomes the `epoch:<E>` entry of the
+ *     LEVEL-1 SMT, and the hot tree resets to empty;
+ *   - [[compose]] binds everything into the TOP catalog SMT: `{ current:mpt -> mptRoot, epoch:hot
+ *     -> hotRoot, epoch:sealed -> level1Root }`, whose root is the breadcrumb's `catalogRoot`.
+ *
+ * A proof of an ancient ordinal is therefore two fixed-depth SMT inclusions (level-1 -> sealed
+ * epoch tree) under a constant-size top catalog; non-membership is absence in the hot tree plus
+ * absence on the sealed path (see [[OrdinalCatalogProof]]).
+ *
+ * RETENTION: [[sealedTrees]] (the full contents of sealed epochs) is a SERVING cache pruned to the
+ * last [[CommittedConfig.sealedEpochRetention]] epochs. Pruning never changes any root --
+ * [[level1Entries]] keeps every sealed epoch root forever (32 bytes per ~2^16 ordinals), so proofs
+ * issued before pruning remain verifiable; the node merely can no longer SERVE new proofs for
+ * pruned epochs ([[CommittedProofError.EpochPruned]]).
+ *
+ * The value is immutable: [[advance]] returns a new catalog (plus the [[SealEvent]], for journal
+ * write-through), sharing all untouched trees structurally.
+ */
+final case class EpochCatalog[F[_]] private (
+  epochSize: Int,
+  retention: Int,
+  epochIndex: Long,
+  hotEntries: SortedMap[Long, Hash],
+  hotTree: InMemorySparseMerkleTree[F],
+  level1Entries: SortedMap[Long, Hash],
+  level1Tree: InMemorySparseMerkleTree[F],
+  sealedTrees: SortedMap[Long, EpochCatalog.SealedEpoch[F]]
+) {
+  import CommitCatalog._
+
+  /**
+   * The transition step into ordinal `prevOrdinal + 1`: insert `ordinal:<prevOrdinal> ->
+   * prevMptRoot`, sealing the hot epoch first if `prevOrdinal` opens a new epoch. Returns the
+   * advanced catalog and the seal event, if one occurred.
+   */
+  def advance(prevOrdinal: Long, prevMptRoot: Hash)(
+    implicit F: Sync[F],
+    H: JsonBinaryHasher[F]
+  ): F[(EpochCatalog[F], Option[EpochCatalog.SealEvent])] = {
+    val targetEpoch = epochOf(prevOrdinal, epochSize)
+
+    val sealedStep: F[(EpochCatalog[F], Option[EpochCatalog.SealEvent])] =
+      if (targetEpoch <= epochIndex)
+        (this, none[EpochCatalog.SealEvent]).pure[F]
+      else
+        for {
+          hotRoot <- hotTree.root
+          newLevel1 <- level1Tree
+            .insert(epochKey(epochIndex), rootValueBytes(hotRoot))
+            .flatMap(EpochCatalog.requireInMemory[F])
+          emptyHot <- InMemorySparseMerkleTree.empty[F]
+          retained = (sealedTrees + (epochIndex -> EpochCatalog.SealedEpoch(hotEntries, hotTree)))
+          pruned = retained.drop((retained.size - retention).max(0))
+        } yield (
+          copy(
+            epochIndex = targetEpoch,
+            hotEntries = SortedMap.empty[Long, Hash],
+            hotTree = emptyHot,
+            level1Entries = level1Entries + (epochIndex -> hotRoot.value),
+            level1Tree = newLevel1,
+            sealedTrees = pruned
+          ),
+          EpochCatalog.SealEvent(epochIndex, hotRoot, hotEntries.keySet.toList).some
+        )
+
+    sealedStep.flatMap {
+      case (catalog, seal) =>
+        catalog.hotTree
+          .insert(ordinalKey(prevOrdinal), rootValueBytes(prevMptRoot))
+          .flatMap(EpochCatalog.requireInMemory[F])
+          .map { newHot =>
+            (
+              catalog.copy(
+                hotEntries = catalog.hotEntries + (prevOrdinal -> prevMptRoot),
+                hotTree = newHot
+              ),
+              seal
+            )
+          }
+    }
+  }
+
+  /**
+   * Bind the catalog to the current state-dict root: the TOP catalog SMT `{ current:mpt ->
+   * mptRoot, epoch:hot -> hotRoot, epoch:sealed -> level1Root }` and its root (the breadcrumb's
+   * `catalogRoot`).
+   */
+  def compose(mptRoot: Hash)(implicit F: Sync[F], H: JsonBinaryHasher[F]): F[(InMemorySparseMerkleTree[F], SparseMerkleRoot)] =
+    for {
+      hotRoot    <- hotTree.root
+      level1Root <- level1Tree.root
+      top <- InMemorySparseMerkleTree.make[F](
+        Map(
+          currentMptKey   -> rootValueBytes(mptRoot),
+          hotEpochsKey    -> rootValueBytes(hotRoot),
+          sealedEpochsKey -> rootValueBytes(level1Root)
+        )
+      )
+      root <- top.root
+    } yield (top, root)
+
+  /** The replication/hydration payload: enough to rebuild this catalog elsewhere. */
+  def contents: CatalogContents =
+    CatalogContents(
+      epochSize = epochSize,
+      hot = hotEntries,
+      level1 = level1Entries,
+      sealedEpochs = sealedTrees.map { case (e, s) => e -> s.entries }
+    )
+
+  /**
+   * Serve the catalog-side attestation of `ordinal` against the composed catalog root: inclusion
+   * via the hot tree or the sealed path, or non-membership at both. `top` must be the tree
+   * [[compose]] produced for the CURRENT committed roots.
+   */
+  def proveOrdinal(ordinal: Long, top: InMemorySparseMerkleTree[F])(
+    implicit F: Sync[F]
+  ): F[Either[CommittedProofError, OrdinalCatalogProof]] = {
+    val epoch = epochOf(ordinal, epochSize)
+
+    def prove(tree: InMemorySparseMerkleTree[F], key: Hex) =
+      EitherT(tree.prover.flatMap(_.prove(key)))
+        .leftMap(CommittedProofError.ProofUnavailable(_): CommittedProofError)
+
+    val sealedEntryProof: EitherT[F, CommittedProofError, Option[SparseMerkleProof]] =
+      if (!level1Entries.contains(epoch))
+        EitherT.rightT[F, CommittedProofError](none[SparseMerkleProof])
+      else
+        sealedTrees.get(epoch) match {
+          case None              => EitherT.leftT[F, Option[SparseMerkleProof]](CommittedProofError.EpochPruned(epoch): CommittedProofError)
+          case Some(sealedEpoch) => prove(sealedEpoch.tree, ordinalKey(ordinal)).map(_.some)
+        }
+
+    (for {
+      topHot      <- prove(top, hotEpochsKey)
+      topSealed   <- prove(top, sealedEpochsKey)
+      hot         <- prove(hotTree, ordinalKey(ordinal))
+      level1      <- prove(level1Tree, epochKey(epoch))
+      sealedEntry <- sealedEntryProof
+    } yield OrdinalCatalogProof(ordinal, topHot, topSealed, hot, level1, sealedEntry)).value
+  }
+}
+
+object EpochCatalog {
+
+  /** A sealed epoch retained for SERVING: its full `ordinal -> mptRoot` contents plus the frozen tree. */
+  final case class SealedEpoch[F[_]](entries: SortedMap[Long, Hash], tree: InMemorySparseMerkleTree[F])
+
+  /** Emitted by [[EpochCatalog.advance]] when an epoch boundary seals the hot tree. */
+  final case class SealEvent(epoch: Long, root: SparseMerkleRoot, sealedOrdinals: List[Long])
+
+  /** The empty catalog (genesis: no history yet). */
+  def empty[F[_]: Sync: JsonBinaryHasher](config: CommittedConfig): F[EpochCatalog[F]] =
+    for {
+      hot    <- InMemorySparseMerkleTree.empty[F]
+      level1 <- InMemorySparseMerkleTree.empty[F]
+    } yield EpochCatalog(
+      config.epochSize,
+      config.sealedEpochRetention,
+      0L,
+      SortedMap.empty,
+      hot,
+      SortedMap.empty,
+      level1,
+      SortedMap.empty
+    )
+
+  /**
+   * Rebuild a catalog from transported [[CatalogContents]] (hydration / replication). Validates
+   * internal consistency: hot ordinals all in one epoch later than every sealed epoch, and each
+   * transported sealed epoch's rebuilt root equal to its level-1 entry. The COMMITMENT itself is
+   * NOT trusted from here -- callers must compare `compose(...)` against an attested root.
+   */
+  def fromContents[F[_]: Sync: JsonBinaryHasher](
+    config: CommittedConfig,
+    contents: CatalogContents
+  ): F[Either[CommittedStateError, EpochCatalog[F]]] = {
+    val epochSize = contents.epochSize
+    val hotEpochs = contents.hot.keySet.map(CommitCatalog.epochOf(_, epochSize))
+    val epochIndex = hotEpochs.headOption.getOrElse(contents.level1.lastOption.map(_._1 + 1).getOrElse(0L))
+
+    val structural: Either[CommittedStateError, Unit] =
+      if (epochSize <= 0)
+        CommittedStateError.MalformedCatalogContents(s"epochSize must be positive: $epochSize").asLeft
+      else if (hotEpochs.size > 1)
+        CommittedStateError.MalformedCatalogContents(s"hot ordinals span multiple epochs: $hotEpochs").asLeft
+      else if (contents.level1.lastOption.exists(_._1 >= epochIndex) && hotEpochs.nonEmpty)
+        CommittedStateError.MalformedCatalogContents("level-1 contains the hot epoch or a later one").asLeft
+      else if (!contents.sealedEpochs.keySet.subsetOf(contents.level1.keySet))
+        CommittedStateError.MalformedCatalogContents("sealed epoch contents without a level-1 root").asLeft
+      else ().asRight
+
+    structural.flatTraverse { _ =>
+      for {
+        hot <- InMemorySparseMerkleTree.make[F](
+          contents.hot.map { case (o, h) => CommitCatalog.ordinalKey(o) -> CommitCatalog.rootValueBytes(h) }.toMap
+        )
+        level1 <- InMemorySparseMerkleTree.make[F](
+          contents.level1.map { case (e, h) => CommitCatalog.epochKey(e) -> CommitCatalog.rootValueBytes(h) }.toMap
+        )
+        rebuiltSealed <- contents.sealedEpochs.toList.traverse {
+          case (epoch, entries) =>
+            InMemorySparseMerkleTree
+              .make[F](entries.map { case (o, h) => CommitCatalog.ordinalKey(o) -> CommitCatalog.rootValueBytes(h) }.toMap)
+              .flatMap(tree => tree.root.map(root => (epoch, SealedEpoch(entries, tree), root)))
+        }
+        mismatch = rebuiltSealed.collectFirst {
+          case (epoch, _, root) if !contents.level1.get(epoch).contains(root.value) => epoch
+        }
+      } yield mismatch match {
+        case Some(epoch) =>
+          (CommittedStateError.MalformedCatalogContents(s"sealed epoch $epoch contents do not reproduce its level-1 root"): CommittedStateError).asLeft
+        case None =>
+          EpochCatalog(
+            epochSize,
+            config.sealedEpochRetention,
+            epochIndex,
+            contents.hot,
+            hot,
+            contents.level1,
+            level1,
+            SortedMap.from(rebuiltSealed.map { case (e, s, _) => e -> s })
+          ).asRight[CommittedStateError]
+      }
+    }
+  }
+
+  private[committed] def requireInMemory[F[_]: Sync](
+    tree: SparseMerkleTree[F]
+  ): F[InMemorySparseMerkleTree[F]] =
+    tree match {
+      case t: InMemorySparseMerkleTree[F] => t.pure[F]
+      case other =>
+        Sync[F].raiseError(CommittedStateError.CatalogImplementationMismatch(other.getClass.getName))
+    }
+}
+
+/**
+ * The transportable catalog payload: everything needed to rebuild an [[EpochCatalog]] -- the hot
+ * epoch entries, the level-1 sealed-epoch roots, and (optionally, for serving) retained sealed
+ * epochs' full contents. `epochSize` is included because the rollup geometry is part of the
+ * commitment.
+ */
+final case class CatalogContents(
+  epochSize: Int,
+  hot: SortedMap[Long, Hash],
+  level1: SortedMap[Long, Hash],
+  sealedEpochs: SortedMap[Long, SortedMap[Long, Hash]]
+)
+
+object CatalogContents {
+
+  implicit private val longKeyEncoder: KeyEncoder[Long] = KeyEncoder.encodeKeyLong
+  implicit private val longKeyDecoder: KeyDecoder[Long] = KeyDecoder.decodeKeyLong
+
+  implicit private val longHashMapEncoder: Encoder[SortedMap[Long, Hash]] =
+    Encoder.encodeMap[Long, Hash].contramap(identity)
+
+  implicit private val longHashMapDecoder: Decoder[SortedMap[Long, Hash]] =
+    Decoder.decodeMap[Long, Hash].map(SortedMap.from(_))
+
+  implicit val encoder: Encoder[CatalogContents] =
+    (c: CatalogContents) =>
+      Json.obj(
+        "epochSize"    -> c.epochSize.asJson,
+        "hot"          -> c.hot.asJson,
+        "level1"       -> c.level1.asJson,
+        "sealedEpochs" -> Encoder.encodeMap[Long, SortedMap[Long, Hash]].apply(c.sealedEpochs)
+      )
+
+  implicit val decoder: Decoder[CatalogContents] = (c: HCursor) =>
+    for {
+      epochSize <- c.downField("epochSize").as[Int]
+      hot       <- c.downField("hot").as[SortedMap[Long, Hash]]
+      level1    <- c.downField("level1").as[SortedMap[Long, Hash]]
+      sealedEpochs <- c
+        .downField("sealedEpochs")
+        .as[Map[Long, SortedMap[Long, Hash]]]
+        .map(SortedMap.from(_))
+    } yield CatalogContents(epochSize, hot, level1, sealedEpochs)
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/OrdinalCatalogProof.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/OrdinalCatalogProof.scala
@@ -168,8 +168,7 @@ object CommittedProofError {
       )
 
   /** The catalog is seeded from a breadcrumb but not hydrated: contents unknown, proofs unavailable. */
-  case object CatalogNotHydrated
-      extends CommittedProofError("catalog is breadcrumb-seeded but not hydrated; POST /committed/hydrate first")
+  case object CatalogNotHydrated extends CommittedProofError("catalog is breadcrumb-seeded but not hydrated; POST /committed/hydrate first")
 
   final case class ProofUnavailable(cause: SparseMerkleProofError)
       extends CommittedProofError(s"failed to produce catalog proof: ${cause.getMessage}")

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/OrdinalCatalogProof.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/OrdinalCatalogProof.scala
@@ -1,0 +1,184 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.MonadThrow
+import cats.data.EitherT
+
+import io.constellationnetwork.metagraph_sdk.crypto.smt.api.SparseMerkleVerifier
+import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleEntry, SparseMerkleProof, SparseMerkleProofError, SparseMerkleRoot}
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+/**
+ * The catalog-side attestation of one ordinal against a single trusted catalog root: was an MPT
+ * root committed at snapshot ordinal `ordinal`, and if so which one?
+ *
+ * Structure (see [[EpochCatalog]] for the rollup): the two TOP inclusions surface the hot-epoch
+ * and level-1 roots, then
+ *   - HOT ordinal: `hot` is an inclusion -> the committed MPT root;
+ *   - ANCIENT ordinal: `level1` includes the sealed root of epoch `ordinal / epochSize` and
+ *     `sealedEntry` includes the ordinal inside that sealed tree -- two fixed-depth inclusions;
+ *   - NON-MEMBERSHIP: `hot` is an absence AND the sealed path terminates in an absence (the epoch
+ *     was never sealed, or the ordinal is absent from the sealed tree).
+ *
+ * [[OrdinalCatalogProofVerifier.verify]] recomputes every key locally (from `ordinal` and the
+ * chain's `epochSize`) -- nothing inside the proof chooses which slots are checked, so a prover
+ * cannot e.g. prove absence in the wrong epoch tree.
+ */
+final case class OrdinalCatalogProof(
+  ordinal: Long,
+  topHot: SparseMerkleProof,
+  topSealed: SparseMerkleProof,
+  hot: SparseMerkleProof,
+  level1: SparseMerkleProof,
+  sealedEntry: Option[SparseMerkleProof]
+)
+
+object OrdinalCatalogProof {
+
+  implicit val encoder: Encoder[OrdinalCatalogProof] =
+    (p: OrdinalCatalogProof) =>
+      Json.obj(
+        "ordinal"     -> p.ordinal.asJson,
+        "topHot"      -> p.topHot.asJson,
+        "topSealed"   -> p.topSealed.asJson,
+        "hot"         -> p.hot.asJson,
+        "level1"      -> p.level1.asJson,
+        "sealedEntry" -> p.sealedEntry.asJson
+      )
+
+  implicit val decoder: Decoder[OrdinalCatalogProof] = (c: HCursor) =>
+    for {
+      ordinal     <- c.downField("ordinal").as[Long]
+      topHot      <- c.downField("topHot").as[SparseMerkleProof]
+      topSealed   <- c.downField("topSealed").as[SparseMerkleProof]
+      hot         <- c.downField("hot").as[SparseMerkleProof]
+      level1      <- c.downField("level1").as[SparseMerkleProof]
+      sealedEntry <- c.downField("sealedEntry").as[Option[SparseMerkleProof]]
+    } yield OrdinalCatalogProof(ordinal, topHot, topSealed, hot, level1, sealedEntry)
+}
+
+/** The verified outcome of an [[OrdinalCatalogProof]]. */
+sealed trait OrdinalAttestation extends Product with Serializable
+
+object OrdinalAttestation {
+
+  /** Ordinal `ordinal` committed MPT root `mptRoot` (proven against the catalog root). */
+  final case class CommittedAt(ordinal: Long, mptRoot: Hash) extends OrdinalAttestation
+
+  /** Ordinal `ordinal` is provably NOT committed in the catalog. */
+  final case class NotCommitted(ordinal: Long) extends OrdinalAttestation
+}
+
+object OrdinalCatalogProofVerifier {
+
+  /**
+   * Verify `proof` against the trusted `catalogRoot`. `epochSize` is the chain-wide rollup
+   * geometry ([[CommittedConfig.epochSize]]) -- it determines the unique epoch tree the ordinal
+   * may live in and MUST come from configuration, never from the prover.
+   */
+  def verify[F[_]: MonadThrow: JsonBinaryHasher](
+    catalogRoot: SparseMerkleRoot,
+    proof: OrdinalCatalogProof,
+    epochSize: Int
+  ): F[Either[CommittedProofError, OrdinalAttestation]] = {
+    val verifier = SparseMerkleVerifier.make[F]
+    val epoch = CommitCatalog.epochOf(proof.ordinal, epochSize)
+
+    def checked(
+      component: String,
+      root: SparseMerkleRoot,
+      smtProof: SparseMerkleProof,
+      expectedKey: Hex
+    ): EitherT[F, CommittedProofError, SparseMerkleEntry] =
+      if (smtProof.key != expectedKey)
+        EitherT.leftT[F, SparseMerkleEntry](
+          CommittedProofError.WrongProofKey(component, expectedKey, smtProof.key): CommittedProofError
+        )
+      else
+        EitherT(verifier.verify(root, smtProof))
+          .bimap(CommittedProofError.ProofInvalid(component, _): CommittedProofError, _.value)
+
+    def requireSubRoot(component: String, entry: SparseMerkleEntry): EitherT[F, CommittedProofError, SparseMerkleRoot] =
+      entry match {
+        case SparseMerkleEntry.Present(_, value) =>
+          EitherT.rightT[F, CommittedProofError](SparseMerkleRoot(CommitCatalog.rootFromValueBytes(value)))
+        case SparseMerkleEntry.Absent(_) =>
+          EitherT.leftT[F, SparseMerkleRoot](
+            CommittedProofError.MalformedOrdinalProof(s"$component must be an inclusion in the top catalog"): CommittedProofError
+          )
+      }
+
+    (for {
+      hotEntry    <- checked("topHot", catalogRoot, proof.topHot, CommitCatalog.hotEpochsKey)
+      hotRoot     <- requireSubRoot("topHot", hotEntry)
+      sealedEntry <- checked("topSealed", catalogRoot, proof.topSealed, CommitCatalog.sealedEpochsKey)
+      level1Root  <- requireSubRoot("topSealed", sealedEntry)
+
+      hotResult <- checked("hot", hotRoot, proof.hot, CommitCatalog.ordinalKey(proof.ordinal))
+
+      attestation <- hotResult match {
+        case SparseMerkleEntry.Present(_, value) =>
+          EitherT.rightT[F, CommittedProofError](
+            OrdinalAttestation.CommittedAt(proof.ordinal, CommitCatalog.rootFromValueBytes(value)): OrdinalAttestation
+          )
+        case SparseMerkleEntry.Absent(_) =>
+          checked("level1", level1Root, proof.level1, CommitCatalog.epochKey(epoch)).flatMap {
+            case SparseMerkleEntry.Absent(_) =>
+              // hot-absent AND the ordinal's epoch was never sealed => not committed.
+              EitherT.rightT[F, CommittedProofError](
+                OrdinalAttestation.NotCommitted(proof.ordinal): OrdinalAttestation
+              )
+            case SparseMerkleEntry.Present(_, sealedRootBytes) =>
+              val sealedRoot = SparseMerkleRoot(CommitCatalog.rootFromValueBytes(sealedRootBytes))
+              proof.sealedEntry match {
+                case None =>
+                  EitherT.leftT[F, OrdinalAttestation](
+                    CommittedProofError.MalformedOrdinalProof(
+                      s"epoch $epoch is sealed; a sealedEntry proof is required"
+                    ): CommittedProofError
+                  )
+                case Some(entryProof) =>
+                  checked("sealedEntry", sealedRoot, entryProof, CommitCatalog.ordinalKey(proof.ordinal)).map {
+                    case SparseMerkleEntry.Present(_, value) =>
+                      OrdinalAttestation.CommittedAt(proof.ordinal, CommitCatalog.rootFromValueBytes(value)): OrdinalAttestation
+                    case SparseMerkleEntry.Absent(_) =>
+                      OrdinalAttestation.NotCommitted(proof.ordinal): OrdinalAttestation
+                  }
+              }
+          }
+      }
+    } yield attestation).value
+  }
+}
+
+/** Errors of the catalog proof surface (serving and verification). */
+sealed abstract class CommittedProofError(message: String) extends RuntimeException(message)
+
+object CommittedProofError {
+
+  /** The node pruned this sealed epoch's contents: it cannot SERVE the proof (others can; the proof stays verifiable). */
+  final case class EpochPruned(epoch: Long)
+      extends CommittedProofError(
+        s"sealed epoch $epoch contents pruned by retention policy on this node; " +
+        "fetch the proof from a node retaining the epoch (the catalog root still verifies it)"
+      )
+
+  /** The catalog is seeded from a breadcrumb but not hydrated: contents unknown, proofs unavailable. */
+  case object CatalogNotHydrated
+      extends CommittedProofError("catalog is breadcrumb-seeded but not hydrated; POST /committed/hydrate first")
+
+  final case class ProofUnavailable(cause: SparseMerkleProofError)
+      extends CommittedProofError(s"failed to produce catalog proof: ${cause.getMessage}")
+
+  final case class WrongProofKey(component: String, expected: Hex, got: Hex)
+      extends CommittedProofError(s"ordinal proof component '$component' proves key ${got.value}, expected ${expected.value}")
+
+  final case class ProofInvalid(component: String, cause: SparseMerkleProofError)
+      extends CommittedProofError(s"ordinal proof component '$component' failed verification: ${cause.getMessage}")
+
+  final case class MalformedOrdinalProof(reason: String) extends CommittedProofError(s"malformed ordinal proof: $reason")
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/StateDelta.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/StateDelta.scala
@@ -1,0 +1,46 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+/**
+ * The replication unit: the canonical change-set that took the committed state from
+ * `parentRoots` (the previous snapshot's commitment) to `roots` at `ordinal`.
+ *
+ * A replica applies `removes` then `upserts` to its own trie, recomputes both roots LOCALLY, and
+ * accepts the delta only if they equal `roots` (see `CommittedReplica.applyDelta`) -- so a tampered
+ * delta (modified value, dropped key, forged roots) is rejected without trusting the sender.
+ */
+final case class StateDelta(
+  ordinal: SnapshotOrdinal,
+  parentRoots: CommittedRoots,
+  roots: CommittedRoots,
+  upserts: SortedMap[CommitKey, Json],
+  removes: SortedSet[CommitKey]
+)
+
+object StateDelta {
+
+  implicit val encoder: Encoder[StateDelta] =
+    (d: StateDelta) =>
+      Json.obj(
+        "ordinal"     -> d.ordinal.asJson,
+        "parentRoots" -> d.parentRoots.asJson,
+        "roots"       -> d.roots.asJson,
+        "upserts"     -> Encoder.encodeMap[CommitKey, Json].apply(d.upserts),
+        "removes"     -> d.removes.toList.asJson
+      )
+
+  implicit val decoder: Decoder[StateDelta] = (c: HCursor) =>
+    for {
+      ordinal     <- c.downField("ordinal").as[SnapshotOrdinal]
+      parentRoots <- c.downField("parentRoots").as[CommittedRoots]
+      roots       <- c.downField("roots").as[CommittedRoots]
+      upserts     <- c.downField("upserts").as[Map[CommitKey, Json]].map(SortedMap.from(_))
+      removes     <- c.downField("removes").as[List[CommitKey]].map(SortedSet.from(_))
+    } yield StateDelta(ordinal, parentRoots, roots, upserts, removes)
+}

--- a/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
@@ -18,14 +18,14 @@ import weaver.SimpleIOSuite
 
 /**
  * End-to-end over the single assembly path: `CommittedApp.makeL0` produces a
- * `BaseDataApplicationL0Service` whose calculated-state surface is the committed cell --
- * `hashCalculatedState` is the pure derivation, `setCalculatedState` commits (and asserts), and the
- * drop-in `/committed/...` routes serve atomically-consistent reads.
+ * `BaseDataApplicationL0Service` whose on-chain type carries the breadcrumb (emitted by `combine`,
+ * validated against the local commitment), whose `hashCalculatedState` commits the live catalog,
+ * and whose drop-in `/committed/...` routes serve atomically-consistent reads.
  */
 object CommittedAppSuite extends SimpleIOSuite {
   import ToyFixtures._
 
-  // The committed service never touches the node context; tests run without one.
+  // The committed service reads the node context defensively; tests run without one.
   implicit private val ctx: L0NodeContext[IO] = null
 
   private def ord(n: Long): SnapshotOrdinal = SnapshotOrdinal.unsafeApply(n)
@@ -64,11 +64,57 @@ object CommittedAppSuite extends SimpleIOSuite {
   private def get(service: BaseDataApplicationL0Service[IO], path: String): IO[Response[IO]] =
     service.routes.orNotFound.run(Request[IO](Method.GET, Uri.unsafeFromString(path)))
 
-  test("hashCalculatedState is the pure two-tier derivation") {
+  test("genesis on-chain state carries the genesis breadcrumb (correct by construction)") {
+    for {
+      service  <- makeService
+      expected <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+    } yield
+      service.genesis.onChain match {
+        case CommittedOnChain(ToyPub(0), breadcrumb) =>
+          expect.all(
+            breadcrumb.ordinal == SnapshotOrdinal.MinValue,
+            breadcrumb.roots.mptRoot == expected.roots.mptRoot,
+            breadcrumb.roots.catalogRoot == expected.roots.catalogRoot
+          )
+        case other => failure(s"genesis onChain is not a CommittedOnChain with the dev PUB inside: $other")
+      }
+  }
+
+  test("combine emits the next breadcrumb; the dev combiner sees only the inner PUB") {
+    for {
+      service <- makeService
+      out     <- service.combine(service.genesis, List.empty)
+      // committing the same transition produces the same breadcrumb
+      reference <- CommittedState.make[IO, ToyState](s0).flatMap(st => st.setCommitted(ord(1), s0))
+    } yield
+      out.onChain match {
+        case CommittedOnChain(ToyPub(0), breadcrumb) =>
+          expect.all(breadcrumb.ordinal == ord(1), breadcrumb.roots == reference.roots)
+        case other => failure(s"combine did not emit a CommittedOnChain: $other")
+      }
+  }
+
+  test("combine rejects a forged incoming breadcrumb (follower-side transition validation)") {
+    for {
+      service <- makeService
+      honest = service.genesis
+      forgedBreadcrumb = honest.onChain match {
+        case CommittedOnChain(inner, b: CommittedBreadcrumb) =>
+          CommittedOnChain(
+            inner.asInstanceOf[ToyPub],
+            b.copy(roots = b.roots.copy(mptRoot = io.constellationnetwork.security.hash.Hash.empty))
+          )
+        case other => throw new RuntimeException(s"unexpected onChain: $other")
+      }
+      result <- service.combine(honest.copy(onChain = forgedBreadcrumb), List.empty).attempt
+    } yield expect(result.left.exists(_.isInstanceOf[CommittedStateError.BreadcrumbMismatch]))
+  }
+
+  test("hashCalculatedState commits the live catalog: the transition hash, not a pure-value hash") {
     for {
       service  <- makeService
       h        <- service.hashCalculatedState(ToyPrv(s1))
-      expected <- CommittedCommitment.deriveHash[IO, ToyPrv](ToyPrv(s1))
+      expected <- CommittedState.make[IO, ToyState](s0).flatMap(_.hashFor(s1, None))
     } yield expect(h == expected)
   }
 
@@ -82,16 +128,17 @@ object CommittedAppSuite extends SimpleIOSuite {
 
   test("GET /committed/root reflects the committed ordinal, roots, and consensus hash") {
     for {
-      service      <- makeService
-      _            <- service.setCalculatedState(ord(1), ToyPrv(s1))
-      res          <- get(service, "/committed/root")
-      json         <- res.as[Json]
-      expectedHash <- CommittedCommitment.deriveHash[IO, ToyPrv](ToyPrv(s1))
+      service   <- makeService
+      _         <- service.setCalculatedState(ord(1), ToyPrv(s1))
+      res       <- get(service, "/committed/root")
+      json      <- res.as[Json]
+      reference <- CommittedState.make[IO, ToyState](s0).flatMap(st => st.setCommitted(ord(1), s1))
     } yield
       expect.all(
         res.status == Status.Ok,
         json.hcursor.downField("ordinal").as[SnapshotOrdinal] == Right(ord(1)),
-        json.hcursor.downField("calculatedStateHash").as[String] == Right(expectedHash.value)
+        json.hcursor.downField("calculatedStateHash").as[String] == Right(reference.roots.combinedHash.value),
+        json.hcursor.downField("hydrated").as[Boolean] == Right(true)
       )
   }
 
@@ -139,6 +186,25 @@ object CommittedAppSuite extends SimpleIOSuite {
       )
   }
 
+  test("GET /committed/proof-ordinal/:ordinal serves a verifiable catalog attestation") {
+    for {
+      service <- makeService
+      _       <- service.setCalculatedState(ord(1), ToyPrv(s1))
+      res     <- get(service, "/committed/proof-ordinal/0")
+      json    <- res.as[Json]
+      proof   <- IO.fromEither(json.hcursor.downField("proof").as[OrdinalCatalogProof])
+      root    <- IO.fromEither(json.hcursor.downField("catalogRoot").as[io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleRoot])
+      attestation <- OrdinalCatalogProofVerifier
+        .verify[IO](root, proof, CommittedConfig.DefaultEpochSize)
+        .flatMap(IO.fromEither(_))
+      genesisRoots <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+    } yield
+      expect.all(
+        res.status == Status.Ok,
+        attestation == OrdinalAttestation.CommittedAt(0L, genesisRoots.roots.mptRoot)
+      )
+  }
+
   test("GET /committed/delta/:ordinal serves retained deltas and 404s evicted ones") {
     for {
       service <- makeService
@@ -149,13 +215,29 @@ object CommittedAppSuite extends SimpleIOSuite {
     } yield expect.all(hit.status == Status.Ok, delta.ordinal == ord(1), miss.status == Status.NotFound)
   }
 
-  test("GET /committed/snapshot is a valid replication seed") {
+  test("GET /committed/snapshot is a valid replication seed; GET /committed/catalog matches it") {
     for {
       service  <- makeService
       _        <- service.setCalculatedState(ord(1), ToyPrv(s1))
       res      <- get(service, "/committed/snapshot")
       snapshot <- res.as[CommittedSnapshot]
+      catRes   <- get(service, "/committed/catalog")
+      contents <- catRes.as[CatalogContents]
       replica  <- CommittedReplica.fromSnapshot[IO](snapshot).flatMap(IO.fromEither(_))
-    } yield expect.all(res.status == Status.Ok, replica.ordinal == ord(1), replica.roots == snapshot.roots)
+    } yield
+      expect.all(
+        res.status == Status.Ok,
+        replica.ordinal == ord(1),
+        replica.roots == snapshot.roots,
+        contents == snapshot.catalog
+      )
+  }
+
+  test("CommittedOnChain round-trips through the service's on-chain codec") {
+    for {
+      service <- makeService
+      bytes   <- service.serializeState(service.genesis.onChain)
+      decoded <- service.deserializeState(bytes)
+    } yield expect(decoded == Right(service.genesis.onChain))
   }
 }

--- a/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
@@ -1,0 +1,156 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.metagraph_sdk.lifecycle.{CombinerService, ValidationService}
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.signature.Signed
+
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+import org.http4s._
+import org.http4s.circe.CirceEntityCodec.{circeEntityDecoder, circeEntityEncoder}
+import org.http4s.implicits._
+import weaver.SimpleIOSuite
+
+/**
+ * End-to-end over the single assembly path: `CommittedApp.makeL0` produces a
+ * `BaseDataApplicationL0Service` whose calculated-state surface is the committed cell --
+ * `hashCalculatedState` is the pure derivation, `setCalculatedState` commits (and asserts), and the
+ * drop-in `/committed/...` routes serve atomically-consistent reads.
+ */
+object CommittedAppSuite extends SimpleIOSuite {
+  import ToyFixtures._
+
+  // The committed service never touches the node context; tests run without one.
+  implicit private val ctx: L0NodeContext[IO] = null
+
+  private def ord(n: Long): SnapshotOrdinal = SnapshotOrdinal.unsafeApply(n)
+
+  private val s0 = ToyState(Map("aaa" -> 1, "bbb" -> 2), Map("alpha" -> "x"))
+  private val s1 = ToyState(Map("aaa" -> 5, "ccc" -> 3), Map("alpha" -> "x", "beta" -> "y"))
+
+  private val combiner: CombinerService[IO, ToyTx, ToyPub, ToyPrv] =
+    new CombinerService[IO, ToyTx, ToyPub, ToyPrv] {
+
+      def insert(previous: DataState[ToyPub, ToyPrv], update: Signed[ToyTx])(implicit
+        ctx: L0NodeContext[IO]
+      ): IO[DataState[ToyPub, ToyPrv]] =
+        previous.copy(onChain = ToyPub(previous.onChain.updateCount + 1)).pure[IO]
+    }
+
+  private val validator: ValidationService[IO, ToyTx, ToyPub, ToyPrv] =
+    new ValidationService[IO, ToyTx, ToyPub, ToyPrv] {
+
+      def validateUpdate(update: ToyTx)(implicit ctx: L1NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] =
+        ().validNec[DataApplicationValidationError].pure[IO]
+
+      def validateSignedUpdate(current: DataState[ToyPub, ToyPrv], signedUpdate: Signed[ToyTx])(implicit
+        ctx: L0NodeContext[IO]
+      ): IO[DataApplicationValidationErrorOr[Unit]] =
+        ().validNec[DataApplicationValidationError].pure[IO]
+    }
+
+  private def makeService: IO[BaseDataApplicationL0Service[IO]] =
+    CommittedApp.makeL0[IO, ToyTx, ToyPub, ToyPrv](
+      DataState(ToyPub(0), ToyPrv(s0)),
+      combiner,
+      validator
+    )
+
+  private def get(service: BaseDataApplicationL0Service[IO], path: String): IO[Response[IO]] =
+    service.routes.orNotFound.run(Request[IO](Method.GET, Uri.unsafeFromString(path)))
+
+  test("hashCalculatedState is the pure two-tier derivation") {
+    for {
+      service  <- makeService
+      h        <- service.hashCalculatedState(ToyPrv(s1))
+      expected <- CommittedCommitment.deriveHash[IO, ToyPrv](ToyPrv(s1))
+    } yield expect(h == expected)
+  }
+
+  test("setCalculatedState commits through the cell; getCalculatedState reads it back") {
+    for {
+      service <- makeService
+      ok      <- service.setCalculatedState(ord(1), ToyPrv(s1))
+      result  <- service.getCalculatedState
+    } yield expect.all(ok, result._1 == ord(1), result._2 == ToyPrv(s1))
+  }
+
+  test("GET /committed/root reflects the committed ordinal, roots, and consensus hash") {
+    for {
+      service <- makeService
+      _       <- service.setCalculatedState(ord(1), ToyPrv(s1))
+      res     <- get(service, "/committed/root")
+      json    <- res.as[Json]
+      expectedHash <- CommittedCommitment.deriveHash[IO, ToyPrv](ToyPrv(s1))
+    } yield expect.all(
+      res.status == Status.Ok,
+      json.hcursor.downField("ordinal").as[SnapshotOrdinal] == Right(ord(1)),
+      json.hcursor.downField("calculatedStateHash").as[String] == Right(expectedHash.value)
+    )
+  }
+
+  test("GET /committed/proof/<key> proves a key; invalid keys are 400, absent keys 404") {
+    for {
+      service <- makeService
+      found   <- get(service, "/committed/proof/fiber/aaa")
+      json    <- found.as[Json]
+      missing <- get(service, "/committed/proof/fiber/zzz")
+      invalid <- get(service, "/committed/proof/FIBER/aaa")
+    } yield expect.all(
+      found.status == Status.Ok,
+      json.hcursor.downField("key").as[String] == Right("fiber/aaa"),
+      json.hcursor.downField("proof").succeeded,
+      missing.status == Status.NotFound,
+      invalid.status == Status.BadRequest
+    )
+  }
+
+  test("POST /committed/proofs returns one batch proof for many keys") {
+    for {
+      service <- makeService
+      req = Request[IO](Method.POST, uri"/committed/proofs")
+        .withEntity(Json.obj("keys" -> List("fiber/aaa", "registry/alpha").asJson))
+      res  <- service.routes.orNotFound.run(req)
+      json <- res.as[Json]
+    } yield expect.all(
+      res.status == Status.Ok,
+      json.hcursor.downField("proof").downField("paths").as[List[String]].exists(_.size == 2)
+    )
+  }
+
+  test("GET /committed/proof-prefix/<ns> returns the namespace attestation") {
+    for {
+      service <- makeService
+      res     <- get(service, "/committed/proof-prefix/fiber")
+      json    <- res.as[Json]
+    } yield expect.all(
+      res.status == Status.Ok,
+      json.hcursor.downField("namespace").as[String] == Right("fiber"),
+      json.hcursor.downField("proof").downField("paths").as[List[String]].exists(_.size == 2)
+    )
+  }
+
+  test("GET /committed/delta/:ordinal serves retained deltas and 404s evicted ones") {
+    for {
+      service <- makeService
+      _       <- service.setCalculatedState(ord(1), ToyPrv(s1))
+      hit     <- get(service, "/committed/delta/1")
+      delta   <- hit.as[StateDelta]
+      miss    <- get(service, "/committed/delta/999")
+    } yield expect.all(hit.status == Status.Ok, delta.ordinal == ord(1), miss.status == Status.NotFound)
+  }
+
+  test("GET /committed/snapshot is a valid replication seed") {
+    for {
+      service  <- makeService
+      _        <- service.setCalculatedState(ord(1), ToyPrv(s1))
+      res      <- get(service, "/committed/snapshot")
+      snapshot <- res.as[CommittedSnapshot]
+      replica  <- CommittedReplica.fromSnapshot[IO](snapshot).flatMap(IO.fromEither(_))
+    } yield expect.all(res.status == Status.Ok, replica.ordinal == ord(1), replica.roots == snapshot.roots)
+  }
+}

--- a/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
@@ -1,4 +1,5 @@
 package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
 import cats.effect.IO
 import cats.syntax.all._
 
@@ -35,8 +36,8 @@ object CommittedAppSuite extends SimpleIOSuite {
   private val combiner: CombinerService[IO, ToyTx, ToyPub, ToyPrv] =
     new CombinerService[IO, ToyTx, ToyPub, ToyPrv] {
 
-      def insert(previous: DataState[ToyPub, ToyPrv], update: Signed[ToyTx])(implicit
-        ctx: L0NodeContext[IO]
+      def insert(previous: DataState[ToyPub, ToyPrv], update: Signed[ToyTx])(
+        implicit ctx: L0NodeContext[IO]
       ): IO[DataState[ToyPub, ToyPrv]] =
         previous.copy(onChain = ToyPub(previous.onChain.updateCount + 1)).pure[IO]
     }
@@ -47,8 +48,8 @@ object CommittedAppSuite extends SimpleIOSuite {
       def validateUpdate(update: ToyTx)(implicit ctx: L1NodeContext[IO]): IO[DataApplicationValidationErrorOr[Unit]] =
         ().validNec[DataApplicationValidationError].pure[IO]
 
-      def validateSignedUpdate(current: DataState[ToyPub, ToyPrv], signedUpdate: Signed[ToyTx])(implicit
-        ctx: L0NodeContext[IO]
+      def validateSignedUpdate(current: DataState[ToyPub, ToyPrv], signedUpdate: Signed[ToyTx])(
+        implicit ctx: L0NodeContext[IO]
       ): IO[DataApplicationValidationErrorOr[Unit]] =
         ().validNec[DataApplicationValidationError].pure[IO]
     }
@@ -81,16 +82,17 @@ object CommittedAppSuite extends SimpleIOSuite {
 
   test("GET /committed/root reflects the committed ordinal, roots, and consensus hash") {
     for {
-      service <- makeService
-      _       <- service.setCalculatedState(ord(1), ToyPrv(s1))
-      res     <- get(service, "/committed/root")
-      json    <- res.as[Json]
+      service      <- makeService
+      _            <- service.setCalculatedState(ord(1), ToyPrv(s1))
+      res          <- get(service, "/committed/root")
+      json         <- res.as[Json]
       expectedHash <- CommittedCommitment.deriveHash[IO, ToyPrv](ToyPrv(s1))
-    } yield expect.all(
-      res.status == Status.Ok,
-      json.hcursor.downField("ordinal").as[SnapshotOrdinal] == Right(ord(1)),
-      json.hcursor.downField("calculatedStateHash").as[String] == Right(expectedHash.value)
-    )
+    } yield
+      expect.all(
+        res.status == Status.Ok,
+        json.hcursor.downField("ordinal").as[SnapshotOrdinal] == Right(ord(1)),
+        json.hcursor.downField("calculatedStateHash").as[String] == Right(expectedHash.value)
+      )
   }
 
   test("GET /committed/proof/<key> proves a key; invalid keys are 400, absent keys 404") {
@@ -100,13 +102,14 @@ object CommittedAppSuite extends SimpleIOSuite {
       json    <- found.as[Json]
       missing <- get(service, "/committed/proof/fiber/zzz")
       invalid <- get(service, "/committed/proof/FIBER/aaa")
-    } yield expect.all(
-      found.status == Status.Ok,
-      json.hcursor.downField("key").as[String] == Right("fiber/aaa"),
-      json.hcursor.downField("proof").succeeded,
-      missing.status == Status.NotFound,
-      invalid.status == Status.BadRequest
-    )
+    } yield
+      expect.all(
+        found.status == Status.Ok,
+        json.hcursor.downField("key").as[String] == Right("fiber/aaa"),
+        json.hcursor.downField("proof").succeeded,
+        missing.status == Status.NotFound,
+        invalid.status == Status.BadRequest
+      )
   }
 
   test("POST /committed/proofs returns one batch proof for many keys") {
@@ -116,10 +119,11 @@ object CommittedAppSuite extends SimpleIOSuite {
         .withEntity(Json.obj("keys" -> List("fiber/aaa", "registry/alpha").asJson))
       res  <- service.routes.orNotFound.run(req)
       json <- res.as[Json]
-    } yield expect.all(
-      res.status == Status.Ok,
-      json.hcursor.downField("proof").downField("paths").as[List[String]].exists(_.size == 2)
-    )
+    } yield
+      expect.all(
+        res.status == Status.Ok,
+        json.hcursor.downField("proof").downField("paths").as[List[String]].exists(_.size == 2)
+      )
   }
 
   test("GET /committed/proof-prefix/<ns> returns the namespace attestation") {
@@ -127,11 +131,12 @@ object CommittedAppSuite extends SimpleIOSuite {
       service <- makeService
       res     <- get(service, "/committed/proof-prefix/fiber")
       json    <- res.as[Json]
-    } yield expect.all(
-      res.status == Status.Ok,
-      json.hcursor.downField("namespace").as[String] == Right("fiber"),
-      json.hcursor.downField("proof").downField("paths").as[List[String]].exists(_.size == 2)
-    )
+    } yield
+      expect.all(
+        res.status == Status.Ok,
+        json.hcursor.downField("namespace").as[String] == Right("fiber"),
+        json.hcursor.downField("proof").downField("paths").as[List[String]].exists(_.size == 2)
+      )
   }
 
   test("GET /committed/delta/:ordinal serves retained deltas and 404s evicted ones") {

--- a/src/test/scala/lifecycle/committed/CommittedBootstrapSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedBootstrapSuite.scala
@@ -31,20 +31,20 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
 
   test("O(1) bootstrap: hashCalculatedState is verifiable from state + breadcrumb alone") {
     for {
-      src   <- source(5)
-      cSrc  <- src.committed
+      src  <- source(5)
+      cSrc <- src.committed
       bc = cSrc.breadcrumb
 
       fresh <- CommittedState.make[IO, ToyState](state(0), config)
       // the downloading node has NO history; it hashes the fetched state with the attested breadcrumb
-      h     <- fresh.hashFor(state(5), Some(bc))
+      h <- fresh.hashFor(state(5), Some(bc))
     } yield expect(h == cSrc.roots.combinedHash)
   }
 
   test("seeding adopts the attested roots; the catalog starts unhydrated") {
     for {
-      src  <- source(5)
-      cSrc <- src.committed
+      src    <- source(5)
+      cSrc   <- src.committed
       fresh  <- CommittedState.make[IO, ToyState](state(0), config)
       seeded <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
     } yield
@@ -58,9 +58,9 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
 
   test("seeding rejects a state that does not reproduce the attested mptRoot, and a breadcrumb for another ordinal") {
     for {
-      src  <- source(5)
-      cSrc <- src.committed
-      fresh <- CommittedState.make[IO, ToyState](state(0), config)
+      src          <- source(5)
+      cSrc         <- src.committed
+      fresh        <- CommittedState.make[IO, ToyState](state(0), config)
       wrongState   <- fresh.setCommitted(ord(5), state(4), Some(cSrc.breadcrumb)).attempt
       wrongOrdinal <- fresh.setCommitted(ord(6), state(5), Some(cSrc.breadcrumb)).attempt
       noBreadcrumb <- fresh.setCommitted(ord(5), state(5), None).attempt
@@ -74,10 +74,10 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
 
   test("an unhydrated node cannot derive transitions (combine) until hydrated") {
     for {
-      src  <- source(5)
-      cSrc <- src.committed
-      fresh  <- CommittedState.make[IO, ToyState](state(0), config)
-      seeded <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
+      src     <- source(5)
+      cSrc    <- src.committed
+      fresh   <- CommittedState.make[IO, ToyState](state(0), config)
+      seeded  <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
       attempt <- fresh.advanceWork(seeded.breadcrumb, ToyState.view.entries(state(6))).attempt
     } yield expect(attempt.left.exists(_.isInstanceOf[CommittedStateError.BreadcrumbUnresolvable]))
   }
@@ -97,9 +97,9 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
       hydrated <- fresh.hydrate(contents).flatMap(IO.fromEither(_))
 
       // after hydration the node derives the SAME next commitment as the source
-      _      <- src.setCommitted(ord(6), state(6))
-      cSrc6  <- src.committed
-      c6     <- fresh.setCommitted(ord(6), state(6))
+      _     <- src.setCommitted(ord(6), state(6))
+      cSrc6 <- src.committed
+      c6    <- fresh.setCommitted(ord(6), state(6))
     } yield
       expect.all(
         rejected.left.exists(_.isInstanceOf[CommittedStateError.HydrationRootMismatch]),
@@ -233,7 +233,7 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
       stillAt2 <- src.committed
 
       // ...and an independent chain that COMMITS each step derives identical breadcrumbs
-      other <- source(5)
+      other  <- source(5)
       cOther <- other.committed
     } yield
       expect.all(

--- a/src/test/scala/lifecycle/committed/CommittedBootstrapSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedBootstrapSuite.scala
@@ -1,0 +1,245 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import weaver.SimpleIOSuite
+
+/**
+ * The O(1) bootstrap contract: a fresh node verifies and adopts a downloaded state given ONLY the
+ * state value and the latest signed snapshot's on-chain breadcrumb (no history replay); hydration
+ * is verify-gated against the attested catalog root; the journal provides the local restart path;
+ * and the combine-side breadcrumb validation accepts honest transitions and rejects forged ones.
+ */
+object CommittedBootstrapSuite extends SimpleIOSuite {
+  import ToyFixtures._
+
+  private def ord(n: Long): SnapshotOrdinal = SnapshotOrdinal.unsafeApply(n)
+
+  private def state(i: Int): ToyState = ToyState(Map("aaa" -> i, "bbb" -> i * 7), Map("r" -> s"v$i"))
+
+  private val config = CommittedConfig(epochSize = 2, sealedEpochRetention = 4)
+
+  /** A source chain advanced to ordinal `n`. */
+  private def source(n: Int, journal: Option[CatalogJournal[IO]] = None): IO[CommittedState[IO, ToyState]] =
+    for {
+      st <- CommittedState.make[IO, ToyState](state(0), config, journal)
+      _  <- (1 to n).toList.traverse_(i => st.setCommitted(ord(i.toLong), state(i)))
+    } yield st
+
+  test("O(1) bootstrap: hashCalculatedState is verifiable from state + breadcrumb alone") {
+    for {
+      src   <- source(5)
+      cSrc  <- src.committed
+      bc = cSrc.breadcrumb
+
+      fresh <- CommittedState.make[IO, ToyState](state(0), config)
+      // the downloading node has NO history; it hashes the fetched state with the attested breadcrumb
+      h     <- fresh.hashFor(state(5), Some(bc))
+    } yield expect(h == cSrc.roots.combinedHash)
+  }
+
+  test("seeding adopts the attested roots; the catalog starts unhydrated") {
+    for {
+      src  <- source(5)
+      cSrc <- src.committed
+      fresh  <- CommittedState.make[IO, ToyState](state(0), config)
+      seeded <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
+    } yield
+      expect.all(
+        seeded.ordinal == ord(5),
+        seeded.roots == cSrc.roots,
+        !seeded.isHydrated,
+        seeded.breadcrumb == cSrc.breadcrumb
+      )
+  }
+
+  test("seeding rejects a state that does not reproduce the attested mptRoot, and a breadcrumb for another ordinal") {
+    for {
+      src  <- source(5)
+      cSrc <- src.committed
+      fresh <- CommittedState.make[IO, ToyState](state(0), config)
+      wrongState   <- fresh.setCommitted(ord(5), state(4), Some(cSrc.breadcrumb)).attempt
+      wrongOrdinal <- fresh.setCommitted(ord(6), state(5), Some(cSrc.breadcrumb)).attempt
+      noBreadcrumb <- fresh.setCommitted(ord(5), state(5), None).attempt
+    } yield
+      expect.all(
+        wrongState.left.exists(_.isInstanceOf[CommittedStateError.SeedStateMismatch]),
+        wrongOrdinal.left.exists(_.isInstanceOf[CommittedStateError.CannotSeed]),
+        noBreadcrumb.left.exists(_.isInstanceOf[CommittedStateError.CannotSeed])
+      )
+  }
+
+  test("an unhydrated node cannot derive transitions (combine) until hydrated") {
+    for {
+      src  <- source(5)
+      cSrc <- src.committed
+      fresh  <- CommittedState.make[IO, ToyState](state(0), config)
+      seeded <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
+      attempt <- fresh.advanceWork(seeded.breadcrumb, ToyState.view.entries(state(6))).attempt
+    } yield expect(attempt.left.exists(_.isInstanceOf[CommittedStateError.BreadcrumbUnresolvable]))
+  }
+
+  test("hydration is verify-gated: matching contents install, tampered contents are rejected") {
+    for {
+      src  <- source(5)
+      cSrc <- src.committed
+      contents = cSrc.catalogContents.getOrElse(throw new RuntimeException("source must be hydrated"))
+
+      fresh <- CommittedState.make[IO, ToyState](state(0), config)
+      _     <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
+
+      forged = contents.copy(hot = contents.hot.map { case (o, _) => o -> cSrc.roots.mptRoot })
+      rejected <- fresh.hydrate(forged)
+
+      hydrated <- fresh.hydrate(contents).flatMap(IO.fromEither(_))
+
+      // after hydration the node derives the SAME next commitment as the source
+      _      <- src.setCommitted(ord(6), state(6))
+      cSrc6  <- src.committed
+      c6     <- fresh.setCommitted(ord(6), state(6))
+    } yield
+      expect.all(
+        rejected.left.exists(_.isInstanceOf[CommittedStateError.HydrationRootMismatch]),
+        hydrated.isHydrated,
+        c6.roots == cSrc6.roots
+      )
+  }
+
+  test("journal restart: a seeded cell hydrates immediately from its own persisted catalog") {
+    for {
+      journal <- CatalogJournal.inMemory[IO].map(_.some)
+      src     <- source(5, journal) // writes through to the journal on every transition
+      cSrc    <- src.committed
+
+      // 'restart': a new cell over the SAME journal, seeded from the attested breadcrumb
+      restarted <- CommittedState.make[IO, ToyState](state(0), config, journal)
+      seeded    <- restarted.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
+
+      // and it can continue producing transitions in lock-step with the source
+      _     <- src.setCommitted(ord(6), state(6))
+      cSrc6 <- src.committed
+      c6    <- restarted.setCommitted(ord(6), state(6))
+    } yield
+      expect.all(
+        seeded.isHydrated,
+        seeded.roots == cSrc.roots,
+        c6.roots == cSrc6.roots
+      )
+  }
+
+  test("LevelDB journal: sealed-epoch roots survive a process restart and re-hydrate the cell") {
+    import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+    import java.nio.file.attribute.BasicFileAttributes
+    import cats.effect.Resource
+
+    def deleteRecursively(path: Path): IO[Unit] = IO {
+      Files.walkFileTree(
+        path,
+        new SimpleFileVisitor[Path] {
+          override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+            Files.delete(file); FileVisitResult.CONTINUE
+          }
+          override def postVisitDirectory(dir: Path, exc: java.io.IOException): FileVisitResult = {
+            Files.delete(dir); FileVisitResult.CONTINUE
+          }
+        }
+      )
+    }.void
+
+    val tmpDir = Resource.make(IO(Files.createTempDirectory("committed_journal_")))(deleteRecursively)
+
+    tmpDir.use { dir =>
+      for {
+        // first 'process': run the chain over a LevelDB journal, then close it
+        cSrc <- CatalogJournal.levelDb[IO](dir).use { journal =>
+          source(5, journal.some).flatMap(_.committed)
+        }
+        // second 'process': fresh cell, SAME db path -- the journal alone hydrates the seed
+        seeded <- CatalogJournal.levelDb[IO](dir).use { journal =>
+          CommittedState
+            .make[IO, ToyState](state(0), config, journal.some)
+            .flatMap(_.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb)))
+        }
+      } yield expect.all(seeded.isHydrated, seeded.roots == cSrc.roots)
+    }
+  }
+
+  test("journal contents track sealing: hot window pruned, level-1 entries accumulate") {
+    for {
+      journal <- CatalogJournal.inMemory[IO]
+      _       <- source(5, journal.some) // epochSize=2: epochs 0 and 1 sealed, hot = {4}
+      c       <- journal.contents
+      (hot, level1) = c
+    } yield expect.all(hot.keySet == Set(4L), level1.keySet == Set(0L, 1L))
+  }
+
+  test("combine-side validation: the honest parent advances; a forged breadcrumb is rejected") {
+    for {
+      src  <- source(3)
+      cSrc <- src.committed
+
+      next <- src.advanceWork(cSrc.breadcrumb, ToyState.view.entries(state(4)))
+      // the emitted breadcrumb must equal what setCommitted then derives
+      c4 <- src.setCommitted(ord(4), state(4))
+
+      // forged at the committed ordinal: the follower's transition check fires
+      forged = c4.breadcrumb.copy(roots = c4.roots.copy(mptRoot = cSrc.roots.mptRoot))
+      rejected <- src.advanceWork(forged, ToyState.view.entries(state(5))).attempt
+
+      // forged at an unknown ordinal: unresolvable, equally fatal
+      unknown = CommittedBreadcrumb(ord(9), c4.roots)
+      unresolvable <- src.advanceWork(unknown, ToyState.view.entries(state(5))).attempt
+    } yield
+      expect.all(
+        next.ordinal == ord(4),
+        next.roots == c4.roots,
+        rejected.left.exists(_.isInstanceOf[CommittedStateError.BreadcrumbMismatch]),
+        unresolvable.left.exists(_.isInstanceOf[CommittedStateError.BreadcrumbUnresolvable])
+      )
+  }
+
+  test("setCommitted cross-checks a consensus breadcrumb for the same ordinal") {
+    for {
+      src  <- source(3)
+      cSrc <- src.committed
+      // an honest follower derives the same roots the proposer attested
+      preview <- src.advanceWork(cSrc.breadcrumb, ToyState.view.entries(state(4)))
+      ok      <- src.setCommitted(ord(4), state(4), Some(preview))
+
+      // a forged attested breadcrumb for the NEXT ordinal is caught at commit time
+      forged = CommittedBreadcrumb(ord(5), ok.roots)
+      bad <- src.setCommitted(ord(5), state(5), Some(forged)).attempt
+    } yield
+      expect.all(
+        ok.roots == preview.roots,
+        bad.left.exists(_.isInstanceOf[CommittedStateError.BreadcrumbMismatch])
+      )
+  }
+
+  test("replay: consecutive advanceWork calls chain through the work cache without touching the cell") {
+    for {
+      src  <- source(2)
+      cSrc <- src.committed
+
+      // fold combine over three future ordinals (the DataApplicationTraverse pattern)
+      b3 <- src.advanceWork(cSrc.breadcrumb, ToyState.view.entries(state(3)))
+      b4 <- src.advanceWork(b3, ToyState.view.entries(state(4)))
+      b5 <- src.advanceWork(b4, ToyState.view.entries(state(5)))
+
+      // the cell is untouched...
+      stillAt2 <- src.committed
+
+      // ...and an independent chain that COMMITS each step derives identical breadcrumbs
+      other <- source(5)
+      cOther <- other.committed
+    } yield
+      expect.all(
+        stillAt2.ordinal == ord(2),
+        b5 == cOther.breadcrumb,
+        b4.ordinal == ord(4)
+      )
+  }
+}

--- a/src/test/scala/lifecycle/committed/CommittedProofSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedProofSuite.scala
@@ -16,7 +16,7 @@ import weaver.SimpleIOSuite
 /**
  * Proof-surface tests: single-key / batch / namespace-prefix proofs against the committed MPT root
  * (verified with the existing verifiers AND through the JLVM's `mpt_prefix_verify` hex formats),
- * plus SMT catalog membership (current + historical) and first-class NON-membership.
+ * plus the TOP catalog name proofs and the ordinal attestations of the epoch rollup.
  */
 object CommittedProofSuite extends SimpleIOSuite {
   import ToyFixtures._
@@ -81,29 +81,22 @@ object CommittedProofSuite extends SimpleIOSuite {
     } yield expect.all(complete == Right(BoolValue(true)), incomplete == Right(BoolValue(false)))
   }
 
-  test("SMT catalog: current + historical membership, and NON-membership of an absent ordinal") {
+  test("TOP catalog: current:mpt binds the state-dict root; an unknown family is provably absent") {
     for {
       st <- CommittedState.make[IO, ToyState](s0)
-      c1 <- st.setCommitted(ord(1), s1)
+      _  <- st.setCommitted(ord(1), s1)
       c2 <- st.setCommitted(ord(2), s2)
       verifier = SparseMerkleVerifier.make[IO]
 
       currentProof <- c2.proveCatalog(CommitCatalog.CurrentMptName).flatMap(IO.fromEither(_))
-      current      <- verifier.verify(c2.roots.smtRoot, currentProof).flatMap(IO.fromEither(_))
+      current      <- verifier.verify(c2.roots.catalogRoot, currentProof).flatMap(IO.fromEither(_))
 
-      historicalProof <- c2.proveCatalog(CommitCatalog.ordinalName(ord(1))).flatMap(IO.fromEither(_))
-      historical      <- verifier.verify(c2.roots.smtRoot, historicalProof).flatMap(IO.fromEither(_))
-
-      absentProof <- c2.proveCatalog(CommitCatalog.ordinalName(ord(999999))).flatMap(IO.fromEither(_))
-      absent      <- verifier.verify(c2.roots.smtRoot, absentProof).flatMap(IO.fromEither(_))
+      absentProof <- c2.proveCatalog("shadow:poseidon").flatMap(IO.fromEither(_))
+      absent      <- verifier.verify(c2.roots.catalogRoot, absentProof).flatMap(IO.fromEither(_))
     } yield
       expect.all(
         current.value match {
           case SparseMerkleEntry.Present(_, value) => value.sameElements(CommitCatalog.rootValueBytes(c2.roots.mptRoot))
-          case _                                   => false
-        },
-        historical.value match {
-          case SparseMerkleEntry.Present(_, value) => value.sameElements(CommitCatalog.rootValueBytes(c1.roots.mptRoot))
           case _                                   => false
         },
         absentProof.isInstanceOf[SparseMerkleProof.Absence],
@@ -112,5 +105,41 @@ object CommittedProofSuite extends SimpleIOSuite {
           case _                           => false
         }
       )
+  }
+
+  test("ordinal attestations: historical membership at every ordinal, and NON-membership of an absent one") {
+    for {
+      st           <- CommittedState.make[IO, ToyState](s0)
+      c1           <- st.setCommitted(ord(1), s1)
+      c2           <- st.setCommitted(ord(2), s2)
+      genesisRoots <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed).map(_.roots)
+
+      p0 <- c2.proveOrdinal(ord(0)).flatMap(IO.fromEither(_))
+      a0 <- OrdinalCatalogProofVerifier.verify[IO](c2.roots.catalogRoot, p0, CommittedConfig.DefaultEpochSize).flatMap(IO.fromEither(_))
+
+      p1 <- c2.proveOrdinal(ord(1)).flatMap(IO.fromEither(_))
+      a1 <- OrdinalCatalogProofVerifier.verify[IO](c2.roots.catalogRoot, p1, CommittedConfig.DefaultEpochSize).flatMap(IO.fromEither(_))
+
+      pAbsent <- c2.proveOrdinal(ord(999999)).flatMap(IO.fromEither(_))
+      aAbsent <- OrdinalCatalogProofVerifier
+        .verify[IO](c2.roots.catalogRoot, pAbsent, CommittedConfig.DefaultEpochSize)
+        .flatMap(IO.fromEither(_))
+    } yield
+      expect.all(
+        a0 == OrdinalAttestation.CommittedAt(0L, genesisRoots.mptRoot),
+        a1 == OrdinalAttestation.CommittedAt(1L, c1.roots.mptRoot),
+        aAbsent == OrdinalAttestation.NotCommitted(999999L)
+      )
+  }
+
+  test("ordinal proof JSON round-trips (route payload format)") {
+    for {
+      st    <- CommittedState.make[IO, ToyState](s0)
+      _     <- st.setCommitted(ord(1), s1)
+      c     <- st.committed
+      proof <- c.proveOrdinal(ord(0)).flatMap(IO.fromEither(_))
+      decoded = proof.asJson.as[OrdinalCatalogProof]
+      // SparseMerkleProof.Inclusion carries Array[Byte] (reference equality); compare re-encoded JSON
+    } yield expect(decoded.map(_.asJson) == Right(proof.asJson))
   }
 }

--- a/src/test/scala/lifecycle/committed/CommittedProofSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedProofSuite.scala
@@ -2,11 +2,7 @@ package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 
 import cats.effect.IO
 
-import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{
-  MerklePatriciaBatchInclusionVerifier,
-  MerklePatriciaVerifier,
-  PathNotFound
-}
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{MerklePatriciaBatchInclusionVerifier, MerklePatriciaVerifier, PathNotFound}
 import io.constellationnetwork.metagraph_sdk.crypto.smt.api.SparseMerkleVerifier
 import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleEntry, SparseMerkleProof}
 import io.constellationnetwork.metagraph_sdk.json_logic.core.{BoolValue, JsonLogicValue, MapValue, StrValue}
@@ -54,10 +50,11 @@ object CommittedProofSuite extends SimpleIOSuite {
       c     <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
       proof <- c.attestNamespace(CommitNamespace.unsafe("fiber")).flatMap(IO.fromEither(_))
       ok    <- MerklePatriciaBatchInclusionVerifier.make[IO](c.roots.mptRoot).confirm(proof)
-    } yield expect.all(
-      ok.isRight,
-      proof.paths.toSet == Set(CommitKey.unsafe("fiber/aaa").toHex, CommitKey.unsafe("fiber/bbb").toHex)
-    )
+    } yield
+      expect.all(
+        ok.isRight,
+        proof.paths.toSet == Set(CommitKey.unsafe("fiber/aaa").toHex, CommitKey.unsafe("fiber/bbb").toHex)
+      )
   }
 
   test("namespace attestation is JLVM mpt_prefix_verify compatible (0x-prefixed hex formats)") {
@@ -77,7 +74,7 @@ object CommittedProofSuite extends SimpleIOSuite {
         entriesJlv,
         jlv(proof.asJson)
       )
-      complete   <- AuthDbOps.mptPrefixVerify[IO](args)
+      complete <- AuthDbOps.mptPrefixVerify[IO](args)
       incomplete <- AuthDbOps.mptPrefixVerify[IO](
         args.updated(2, MapValue(entriesJlv.value - CommitKey.unsafe("fiber/bbb").toHex.value))
       )
@@ -99,20 +96,21 @@ object CommittedProofSuite extends SimpleIOSuite {
 
       absentProof <- c2.proveCatalog(CommitCatalog.ordinalName(ord(999999))).flatMap(IO.fromEither(_))
       absent      <- verifier.verify(c2.roots.smtRoot, absentProof).flatMap(IO.fromEither(_))
-    } yield expect.all(
-      current.value match {
-        case SparseMerkleEntry.Present(_, value) => value.sameElements(CommitCatalog.rootValueBytes(c2.roots.mptRoot))
-        case _                                   => false
-      },
-      historical.value match {
-        case SparseMerkleEntry.Present(_, value) => value.sameElements(CommitCatalog.rootValueBytes(c1.roots.mptRoot))
-        case _                                   => false
-      },
-      absentProof.isInstanceOf[SparseMerkleProof.Absence],
-      absent.value match {
-        case SparseMerkleEntry.Absent(_) => true
-        case _                           => false
-      }
-    )
+    } yield
+      expect.all(
+        current.value match {
+          case SparseMerkleEntry.Present(_, value) => value.sameElements(CommitCatalog.rootValueBytes(c2.roots.mptRoot))
+          case _                                   => false
+        },
+        historical.value match {
+          case SparseMerkleEntry.Present(_, value) => value.sameElements(CommitCatalog.rootValueBytes(c1.roots.mptRoot))
+          case _                                   => false
+        },
+        absentProof.isInstanceOf[SparseMerkleProof.Absence],
+        absent.value match {
+          case SparseMerkleEntry.Absent(_) => true
+          case _                           => false
+        }
+      )
   }
 }

--- a/src/test/scala/lifecycle/committed/CommittedProofSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedProofSuite.scala
@@ -1,0 +1,118 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.crypto.mpt.api.{
+  MerklePatriciaBatchInclusionVerifier,
+  MerklePatriciaVerifier,
+  PathNotFound
+}
+import io.constellationnetwork.metagraph_sdk.crypto.smt.api.SparseMerkleVerifier
+import io.constellationnetwork.metagraph_sdk.crypto.smt.{SparseMerkleEntry, SparseMerkleProof}
+import io.constellationnetwork.metagraph_sdk.json_logic.core.{BoolValue, JsonLogicValue, MapValue, StrValue}
+import io.constellationnetwork.metagraph_sdk.json_logic.ops.AuthDbOps
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+import weaver.SimpleIOSuite
+
+/**
+ * Proof-surface tests: single-key / batch / namespace-prefix proofs against the committed MPT root
+ * (verified with the existing verifiers AND through the JLVM's `mpt_prefix_verify` hex formats),
+ * plus SMT catalog membership (current + historical) and first-class NON-membership.
+ */
+object CommittedProofSuite extends SimpleIOSuite {
+  import ToyFixtures._
+
+  private def ord(n: Long): SnapshotOrdinal = SnapshotOrdinal.unsafeApply(n)
+
+  private val s0 = ToyState(Map("aaa" -> 1, "bbb" -> 2), Map("alpha" -> "x"))
+  private val s1 = ToyState(Map("aaa" -> 5, "bbb" -> 2), Map("alpha" -> "x"))
+  private val s2 = ToyState(Map("aaa" -> 5, "bbb" -> 9), Map("alpha" -> "x", "beta" -> "y"))
+
+  test("single-key proof verifies against the committed mptRoot; absent key is PathNotFound") {
+    for {
+      c       <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      proof   <- c.proveKey(CommitKey.unsafe("fiber/aaa")).flatMap(IO.fromEither(_))
+      ok      <- MerklePatriciaVerifier.make[IO](c.roots.mptRoot).confirm(proof)
+      missing <- c.proveKey(CommitKey.unsafe("fiber/zzz"))
+    } yield expect.all(ok.isRight, missing.left.exists(_.isInstanceOf[PathNotFound]))
+  }
+
+  test("batch proof covers all requested keys and verifies") {
+    val keys = List(CommitKey.unsafe("fiber/aaa"), CommitKey.unsafe("registry/alpha"))
+    for {
+      c     <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      proof <- c.proveKeys(keys).flatMap(IO.fromEither(_))
+      ok    <- MerklePatriciaBatchInclusionVerifier.make[IO](c.roots.mptRoot).confirm(proof)
+    } yield expect.all(ok.isRight, proof.paths.toSet == keys.map(_.toHex).toSet)
+  }
+
+  test("namespace attestation covers exactly the namespace's keys and verifies") {
+    for {
+      c     <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      proof <- c.attestNamespace(CommitNamespace.unsafe("fiber")).flatMap(IO.fromEither(_))
+      ok    <- MerklePatriciaBatchInclusionVerifier.make[IO](c.roots.mptRoot).confirm(proof)
+    } yield expect.all(
+      ok.isRight,
+      proof.paths.toSet == Set(CommitKey.unsafe("fiber/aaa").toHex, CommitKey.unsafe("fiber/bbb").toHex)
+    )
+  }
+
+  test("namespace attestation is JLVM mpt_prefix_verify compatible (0x-prefixed hex formats)") {
+    val ns = CommitNamespace.unsafe("fiber")
+    val entries = ToyState.view.entries(s0).filter { case (k, _) => k.namespace == "fiber" }
+
+    def jlv(json: Json): JsonLogicValue =
+      json.as[JsonLogicValue].fold(e => throw new RuntimeException(s"bad bridge: $e"), identity)
+
+    for {
+      c     <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      proof <- c.attestNamespace(ns).flatMap(IO.fromEither(_))
+      entriesJlv = MapValue(entries.map { case (k, v) => k.toHex.value -> jlv(v) }.toMap)
+      args = List[JsonLogicValue](
+        StrValue("0x" + c.roots.mptRoot.value),
+        StrValue("0x" + ns.prefixHex.value),
+        entriesJlv,
+        jlv(proof.asJson)
+      )
+      complete   <- AuthDbOps.mptPrefixVerify[IO](args)
+      incomplete <- AuthDbOps.mptPrefixVerify[IO](
+        args.updated(2, MapValue(entriesJlv.value - CommitKey.unsafe("fiber/bbb").toHex.value))
+      )
+    } yield expect.all(complete == Right(BoolValue(true)), incomplete == Right(BoolValue(false)))
+  }
+
+  test("SMT catalog: current + historical membership, and NON-membership of an absent ordinal") {
+    for {
+      st <- CommittedState.make[IO, ToyState](s0)
+      c1 <- st.setCommitted(ord(1), s1)
+      c2 <- st.setCommitted(ord(2), s2)
+      verifier = SparseMerkleVerifier.make[IO]
+
+      currentProof <- c2.proveCatalog(CommitCatalog.CurrentMptName).flatMap(IO.fromEither(_))
+      current      <- verifier.verify(c2.roots.smtRoot, currentProof).flatMap(IO.fromEither(_))
+
+      historicalProof <- c2.proveCatalog(CommitCatalog.ordinalName(ord(1))).flatMap(IO.fromEither(_))
+      historical      <- verifier.verify(c2.roots.smtRoot, historicalProof).flatMap(IO.fromEither(_))
+
+      absentProof <- c2.proveCatalog(CommitCatalog.ordinalName(ord(999999))).flatMap(IO.fromEither(_))
+      absent      <- verifier.verify(c2.roots.smtRoot, absentProof).flatMap(IO.fromEither(_))
+    } yield expect.all(
+      current.value match {
+        case SparseMerkleEntry.Present(_, value) => value.sameElements(CommitCatalog.rootValueBytes(c2.roots.mptRoot))
+        case _                                   => false
+      },
+      historical.value match {
+        case SparseMerkleEntry.Present(_, value) => value.sameElements(CommitCatalog.rootValueBytes(c1.roots.mptRoot))
+        case _                                   => false
+      },
+      absentProof.isInstanceOf[SparseMerkleProof.Absence],
+      absent.value match {
+        case SparseMerkleEntry.Absent(_) => true
+        case _                           => false
+      }
+    )
+  }
+}

--- a/src/test/scala/lifecycle/committed/CommittedReplicationSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedReplicationSuite.scala
@@ -1,0 +1,112 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import io.circe.Json
+import weaver.SimpleIOSuite
+
+/**
+ * Replication contract: a verifying replica seeded from a snapshot follows the StateDelta stream
+ * with byte-identical roots at every step, rejects tampered or out-of-order deltas, and falls back
+ * to the snapshot route once the source's ring buffer has evicted what it missed.
+ */
+object CommittedReplicationSuite extends SimpleIOSuite {
+  import ToyFixtures._
+
+  private def ord(n: Long): SnapshotOrdinal = SnapshotOrdinal.unsafeApply(n)
+
+  private val s0 = ToyState(Map("aaa" -> 1, "bbb" -> 2), Map("alpha" -> "x"))
+
+  private val stream = List(
+    ToyState(Map("aaa" -> 5, "bbb" -> 2), Map("alpha" -> "x")),                              // modify
+    ToyState(Map("aaa" -> 5), Map("alpha" -> "x", "beta" -> "y")),                           // remove + add
+    ToyState(Map("aaa" -> 5, "ccc" -> 7), Map("beta" -> "y"))                                // add + remove
+  )
+
+  test("a replica applying the delta stream matches the source's roots at every step") {
+    for {
+      source  <- CommittedState.make[IO, ToyState](s0)
+      genesis <- source.committed
+      replica <- CommittedReplica.fromSnapshot[IO](genesis.snapshot).flatMap(IO.fromEither(_))
+
+      result <- stream.zipWithIndex.foldLeftM((replica, List.empty[Boolean])) {
+        case ((rep, acc), (s, i)) =>
+          for {
+            c     <- source.setCommitted(ord(i.toLong + 1), s)
+            delta <- IO.fromOption(c.deltaFor(ord(i.toLong + 1)))(new RuntimeException("delta missing"))
+            next  <- rep.applyDelta(delta).flatMap(IO.fromEither(_))
+          } yield (next, acc :+ (next.roots == c.roots && next.ordinal == c.ordinal))
+      }
+    } yield expect(result._2.forall(identity))
+  }
+
+  test("a tampered delta is rejected (modified upsert, dropped remove, forged roots)") {
+    for {
+      source  <- CommittedState.make[IO, ToyState](s0)
+      genesis <- source.committed
+      replica <- CommittedReplica.fromSnapshot[IO](genesis.snapshot).flatMap(IO.fromEither(_))
+      c1      <- source.setCommitted(ord(1), stream(1))
+      delta   <- IO.fromOption(c1.deltaFor(ord(1)))(new RuntimeException("delta missing"))
+
+      tamperedValue = delta.copy(upserts = delta.upserts.map { case (k, _) => k -> Json.fromString("evil") })
+      tamperedRemoves = delta.copy(removes = delta.removes.take(0))
+      forgedRoots = delta.copy(roots = delta.roots.copy(mptRoot = genesis.roots.mptRoot))
+
+      r1 <- replica.applyDelta(tamperedValue)
+      r2 <- replica.applyDelta(tamperedRemoves)
+      r3 <- replica.applyDelta(forgedRoots)
+      ok <- replica.applyDelta(delta)
+    } yield expect.all(
+      r1.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
+      r2.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
+      r3.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
+      ok.isRight
+    )
+  }
+
+  test("a delta that does not chain from the replica's roots is rejected") {
+    for {
+      source  <- CommittedState.make[IO, ToyState](s0)
+      genesis <- source.committed
+      replica <- CommittedReplica.fromSnapshot[IO](genesis.snapshot).flatMap(IO.fromEither(_))
+      _       <- source.setCommitted(ord(1), stream.head)
+      c2      <- source.setCommitted(ord(2), stream(1))
+      delta2  <- IO.fromOption(c2.deltaFor(ord(2)))(new RuntimeException("delta missing"))
+      skipped <- replica.applyDelta(delta2) // replica never saw ordinal 1
+    } yield expect(skipped.left.exists(_.isInstanceOf[ReplicationError.ParentRootsMismatch]))
+  }
+
+  test("a snapshot that does not reproduce its claimed roots is rejected") {
+    for {
+      genesis <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      forged = genesis.snapshot.copy(entries = genesis.snapshot.entries - CommitKey.unsafe("fiber/aaa"))
+      result <- CommittedReplica.fromSnapshot[IO](forged)
+    } yield expect(result.left.exists(_.isInstanceOf[ReplicationError.SnapshotRootsMismatch]))
+  }
+
+  test("ring-buffer eviction forces the snapshot fallback, after which the stream resumes") {
+    for {
+      source  <- CommittedState.make[IO, ToyState](s0, maxRecentDeltas = 1)
+      genesis <- source.committed
+      replica <- CommittedReplica.fromSnapshot[IO](genesis.snapshot).flatMap(IO.fromEither(_))
+
+      _  <- source.setCommitted(ord(1), stream.head)
+      _  <- source.setCommitted(ord(2), stream(1))
+      c3 <- source.setCommitted(ord(3), stream(2))
+
+      // the replica is at genesis; the delta it needs (ordinal 1) has been evicted
+      evicted = c3.deltaFor(ord(1)).isEmpty
+
+      // fallback: rebuild from the source's current snapshot (verified against its roots)
+      refreshed <- CommittedReplica.fromSnapshot[IO](c3.snapshot).flatMap(IO.fromEither(_))
+
+      // ...and the stream resumes from there
+      c4     <- source.setCommitted(ord(4), s0)
+      delta4 <- IO.fromOption(c4.deltaFor(ord(4)))(new RuntimeException("delta missing"))
+      next   <- refreshed.applyDelta(delta4).flatMap(IO.fromEither(_))
+    } yield expect.all(evicted, refreshed.roots == c3.roots, next.roots == c4.roots)
+  }
+}

--- a/src/test/scala/lifecycle/committed/CommittedReplicationSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedReplicationSuite.scala
@@ -21,9 +21,9 @@ object CommittedReplicationSuite extends SimpleIOSuite {
   private val s0 = ToyState(Map("aaa" -> 1, "bbb" -> 2), Map("alpha" -> "x"))
 
   private val stream = List(
-    ToyState(Map("aaa" -> 5, "bbb" -> 2), Map("alpha" -> "x")),                              // modify
-    ToyState(Map("aaa" -> 5), Map("alpha" -> "x", "beta" -> "y")),                           // remove + add
-    ToyState(Map("aaa" -> 5, "ccc" -> 7), Map("beta" -> "y"))                                // add + remove
+    ToyState(Map("aaa" -> 5, "bbb" -> 2), Map("alpha" -> "x")), // modify
+    ToyState(Map("aaa" -> 5), Map("alpha" -> "x", "beta" -> "y")), // remove + add
+    ToyState(Map("aaa" -> 5, "ccc" -> 7), Map("beta" -> "y")) // add + remove
   )
 
   test("a replica applying the delta stream matches the source's roots at every step") {
@@ -59,12 +59,13 @@ object CommittedReplicationSuite extends SimpleIOSuite {
       r2 <- replica.applyDelta(tamperedRemoves)
       r3 <- replica.applyDelta(forgedRoots)
       ok <- replica.applyDelta(delta)
-    } yield expect.all(
-      r1.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
-      r2.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
-      r3.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
-      ok.isRight
-    )
+    } yield
+      expect.all(
+        r1.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
+        r2.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
+        r3.left.exists(_.isInstanceOf[ReplicationError.MptRootMismatch]),
+        ok.isRight
+      )
   }
 
   test("a delta that does not chain from the replica's roots is rejected") {

--- a/src/test/scala/lifecycle/committed/CommittedReplicationSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedReplicationSuite.scala
@@ -10,8 +10,9 @@ import weaver.SimpleIOSuite
 
 /**
  * Replication contract: a verifying replica seeded from a snapshot follows the StateDelta stream
- * with byte-identical roots at every step, rejects tampered or out-of-order deltas, and falls back
- * to the snapshot route once the source's ring buffer has evicted what it missed.
+ * with byte-identical roots at every step (including across epoch-seal boundaries), rejects
+ * tampered or out-of-order deltas, and falls back to the snapshot route once the source's ring
+ * buffer has evicted what it missed.
  */
 object CommittedReplicationSuite extends SimpleIOSuite {
   import ToyFixtures._
@@ -26,11 +27,14 @@ object CommittedReplicationSuite extends SimpleIOSuite {
     ToyState(Map("aaa" -> 5, "ccc" -> 7), Map("beta" -> "y")) // add + remove
   )
 
+  private def snapshotOf(c: Committed[IO, ToyState]): CommittedSnapshot =
+    c.snapshot.getOrElse(throw new RuntimeException("hydrated source expected"))
+
   test("a replica applying the delta stream matches the source's roots at every step") {
     for {
       source  <- CommittedState.make[IO, ToyState](s0)
       genesis <- source.committed
-      replica <- CommittedReplica.fromSnapshot[IO](genesis.snapshot).flatMap(IO.fromEither(_))
+      replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
 
       result <- stream.zipWithIndex.foldLeftM((replica, List.empty[Boolean])) {
         case ((rep, acc), (s, i)) =>
@@ -43,11 +47,35 @@ object CommittedReplicationSuite extends SimpleIOSuite {
     } yield expect(result._2.forall(identity))
   }
 
+  test("a replica follows across an epoch-seal boundary with identical roots") {
+    val config = CommittedConfig(epochSize = 2, sealedEpochRetention = 2)
+    val states = (1 to 6).toList.map(i => ToyState(Map("aaa" -> i), Map.empty))
+    for {
+      source  <- CommittedState.make[IO, ToyState](s0, config)
+      genesis <- source.committed
+      replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis), config).flatMap(IO.fromEither(_))
+
+      result <- states.zipWithIndex.foldLeftM((replica, List.empty[Boolean])) {
+        case ((rep, acc), (s, i)) =>
+          for {
+            c     <- source.setCommitted(ord(i.toLong + 1), s)
+            delta <- IO.fromOption(c.deltaFor(ord(i.toLong + 1)))(new RuntimeException("delta missing"))
+            next  <- rep.applyDelta(delta).flatMap(IO.fromEither(_))
+          } yield (next, acc :+ (next.roots == c.roots))
+      }
+      (finalReplica, checks) = result
+    } yield
+      expect.all(
+        checks.forall(identity),
+        finalReplica.epochs.level1Entries.keySet == Set(0L, 1L) // the replica sealed the same epochs
+      )
+  }
+
   test("a tampered delta is rejected (modified upsert, dropped remove, forged roots)") {
     for {
       source  <- CommittedState.make[IO, ToyState](s0)
       genesis <- source.committed
-      replica <- CommittedReplica.fromSnapshot[IO](genesis.snapshot).flatMap(IO.fromEither(_))
+      replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
       c1      <- source.setCommitted(ord(1), stream(1))
       delta   <- IO.fromOption(c1.deltaFor(ord(1)))(new RuntimeException("delta missing"))
 
@@ -68,11 +96,23 @@ object CommittedReplicationSuite extends SimpleIOSuite {
       )
   }
 
+  test("a forged catalog root is rejected by the replica's local recomputation") {
+    for {
+      source  <- CommittedState.make[IO, ToyState](s0)
+      genesis <- source.committed
+      replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
+      c1      <- source.setCommitted(ord(1), stream.head)
+      delta   <- IO.fromOption(c1.deltaFor(ord(1)))(new RuntimeException("delta missing"))
+      forged = delta.copy(roots = delta.roots.copy(catalogRoot = genesis.roots.catalogRoot))
+      result <- replica.applyDelta(forged)
+    } yield expect(result.left.exists(_.isInstanceOf[ReplicationError.CatalogRootMismatch]))
+  }
+
   test("a delta that does not chain from the replica's roots is rejected") {
     for {
       source  <- CommittedState.make[IO, ToyState](s0)
       genesis <- source.committed
-      replica <- CommittedReplica.fromSnapshot[IO](genesis.snapshot).flatMap(IO.fromEither(_))
+      replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
       _       <- source.setCommitted(ord(1), stream.head)
       c2      <- source.setCommitted(ord(2), stream(1))
       delta2  <- IO.fromOption(c2.deltaFor(ord(2)))(new RuntimeException("delta missing"))
@@ -83,16 +123,16 @@ object CommittedReplicationSuite extends SimpleIOSuite {
   test("a snapshot that does not reproduce its claimed roots is rejected") {
     for {
       genesis <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
-      forged = genesis.snapshot.copy(entries = genesis.snapshot.entries - CommitKey.unsafe("fiber/aaa"))
+      forged = snapshotOf(genesis).copy(entries = snapshotOf(genesis).entries - CommitKey.unsafe("fiber/aaa"))
       result <- CommittedReplica.fromSnapshot[IO](forged)
     } yield expect(result.left.exists(_.isInstanceOf[ReplicationError.SnapshotRootsMismatch]))
   }
 
   test("ring-buffer eviction forces the snapshot fallback, after which the stream resumes") {
     for {
-      source  <- CommittedState.make[IO, ToyState](s0, maxRecentDeltas = 1)
+      source  <- CommittedState.make[IO, ToyState](s0, CommittedConfig(maxRecentDeltas = 1))
       genesis <- source.committed
-      replica <- CommittedReplica.fromSnapshot[IO](genesis.snapshot).flatMap(IO.fromEither(_))
+      replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
 
       _  <- source.setCommitted(ord(1), stream.head)
       _  <- source.setCommitted(ord(2), stream(1))
@@ -102,7 +142,7 @@ object CommittedReplicationSuite extends SimpleIOSuite {
       evicted = c3.deltaFor(ord(1)).isEmpty
 
       // fallback: rebuild from the source's current snapshot (verified against its roots)
-      refreshed <- CommittedReplica.fromSnapshot[IO](c3.snapshot).flatMap(IO.fromEither(_))
+      refreshed <- CommittedReplica.fromSnapshot[IO](snapshotOf(c3)).flatMap(IO.fromEither(_))
 
       // ...and the stream resumes from there
       c4     <- source.setCommitted(ord(4), s0)

--- a/src/test/scala/lifecycle/committed/CommittedStateSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedStateSuite.scala
@@ -12,8 +12,9 @@ import weaver.SimpleIOSuite
 
 /**
  * Core invariants of the committed-state cell: canonical roots regardless of construction order,
- * delta-application byte-identical to the full rebuild (the `setCalculatedState` assertion),
- * the documented combined-hash definition, loud failure on wiring bugs, and ring-buffer eviction.
+ * delta-application byte-identical to the full rebuild (the `setCalculatedState` assertion), the
+ * documented combined-hash definition over the LIVE catalog, per-ordinal catalog evolution, loud
+ * failure on wiring bugs, and ring-buffer eviction.
  */
 object CommittedStateSuite extends SimpleIOSuite {
   import ToyFixtures._
@@ -33,9 +34,7 @@ object CommittedStateSuite extends SimpleIOSuite {
     for {
       c1 <- CommittedState.make[IO, ToyState](a).flatMap(_.committed)
       c2 <- CommittedState.make[IO, ToyState](b).flatMap(_.committed)
-      h1 <- CommittedCommitment.deriveHash[IO, ToyState](a)
-      h2 <- CommittedCommitment.deriveHash[IO, ToyState](b)
-    } yield expect.all(c1.roots == c2.roots, h1 == h2)
+    } yield expect.all(c1.roots == c2.roots, c1.roots.combinedHash == c2.roots.combinedHash)
   }
 
   test("delta-apply == full rebuild (and equals a fresh genesis at the new state)") {
@@ -56,32 +55,57 @@ object CommittedStateSuite extends SimpleIOSuite {
       st        <- CommittedState.make[IO, ToyState](ToyState.empty)
       c1        <- st.setCommitted(ord(1), s0)
       c2        <- st.setCommitted(ord(2), ToyState.empty)
-      derived   <- CommittedCommitment.deriveRoots[IO, ToyState](s0)
+      derived   <- CommittedCommitment.buildTrie[IO](ToyState.view.entries(s0))
       emptyTrie <- CommittedCommitment.emptyTrie[IO]
     } yield
       expect.all(
-        c1.roots.mptRoot == derived.mptRoot,
+        c1.roots.mptRoot == derived.rootNode.digest,
         c2.roots.mptRoot == emptyTrie.rootNode.digest
       )
   }
 
-  test("combined hash is sha256(rawBytes(mptRoot) ++ rawBytes(smtRoot)) over the canonical pair") {
-    for {
-      roots <- CommittedCommitment.deriveRoots[IO, ToyState](s0)
-      h     <- CommittedCommitment.deriveHash[IO, ToyState](s0)
-      manual = Hash.fromBytes(Hex(roots.mptRoot.value).toBytes ++ Hex(roots.smtRoot.value.value).toBytes)
-    } yield expect.all(h == manual, h == roots.combinedHash)
-  }
-
-  test("hashCalculatedState derivation is pure in the value: independent of local history") {
+  test("combined hash is sha256(rawBytes(mptRoot) ++ rawBytes(liveCatalogRoot))") {
     for {
       st <- CommittedState.make[IO, ToyState](s0)
-      _  <- st.setCommitted(ord(1), s1)
-      _  <- st.setCommitted(ord(2), s0)
-      // a node with history at s0 and a node that has only ever seen s0 agree
-      hWithHistory <- st.committed.flatMap(c => CommittedCommitment.deriveHash[IO, ToyState](c.state))
-      hFresh       <- CommittedCommitment.deriveHash[IO, ToyState](s0)
-    } yield expect(hWithHistory == hFresh)
+      c1 <- st.setCommitted(ord(1), s1)
+      manual = Hash.fromBytes(Hex(c1.roots.mptRoot.value).toBytes ++ Hex(c1.roots.catalogRoot.value.value).toBytes)
+    } yield expect(c1.roots.combinedHash == manual)
+  }
+
+  test("the live catalog COMMITS history: same state value at different ordinals -> different catalog roots") {
+    for {
+      st <- CommittedState.make[IO, ToyState](s0)
+      c1 <- st.setCommitted(ord(1), s1)
+      c2 <- st.setCommitted(ord(2), s0) // back to the s0 VALUE, but with two ordinals of history
+      g  <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+    } yield
+      expect.all(
+        c2.roots.mptRoot == g.roots.mptRoot, // tier 1 is pure in the value
+        c2.roots.catalogRoot != g.roots.catalogRoot, // tier 2 commits history
+        c1.roots.catalogRoot != c2.roots.catalogRoot, // and evolves every ordinal
+        c2.roots.combinedHash != g.roots.combinedHash
+      )
+  }
+
+  test("hashFor on the steady-state path equals the next transition's combined hash") {
+    for {
+      st <- CommittedState.make[IO, ToyState](s0)
+      h  <- st.hashFor(s1, None) // cell at genesis = parent of ordinal 1
+      c1 <- st.setCommitted(ord(1), s1)
+    } yield expect(h == c1.roots.combinedHash)
+  }
+
+  test("re-committing the same ordinal is idempotent for the same value and refused for a different one") {
+    for {
+      st     <- CommittedState.make[IO, ToyState](s0)
+      c1     <- st.setCommitted(ord(1), s1)
+      again  <- st.setCommitted(ord(1), s1)
+      forged <- st.setCommitted(ord(1), s0).attempt
+    } yield
+      expect.all(
+        again.roots == c1.roots,
+        forged.left.exists(_.isInstanceOf[CommittedStateError.CommitRewrite])
+      )
   }
 
   test("a lying CommittedView.delta is a wiring bug: setCommitted raises RootDivergence") {
@@ -91,7 +115,7 @@ object CommittedStateSuite extends SimpleIOSuite {
     }
 
     for {
-      st <- CommittedState.make[IO, ToyState](s0, CommittedState.DefaultMaxRecentDeltas)(
+      st <- CommittedState.make[IO, ToyState](s0, CommittedConfig.default)(
         IO.asyncForIO,
         JsonBinaryHasher.deriveFromCodec[IO],
         lyingView
@@ -109,7 +133,7 @@ object CommittedStateSuite extends SimpleIOSuite {
     )
 
     for {
-      st <- CommittedState.make[IO, ToyState](s0, maxRecentDeltas = 2)
+      st <- CommittedState.make[IO, ToyState](s0, CommittedConfig(maxRecentDeltas = 2))
       _  <- states.zipWithIndex.traverse { case (s, i) => st.setCommitted(ord(i.toLong + 1), s) }
       c  <- st.committed
     } yield

--- a/src/test/scala/lifecycle/committed/CommittedStateSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedStateSuite.scala
@@ -44,10 +44,11 @@ object CommittedStateSuite extends SimpleIOSuite {
       c1      <- st.setCommitted(ord(1), s1)
       derived <- CommittedCommitment.buildTrie[IO](ToyState.view.entries(s1))
       fresh   <- CommittedState.make[IO, ToyState](s1).flatMap(_.committed)
-    } yield expect.all(
-      c1.roots.mptRoot == derived.rootNode.digest,
-      c1.roots.mptRoot == fresh.roots.mptRoot
-    )
+    } yield
+      expect.all(
+        c1.roots.mptRoot == derived.rootNode.digest,
+        c1.roots.mptRoot == fresh.roots.mptRoot
+      )
   }
 
   test("empty <-> nonempty boundary stays canonical in both directions") {
@@ -57,10 +58,11 @@ object CommittedStateSuite extends SimpleIOSuite {
       c2        <- st.setCommitted(ord(2), ToyState.empty)
       derived   <- CommittedCommitment.deriveRoots[IO, ToyState](s0)
       emptyTrie <- CommittedCommitment.emptyTrie[IO]
-    } yield expect.all(
-      c1.roots.mptRoot == derived.mptRoot,
-      c2.roots.mptRoot == emptyTrie.rootNode.digest
-    )
+    } yield
+      expect.all(
+        c1.roots.mptRoot == derived.mptRoot,
+        c2.roots.mptRoot == emptyTrie.rootNode.digest
+      )
   }
 
   test("combined hash is sha256(rawBytes(mptRoot) ++ rawBytes(smtRoot)) over the canonical pair") {
@@ -110,13 +112,14 @@ object CommittedStateSuite extends SimpleIOSuite {
       st <- CommittedState.make[IO, ToyState](s0, maxRecentDeltas = 2)
       _  <- states.zipWithIndex.traverse { case (s, i) => st.setCommitted(ord(i.toLong + 1), s) }
       c  <- st.committed
-    } yield expect.all(
-      c.recentDeltas.size == 2,
-      c.deltaFor(ord(1)).isEmpty,
-      c.deltaFor(ord(2)).isEmpty,
-      c.deltaFor(ord(3)).nonEmpty,
-      c.deltaFor(ord(4)).nonEmpty
-    )
+    } yield
+      expect.all(
+        c.recentDeltas.size == 2,
+        c.deltaFor(ord(1)).isEmpty,
+        c.deltaFor(ord(2)).isEmpty,
+        c.deltaFor(ord(3)).nonEmpty,
+        c.deltaFor(ord(4)).nonEmpty
+      )
   }
 
   pureTest("CommitKey grammar: valid keys parse, invalid keys are rejected") {

--- a/src/test/scala/lifecycle/committed/CommittedStateSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedStateSuite.scala
@@ -1,0 +1,146 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.metagraph_sdk.std.JsonBinaryHasher
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+
+import weaver.SimpleIOSuite
+
+/**
+ * Core invariants of the committed-state cell: canonical roots regardless of construction order,
+ * delta-application byte-identical to the full rebuild (the `setCalculatedState` assertion),
+ * the documented combined-hash definition, loud failure on wiring bugs, and ring-buffer eviction.
+ */
+object CommittedStateSuite extends SimpleIOSuite {
+  import ToyFixtures._
+
+  private def ord(n: Long): SnapshotOrdinal = SnapshotOrdinal.unsafeApply(n)
+
+  private val s0 = ToyState(Map("aaa" -> 1, "bbb" -> 2), Map("alpha" -> "x"))
+  // vs s0: modifies fiber/aaa, removes fiber/bbb, adds fiber/ccc and registry/beta
+  private val s1 = ToyState(Map("aaa" -> 5, "ccc" -> 3), Map("alpha" -> "x", "beta" -> "y"))
+
+  test("root determinism: same logical state in different construction orders yields the same roots") {
+    // Small immutable Maps (Map1..Map4) iterate in INSERTION order, so these two genuinely
+    // enumerate differently while being equal as maps.
+    val a = ToyState(Map("k1" -> 1, "k2" -> 2, "k3" -> 3, "k4" -> 4), Map("r" -> "v"))
+    val b = ToyState(Map("k4" -> 4, "k3" -> 3, "k2" -> 2, "k1" -> 1), Map("r" -> "v"))
+
+    for {
+      c1 <- CommittedState.make[IO, ToyState](a).flatMap(_.committed)
+      c2 <- CommittedState.make[IO, ToyState](b).flatMap(_.committed)
+      h1 <- CommittedCommitment.deriveHash[IO, ToyState](a)
+      h2 <- CommittedCommitment.deriveHash[IO, ToyState](b)
+    } yield expect.all(c1.roots == c2.roots, h1 == h2)
+  }
+
+  test("delta-apply == full rebuild (and equals a fresh genesis at the new state)") {
+    for {
+      st      <- CommittedState.make[IO, ToyState](s0)
+      c1      <- st.setCommitted(ord(1), s1)
+      derived <- CommittedCommitment.buildTrie[IO](ToyState.view.entries(s1))
+      fresh   <- CommittedState.make[IO, ToyState](s1).flatMap(_.committed)
+    } yield expect.all(
+      c1.roots.mptRoot == derived.rootNode.digest,
+      c1.roots.mptRoot == fresh.roots.mptRoot
+    )
+  }
+
+  test("empty <-> nonempty boundary stays canonical in both directions") {
+    for {
+      st        <- CommittedState.make[IO, ToyState](ToyState.empty)
+      c1        <- st.setCommitted(ord(1), s0)
+      c2        <- st.setCommitted(ord(2), ToyState.empty)
+      derived   <- CommittedCommitment.deriveRoots[IO, ToyState](s0)
+      emptyTrie <- CommittedCommitment.emptyTrie[IO]
+    } yield expect.all(
+      c1.roots.mptRoot == derived.mptRoot,
+      c2.roots.mptRoot == emptyTrie.rootNode.digest
+    )
+  }
+
+  test("combined hash is sha256(rawBytes(mptRoot) ++ rawBytes(smtRoot)) over the canonical pair") {
+    for {
+      roots <- CommittedCommitment.deriveRoots[IO, ToyState](s0)
+      h     <- CommittedCommitment.deriveHash[IO, ToyState](s0)
+      manual = Hash.fromBytes(Hex(roots.mptRoot.value).toBytes ++ Hex(roots.smtRoot.value.value).toBytes)
+    } yield expect.all(h == manual, h == roots.combinedHash)
+  }
+
+  test("hashCalculatedState derivation is pure in the value: independent of local history") {
+    for {
+      st <- CommittedState.make[IO, ToyState](s0)
+      _  <- st.setCommitted(ord(1), s1)
+      _  <- st.setCommitted(ord(2), s0)
+      // a node with history at s0 and a node that has only ever seen s0 agree
+      hWithHistory <- st.committed.flatMap(c => CommittedCommitment.deriveHash[IO, ToyState](c.state))
+      hFresh       <- CommittedCommitment.deriveHash[IO, ToyState](s0)
+    } yield expect(hWithHistory == hFresh)
+  }
+
+  test("a lying CommittedView.delta is a wiring bug: setCommitted raises RootDivergence") {
+    val lyingView: CommittedView[ToyState] = new CommittedView[ToyState] {
+      def entries(s: ToyState) = ToyState.view.entries(s)
+      override def delta(prev: ToyState, next: ToyState): CommitDelta = CommitDelta.empty
+    }
+
+    for {
+      st <- CommittedState.make[IO, ToyState](s0, CommittedState.DefaultMaxRecentDeltas)(
+        IO.asyncForIO,
+        JsonBinaryHasher.deriveFromCodec[IO],
+        lyingView
+      )
+      result <- st.setCommitted(ord(1), s1).attempt
+    } yield expect(result.left.exists(_.isInstanceOf[CommittedStateError.RootDivergence]))
+  }
+
+  test("recentDeltas is a ring buffer: old ordinals evict, recent ones remain") {
+    val states = List(
+      ToyState(Map("aaa" -> 1), Map.empty),
+      ToyState(Map("aaa" -> 2), Map.empty),
+      ToyState(Map("aaa" -> 3), Map.empty),
+      ToyState(Map("aaa" -> 4), Map.empty)
+    )
+
+    for {
+      st <- CommittedState.make[IO, ToyState](s0, maxRecentDeltas = 2)
+      _  <- states.zipWithIndex.traverse { case (s, i) => st.setCommitted(ord(i.toLong + 1), s) }
+      c  <- st.committed
+    } yield expect.all(
+      c.recentDeltas.size == 2,
+      c.deltaFor(ord(1)).isEmpty,
+      c.deltaFor(ord(2)).isEmpty,
+      c.deltaFor(ord(3)).nonEmpty,
+      c.deltaFor(ord(4)).nonEmpty
+    )
+  }
+
+  pureTest("CommitKey grammar: valid keys parse, invalid keys are rejected") {
+    expect.all(
+      CommitKey.from("fiber/0e2f7c1a-aaaa-bbbb-cccc-000000000001").isRight,
+      CommitKey.from("registry/tokens/dag").isRight,
+      CommitKey.from("meta/schema.v1").isRight,
+      CommitKey.from("").isLeft,
+      CommitKey.from("Fiber/abc").isLeft,
+      CommitKey.from("fiber//abc").isLeft,
+      CommitKey.from("/fiber").isLeft,
+      CommitKey.from("fiber/").isLeft,
+      CommitKey.from("fiber/_bad").isLeft,
+      CommitKey.from("a" * 300).isLeft,
+      CommitKey.from(List.fill(17)("a").mkString("/")).isLeft
+    )
+  }
+
+  pureTest("CommitNamespace prefix is segment-exact (trailing separator)") {
+    val ns = CommitNamespace.unsafe("fiber")
+    expect.all(
+      ns.prefixHex == CommitKey.hexOf("fiber/"),
+      CommitKey.unsafe("fiber/abc").toHex.value.startsWith(ns.prefixHex.value),
+      !CommitKey.unsafe("fiberx/abc").toHex.value.startsWith(ns.prefixHex.value)
+    )
+  }
+}

--- a/src/test/scala/lifecycle/committed/EpochCatalogSuite.scala
+++ b/src/test/scala/lifecycle/committed/EpochCatalogSuite.scala
@@ -122,8 +122,8 @@ object EpochCatalogSuite extends SimpleIOSuite {
     for {
       r <- driveTo(3, config)
       (st, _) = r
-      c     <- st.committed
-      proof <- c.proveOrdinal(ord(999)).flatMap(IO.fromEither(_)) // absence proof, epoch keyed by size 2
+      c      <- st.committed
+      proof  <- c.proveOrdinal(ord(999)).flatMap(IO.fromEither(_)) // absence proof, epoch keyed by size 2
       result <- OrdinalCatalogProofVerifier.verify[IO](c.roots.catalogRoot, proof, 3)
     } yield expect(result.isLeft)
   }
@@ -136,7 +136,7 @@ object EpochCatalogSuite extends SimpleIOSuite {
       cAtFour = cs(4)
       oldProof <- cAtFour.proveOrdinal(ord(0)).flatMap(IO.fromEither(_))
 
-      c5 <- st.setCommitted(ord(5), state(5)) // seals epoch 1 -> retention evicts epoch 0's tree
+      c5           <- st.setCommitted(ord(5), state(5)) // seals epoch 1 -> retention evicts epoch 0's tree
       freshAttempt <- c5.proveOrdinal(ord(0))
 
       epochs5 = epochsOf(c5)
@@ -149,7 +149,7 @@ object EpochCatalogSuite extends SimpleIOSuite {
       expect.all(
         freshAttempt.left.exists(_.isInstanceOf[CommittedProofError.EpochPruned]),
         epochs5.level1Entries.keySet == Set(0L, 1L), // roots never pruned
-        epochs5.sealedTrees.keySet == Set(1L),       // serving cache pruned to last K
+        epochs5.sealedTrees.keySet == Set(1L), // serving cache pruned to last K
         oldStillValid == OrdinalAttestation.CommittedAt(0L, cs(0).roots.mptRoot)
       )
   }

--- a/src/test/scala/lifecycle/committed/EpochCatalogSuite.scala
+++ b/src/test/scala/lifecycle/committed/EpochCatalogSuite.scala
@@ -1,0 +1,191 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+
+import weaver.SimpleIOSuite
+
+/**
+ * The two-level epoch rollup: boundary sealing, composition, ancient-ordinal proofs (two
+ * fixed-depth inclusions), non-membership at both levels, retention pruning ("serving, not
+ * trust"), and contents round-trips.
+ */
+object EpochCatalogSuite extends SimpleIOSuite {
+  import ToyFixtures._
+
+  private def ord(n: Long): SnapshotOrdinal = SnapshotOrdinal.unsafeApply(n)
+
+  private def state(i: Int): ToyState = ToyState(Map("aaa" -> i), Map.empty)
+
+  /** Drive a fresh committed cell through ordinals 1..n (committing state(i) at ordinal i). */
+  private def driveTo(n: Int, config: CommittedConfig): IO[(CommittedState[IO, ToyState], Vector[Committed[IO, ToyState]])] =
+    for {
+      st <- CommittedState.make[IO, ToyState](state(0), config)
+      g  <- st.committed
+      cs <- (1 to n).toList.traverse(i => st.setCommitted(ord(i.toLong), state(i)))
+    } yield (st, g +: cs.toVector)
+
+  private def epochsOf(c: Committed[IO, ToyState]): EpochCatalog[IO] =
+    c.catalog.live.map(_.epochs).getOrElse(throw new RuntimeException("expected a hydrated catalog"))
+
+  test("hot epoch fills until the boundary, then seals into level-1 and resets") {
+    val config = CommittedConfig(epochSize = 4, sealedEpochRetention = 4)
+    for {
+      r <- driveTo(5, config)
+      (_, cs) = r
+      atFour = epochsOf(cs(4)) // catalog holds ordinals 0..3 (epoch 0 complete, not yet sealed)
+      atFive = epochsOf(cs(5)) // inserting ordinal 4 sealed epoch 0
+    } yield
+      expect.all(
+        atFour.hotEntries.keySet == Set(0L, 1L, 2L, 3L),
+        atFour.level1Entries.isEmpty,
+        atFive.hotEntries.keySet == Set(4L),
+        atFive.level1Entries.keySet == Set(0L),
+        atFive.epochIndex == 1L,
+        atFive.sealedTrees.keySet == Set(0L)
+      )
+  }
+
+  test("the sealed level-1 entry is exactly the pre-seal hot root") {
+    val config = CommittedConfig(epochSize = 4)
+    for {
+      r <- driveTo(5, config)
+      (_, cs) = r
+      preSealHotRoot <- epochsOf(cs(4)).hotTree.root
+      sealedEntry = epochsOf(cs(5)).level1Entries.get(0L)
+    } yield expect(sealedEntry.contains(preSealHotRoot.value))
+  }
+
+  test("hot-ordinal proof: inclusion verifies to the committed MPT root") {
+    val config = CommittedConfig(epochSize = 4)
+    for {
+      r <- driveTo(3, config)
+      (st, cs) = r
+      c     <- st.committed
+      proof <- c.proveOrdinal(ord(2)).flatMap(IO.fromEither(_))
+      result <- OrdinalCatalogProofVerifier
+        .verify[IO](c.roots.catalogRoot, proof, config.epochSize)
+        .flatMap(IO.fromEither(_))
+    } yield expect(result == OrdinalAttestation.CommittedAt(2L, cs(2).roots.mptRoot))
+  }
+
+  test("ancient-ordinal proof: two fixed-depth inclusions through level-1 and the sealed epoch tree") {
+    val config = CommittedConfig(epochSize = 4)
+    for {
+      r <- driveTo(7, config) // epoch 0 (ordinals 0..3) sealed; hot = {4,5,6}
+      (st, cs) = r
+      c     <- st.committed
+      proof <- c.proveOrdinal(ord(1)).flatMap(IO.fromEither(_))
+      result <- OrdinalCatalogProofVerifier
+        .verify[IO](c.roots.catalogRoot, proof, config.epochSize)
+        .flatMap(IO.fromEither(_))
+    } yield
+      expect.all(
+        proof.sealedEntry.nonEmpty,
+        result == OrdinalAttestation.CommittedAt(1L, cs(1).roots.mptRoot)
+      )
+  }
+
+  test("non-membership: an uncommitted ordinal is provably absent at both levels") {
+    val config = CommittedConfig(epochSize = 2)
+    for {
+      r <- driveTo(3, config) // catalog holds ordinals 0..2
+      (st, _) = r
+      c     <- st.committed
+      proof <- c.proveOrdinal(ord(999)).flatMap(IO.fromEither(_))
+      result <- OrdinalCatalogProofVerifier
+        .verify[IO](c.roots.catalogRoot, proof, config.epochSize)
+        .flatMap(IO.fromEither(_))
+    } yield expect(result == OrdinalAttestation.NotCommitted(999L))
+  }
+
+  test("a tampered inclusion is rejected by the verifier") {
+    val config = CommittedConfig(epochSize = 4)
+    for {
+      r <- driveTo(3, config)
+      (st, _) = r
+      c     <- st.committed
+      proof <- c.proveOrdinal(ord(2)).flatMap(IO.fromEither(_))
+      tampered = proof.hot match {
+        case i: io.constellationnetwork.metagraph_sdk.crypto.smt.SparseMerkleProof.Inclusion =>
+          proof.copy(hot = i.copy(value = i.value.map(b => (b ^ 0x01).toByte)))
+        case other => proof.copy(hot = other)
+      }
+      result <- OrdinalCatalogProofVerifier.verify[IO](c.roots.catalogRoot, tampered, config.epochSize)
+    } yield expect(result.left.exists(_.isInstanceOf[CommittedProofError.ProofInvalid]))
+  }
+
+  test("a wrong epochSize cannot be smuggled past the verifier (keys are recomputed locally)") {
+    val config = CommittedConfig(epochSize = 2)
+    for {
+      r <- driveTo(3, config)
+      (st, _) = r
+      c     <- st.committed
+      proof <- c.proveOrdinal(ord(999)).flatMap(IO.fromEither(_)) // absence proof, epoch keyed by size 2
+      result <- OrdinalCatalogProofVerifier.verify[IO](c.roots.catalogRoot, proof, 3)
+    } yield expect(result.isLeft)
+  }
+
+  test("retention prunes SERVING of old sealed epochs; committed roots and old proofs stay verifiable") {
+    val config = CommittedConfig(epochSize = 2, sealedEpochRetention = 1)
+    for {
+      r <- driveTo(4, config) // epoch 0 sealed (at transition to 3), retained (only seal so far)
+      (st, cs) = r
+      cAtFour = cs(4)
+      oldProof <- cAtFour.proveOrdinal(ord(0)).flatMap(IO.fromEither(_))
+
+      c5 <- st.setCommitted(ord(5), state(5)) // seals epoch 1 -> retention evicts epoch 0's tree
+      freshAttempt <- c5.proveOrdinal(ord(0))
+
+      epochs5 = epochsOf(c5)
+
+      // the proof issued before pruning still verifies against the roots it attested
+      oldStillValid <- OrdinalCatalogProofVerifier
+        .verify[IO](cAtFour.roots.catalogRoot, oldProof, config.epochSize)
+        .flatMap(IO.fromEither(_))
+    } yield
+      expect.all(
+        freshAttempt.left.exists(_.isInstanceOf[CommittedProofError.EpochPruned]),
+        epochs5.level1Entries.keySet == Set(0L, 1L), // roots never pruned
+        epochs5.sealedTrees.keySet == Set(1L),       // serving cache pruned to last K
+        oldStillValid == OrdinalAttestation.CommittedAt(0L, cs(0).roots.mptRoot)
+      )
+  }
+
+  test("catalog contents round-trip: rebuild composes to identical roots") {
+    val config = CommittedConfig(epochSize = 2, sealedEpochRetention = 2)
+    for {
+      r <- driveTo(5, config)
+      (st, _) = r
+      c <- st.committed
+      contents = c.catalogContents.getOrElse(throw new RuntimeException("hydrated catalog expected"))
+      rebuilt  <- EpochCatalog.fromContents[IO](config, contents).flatMap(IO.fromEither(_))
+      composed <- rebuilt.compose(c.roots.mptRoot)
+    } yield expect(composed._2 == c.roots.catalogRoot)
+  }
+
+  test("tampered contents are rejected structurally or by root comparison") {
+    val config = CommittedConfig(epochSize = 2, sealedEpochRetention = 2)
+    for {
+      r <- driveTo(5, config)
+      (st, _) = r
+      c <- st.committed
+      contents = c.catalogContents.getOrElse(throw new RuntimeException("hydrated catalog expected"))
+      // a sealed epoch whose contents do not reproduce its level-1 root is rejected outright
+      tamperedSealed = contents.copy(
+        sealedEpochs = contents.sealedEpochs.map { case (e, m) => e -> (m - m.firstKey) }
+      )
+      structural <- EpochCatalog.fromContents[IO](config, tamperedSealed)
+      // a tampered HOT entry rebuilds fine but recomposes to a different root
+      tamperedHot = contents.copy(hot = contents.hot.map { case (o, _) => o -> c.roots.mptRoot })
+      rebuilt  <- EpochCatalog.fromContents[IO](config, tamperedHot).flatMap(IO.fromEither(_))
+      composed <- rebuilt.compose(c.roots.mptRoot)
+    } yield
+      expect.all(
+        structural.left.exists(_.isInstanceOf[CommittedStateError.MalformedCatalogContents]),
+        composed._2 != c.roots.catalogRoot
+      )
+  }
+}

--- a/src/test/scala/lifecycle/committed/ToyFixtures.scala
+++ b/src/test/scala/lifecycle/committed/ToyFixtures.scala
@@ -24,7 +24,7 @@ object ToyFixtures {
       def entries(s: ToyState): SortedMap[CommitKey, Json] =
         SortedMap.from(
           s.fibers.map { case (id, v) => CommitKey.unsafe(s"fiber/$id") -> Json.obj("count" -> v.asJson) } ++
-            s.registry.map { case (n, v) => CommitKey.unsafe(s"registry/$n") -> Json.fromString(v) }
+          s.registry.map { case (n, v) => CommitKey.unsafe(s"registry/$n") -> Json.fromString(v) }
         )
     }
 

--- a/src/test/scala/lifecycle/committed/ToyFixtures.scala
+++ b/src/test/scala/lifecycle/committed/ToyFixtures.scala
@@ -1,0 +1,59 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.currency.dataApplication.{DataCalculatedState, DataOnChainState, DataUpdate}
+
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, Json}
+
+/**
+ * A toy application state with a `CommittedView`, plus tessellation-typed wrappers for exercising
+ * `CommittedApp.makeL0`. Lives in the production package so suites can reach the package-private
+ * assembly internals (`CommittedState.make`) for white-box tests.
+ */
+object ToyFixtures {
+
+  final case class ToyState(fibers: Map[String, Int], registry: Map[String, String])
+
+  object ToyState {
+    val empty: ToyState = ToyState(Map.empty, Map.empty)
+
+    implicit val view: CommittedView[ToyState] = new CommittedView[ToyState] {
+
+      def entries(s: ToyState): SortedMap[CommitKey, Json] =
+        SortedMap.from(
+          s.fibers.map { case (id, v) => CommitKey.unsafe(s"fiber/$id") -> Json.obj("count" -> v.asJson) } ++
+            s.registry.map { case (n, v) => CommitKey.unsafe(s"registry/$n") -> Json.fromString(v) }
+        )
+    }
+
+    implicit val encoder: Encoder[ToyState] = Encoder.forProduct2("fibers", "registry")(s => (s.fibers, s.registry))
+    implicit val decoder: Decoder[ToyState] = Decoder.forProduct2("fibers", "registry")(ToyState.apply)
+  }
+
+  final case class ToyTx(value: Int) extends DataUpdate
+
+  object ToyTx {
+    implicit val encoder: Encoder[ToyTx] = Encoder.forProduct1("value")(_.value)
+    implicit val decoder: Decoder[ToyTx] = Decoder.forProduct1("value")(ToyTx(_))
+  }
+
+  final case class ToyPub(updateCount: Int) extends DataOnChainState
+
+  object ToyPub {
+    implicit val encoder: Encoder[ToyPub] = Encoder.forProduct1("updateCount")(_.updateCount)
+    implicit val decoder: Decoder[ToyPub] = Decoder.forProduct1("updateCount")(ToyPub(_))
+  }
+
+  final case class ToyPrv(state: ToyState) extends DataCalculatedState
+
+  object ToyPrv {
+    implicit val encoder: Encoder[ToyPrv] = Encoder.forProduct1("state")(_.state)
+    implicit val decoder: Decoder[ToyPrv] = Decoder.forProduct1("state")(ToyPrv(_))
+
+    implicit val view: CommittedView[ToyPrv] = new CommittedView[ToyPrv] {
+      def entries(s: ToyPrv): SortedMap[CommitKey, Json] = ToyState.view.entries(s.state)
+    }
+  }
+}


### PR DESCRIPTION
Implements the agreed state-root commitment design (2026-06-10, incl. the breadcrumb redesign): two-tier commitment with **consensus-anchored history**.

- **CommittedView[S]**: dev writes one pure `entries(s): SortedMap[CommitKey, Json]` (namespaced keys per `docs/committed-namespaces.md`).
- **Committed live catalog**: `hashCalculatedState = sha256(mptRoot ‖ liveCatalogRoot)` — history is consensus-bound; inclusion AND non-membership of any past ordinal verify against the signed tip.
- **Two-level epoch rollup**: hot epoch SMT + level-1 SMT of sealed epoch roots (`epochSize` config, default 2^16, consensus-critical); ancient proofs = two fixed-depth inclusions with verifier-recomputed keys; LevelDB-persisted journal (restart-tested).
- **Constant onchain breadcrumb** `(ordinal, mptRoot, catalogRoot)` per snapshot — makeL0 owns the `CommittedOnChain[PUB]` wrapper + serializers (dev can't omit/forge); followers reject forged transitions in combine; `setCalculatedState` cross-checks the signed snapshot's breadcrumb.
- **O(1) fresh-node bootstrap** (Ethereum-header model): mapped onto tessellation's actual orderings — steady-state hashes derive from the cell; Download verifies the fetched value against the snapshot's attested breadcrumb and adopts the roots; hydration of catalog contents is verify-gated. Flagged tessellation gap: no peer-aux-data hook during download, so catalog hydration wires at app level (ottochain follow-up); un-hydrated nodes verify but raise loudly on combine.
- **Retention = serving, not trust**: `sealedEpochRetention` config; pruned epochs 410 on serving, all proofs remain verifiable against committed roots.
- Correct-by-construction assembly (private cell, `CommittedApp.makeL0` only path, `RootDivergence` assert), routes pack, verifying `CommittedReplica`, JLVM `mpt_prefix_verify` compatibility tested end-to-end.

**59 committed-module tests / 6 suites; full suite 1094/1094 green.**

Follow-up PRs: ottochain adapter (ML0Service → makeL0 + CommittedView[CalculatedState] + hydration wiring), CommittedReplica HTTP polling for ML0_B slice consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)