### PR TITLE
docs+test(content-hash): normative dropNulls-before-RFC8785 rule

### DIFF
--- a/docs/content-hash.md
+++ b/docs/content-hash.md
@@ -1,0 +1,84 @@
+# Content-Hash Rule (normative)
+
+Every hashing or signing surface that operates on **typed content** — data
+updates, on-chain / calculated state, MPT leaf values, anything whose digest
+or signature another party will recompute from a decoded value — MUST derive
+its bytes as:
+
+```
+bytes = utf8( RFC8785( dropNulls( encode(content) ) ) )
+```
+
+where `dropNulls` is `JsonBinaryCodec.dropNulls`:
+
+1. **Recursively remove null-valued OBJECT fields.** `{"a": 1, "b": null}`
+   hashes as `{"a": 1}` — at every nesting level.
+2. **PRESERVE nulls inside arrays.** `[1, null, 3]` keeps its null; removing
+   it would shift indices and change the meaning of positional data.
+3. **Then canonicalize** with the RFC 8785 canonicalizer
+   (`JsonCanonicalizer`) and take the UTF-8 bytes.
+
+In metakit this is applied internally by both `JsonBinaryCodec` derivations
+(`derive` and `deriveDataUpdate`), so every surface routed through
+`JsonBinaryCodec.serialize`, `JsonBinaryHasher.computeDigest`, or
+`SignatureProtocol.proveSigned`/`verifySigned` is covered automatically —
+including the MPT/SMT node digests and the `lifecycle/committed` state-dict
+leaves built on top of `JsonBinaryHasher`.
+
+## Why drop nulls?
+
+**Schema evolution.** In circe, `Option[A] = None` encodes as an explicit
+`null` field, while a sender that never knew the field omits it entirely.
+Dropping null object fields makes `None ≡ absent`:
+
+- Adding an `Option` field to a schema does **not** change the hash of any
+  previously committed value (old data decodes with `None`, re-encodes with
+  `null`, and the null is dropped — bytes identical to before the field
+  existed).
+- A client that omits optional fields and a node that re-serializes the
+  decoded value with explicit nulls agree on the bytes, so signatures verify.
+
+## The layer distinction (value vs. typed content)
+
+There are TWO canonicalization layers in the stack. Do not conflate them:
+
+| Layer | Role | Null object fields |
+|---|---|---|
+| **Value canonicalizer** (JLVM: Rust `canonical.rs`, TS evaluator output, Scala `JsonCanonicalizer` / `CanonicalJson.from`) | Deterministic rendering of a *JSON Logic value* — null is a real, first-class value the program may have computed | **preserved** |
+| **Typed-content hash** (`JsonBinaryCodec` / `JsonBinaryHasher` and every signing surface) | Bytes whose digest/signature is recomputed from a *decoded typed value* | **dropped** (this document) |
+
+`JsonCanonicalizer` and `CanonicalJson.from`/`fromJson` are therefore raw,
+null-preserving primitives. Never feed their output directly into a hash or
+signature of typed content — go through the codec.
+
+## Cautionary tale: the 2026-06-10 e2e incident
+
+After the metakit `1.7.0-rc.9 → 1.8.0-rc.1` bump, **every ottochain e2e
+scenario failed at step 1** with HTTP 400 from the DL1 `/data` endpoint.
+
+Root cause: metakit 1.8 restored drop-nulls-before-canonicalize in
+`JsonBinaryCodec.serialize` — the bytes `DataApplicationRoutes` hashes to
+verify signature proofs. The e2e client (and external SDK consumers) signed
+over raw RFC 8785 canonical JSON that still contained explicit nulls
+(`"parentFiberId": null`, `"initialState": null`, `"metadata"`/`"effect":
+null` inside fixture definitions) — a shape deliberately aligned to metakit
+1.7's no-drop canonical form. The node dropped the nulls, the client did
+not, the hashes diverged, and every signature verification failed
+(`InvalidSignature → BadRequest`).
+
+The lesson: the drop-nulls rule is only safe if it is applied **universally
+and internally** — by every signer, hasher, and verifier, on every surface,
+in every language — never as an opt-in pre-processing step the caller has to
+remember.
+
+## Conformance checklist for a new hash/sign surface
+
+- [ ] Bytes come from `JsonBinaryCodec.serialize` (or an equivalent that
+      applies `dropNulls` before RFC 8785) — not from `JsonCanonicalizer` /
+      `CanonicalJson.from` directly.
+- [ ] `hash(value with explicit nulls) == hash(value with those fields
+      absent)` is pinned by a test.
+- [ ] Array nulls are preserved (pinned by a test).
+- [ ] Cross-language consumers (TS `@ottochain/sdk` `dropNulls`, Rust
+      `jlvm-core` content hash) produce byte-identical results for a shared
+      fixture.

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/models/package.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/models/package.scala
@@ -18,9 +18,22 @@ package object models {
 
   object CanonicalJson {
 
+    /**
+     * RAW RFC 8785 canonicalization — does NOT drop null object fields.
+     *
+     * This is the value-layer primitive (nulls are preserved as real values).
+     * Do NOT use it to produce bytes for typed-content hashing or signing:
+     * those surfaces must apply the drop-nulls rule first. Route typed
+     * content through `JsonBinaryCodec.serialize` / `JsonBinaryHasher`
+     * instead. See `docs/content-hash.md`.
+     */
     def from[F[_]: MonadThrow, A: Encoder](content: A): F[CanonicalJson] =
       JsonCanonicalizer.make[F].canonicalize(content)
 
+    /**
+     * RAW RFC 8785 canonicalization — does NOT drop null object fields.
+     * See [[from]] for when this is (and is not) appropriate.
+     */
     def fromJson[F[_]: MonadThrow](json: Json): F[CanonicalJson] =
       JsonCanonicalizer.make[F].canonicalize(json)
 

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/JsonBinaryCodec.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/JsonBinaryCodec.scala
@@ -84,20 +84,30 @@ object JsonBinaryCodec {
   /**
    * Recursively removes null values from JSON objects.
    *
+   * This is the normative first step of the content-hash rule (see
+   * `docs/content-hash.md`): drop null OBJECT fields recursively, then
+   * RFC 8785 canonicalize. Every typed-content hashing/signing surface in
+   * the stack MUST apply this transformation; it is applied internally by
+   * both codec derivations in this object, so anything routed through
+   * `JsonBinaryCodec.serialize` / `JsonBinaryHasher.computeDigest` is
+   * covered automatically.
+   *
    * This ensures that Option[T] fields encoded as null by Circe are omitted
    * from the canonical representation, matching the behavior of JSON serializers
    * that omit undefined/null fields (e.g., TypeScript's JSON.stringify with
    * replacer, or Circe's dropNullValues printer).
    *
-   * This is important for signature compatibility: the sender may omit optional
-   * fields entirely, while the receiver's decoder fills them with None (encoded
-   * as null). Without dropping nulls, the re-encoded JSON would differ from the
-   * original, causing signature verification to fail.
+   * This is important for signature compatibility and schema evolution: the
+   * sender may omit optional fields entirely, while the receiver's decoder
+   * fills them with None (encoded as null). Without dropping nulls, the
+   * re-encoded JSON would differ from the original, causing signature
+   * verification to fail — and adding an `Option` field to a schema would
+   * retroactively change the hashes of previously committed data.
    *
    * Note: null values inside arrays are preserved to maintain index positions.
    * Only object field values that are null are removed.
    */
-  private def dropNulls(json: Json): Json =
+  def dropNulls(json: Json): Json =
     json.arrayOrObject(
       json,
       arr => Json.fromValues(arr.map(dropNulls)),

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/std/JsonCanonicalizer.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/std/JsonCanonicalizer.scala
@@ -25,6 +25,17 @@ import io.constellationnetwork.metagraph_sdk.models.CanonicalJson
 import io.circe._
 import io.circe.syntax.EncoderOps
 
+/**
+ * RAW RFC 8785 canonicalizer — the value layer. Nulls are REAL values here:
+ * this layer preserves null object fields (the JLVM value canonicalizers in
+ * Rust/TS behave identically).
+ *
+ * Typed-content hashing/signing MUST NOT call this directly: the normative
+ * content-hash rule (`docs/content-hash.md`) prepends
+ * `JsonBinaryCodec.dropNulls`. Route typed content through
+ * `JsonBinaryCodec.serialize` / `JsonBinaryHasher.computeDigest`, which apply
+ * drop-nulls internally before delegating here.
+ */
 trait JsonCanonicalizer[F[_]] {
   def canonicalize[A: Encoder](content: A): F[CanonicalJson]
 }

--- a/src/test/scala/lifecycle/committed/CommittedCommitmentSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedCommitmentSuite.scala
@@ -1,0 +1,63 @@
+package io.constellationnetwork.metagraph_sdk.lifecycle.committed
+
+import cats.effect.IO
+
+import scala.collection.immutable.SortedMap
+
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+import weaver.SimpleIOSuite
+
+/**
+ * Pins the content-hash rule (docs/content-hash.md) on the committed state-dict: entry values reach
+ * the MPT leaves through `JsonBinaryHasher` -> `JsonBinaryCodec.serialize`, which drops null OBJECT
+ * fields (and preserves array nulls) before RFC 8785 canonicalization. Therefore a `CommittedView`
+ * that projects `Option = None` leaves as explicit nulls commits to the SAME root as one that omits
+ * the fields -- adding optional fields to a projection never changes prior roots.
+ */
+object CommittedCommitmentSuite extends SimpleIOSuite {
+
+  private def entries(pairs: (String, Json)*): SortedMap[CommitKey, Json] =
+    SortedMap.from(pairs.map { case (k, v) => CommitKey.unsafe(k) -> v })
+
+  test("explicit-null entry fields commit to the same MPT root as absent fields") {
+    val withNulls = entries(
+      "fiber/aaa"      -> Json.obj("count" -> 1.asJson, "metadata" -> Json.Null),
+      "registry/alpha" -> Json.obj("v" -> "x".asJson, "note" -> Json.Null, "inner" -> Json.obj("opt" -> Json.Null))
+    )
+    val withoutNulls = entries(
+      "fiber/aaa"      -> Json.obj("count" -> 1.asJson),
+      "registry/alpha" -> Json.obj("v" -> "x".asJson, "inner" -> Json.obj())
+    )
+
+    for {
+      trieWith    <- CommittedCommitment.buildTrie[IO](withNulls)
+      trieWithout <- CommittedCommitment.buildTrie[IO](withoutNulls)
+    } yield expect.same(trieWithout.rootNode.digest, trieWith.rootNode.digest)
+  }
+
+  test("array nulls in entry values are significant (different root)") {
+    val a = entries("fiber/aaa" -> Json.obj("xs" -> Json.arr(1.asJson, Json.Null, 3.asJson)))
+    val b = entries("fiber/aaa" -> Json.obj("xs" -> Json.arr(1.asJson, 3.asJson)))
+
+    for {
+      trieA <- CommittedCommitment.buildTrie[IO](a)
+      trieB <- CommittedCommitment.buildTrie[IO](b)
+    } yield expect(trieA.rootNode.digest != trieB.rootNode.digest)
+  }
+
+  test("applyDelta with null-containing upserts matches the full rebuild over dropped-equivalent entries") {
+    val base = entries("fiber/aaa" -> Json.obj("count" -> 1.asJson))
+    val upsertWithNull = Json.obj("count" -> 2.asJson, "metadata" -> Json.Null)
+    val upsertAbsent = Json.obj("count" -> 2.asJson)
+
+    for {
+      trie0 <- CommittedCommitment.buildTrie[IO](base)
+      viaDelta <- CommittedCommitment.applyDelta[IO](
+        trie0,
+        CommitDelta(entries("fiber/aaa" -> upsertWithNull), scala.collection.immutable.SortedSet.empty)
+      )
+      rebuilt <- CommittedCommitment.buildTrie[IO](entries("fiber/aaa" -> upsertAbsent))
+    } yield expect.same(rebuilt.rootNode.digest, viaDelta.rootNode.digest)
+  }
+}

--- a/src/test/scala/std/JsonBinaryCodecSuite.scala
+++ b/src/test/scala/std/JsonBinaryCodecSuite.scala
@@ -250,4 +250,29 @@ object JsonBinaryCodecSuite extends SimpleIOSuite with Checkers {
       expect(ex.getMessage.contains("64"))
     )
   }
+
+  // --- Public dropNulls semantics (docs/content-hash.md) ---
+
+  test("dropNulls removes null object fields recursively but preserves array nulls") {
+    for {
+      json <- IO.fromEither(
+        io.circe.parser.parse("""{"a":1,"b":null,"c":{"d":null,"e":[{"f":null,"g":2},null]}}""")
+      )
+      expected <- IO.fromEither(io.circe.parser.parse("""{"a":1,"c":{"e":[{"g":2},null]}}"""))
+    } yield expect.same(expected, JsonBinaryCodec.dropNulls(json))
+  }
+
+  test("serialize bytes for explicit-null and absent fields are identical") {
+    val withNone = TestDataComplex("test", 42, None)
+    for {
+      bytesNone <- withNone.toBinary
+      // a hand-built JSON with the explicit null, serialized as raw Json
+      jsonWithNull <- IO.fromEither(
+        io.circe.parser.parse("""{"id":"test","value":42,"nested":null}""")
+      )
+      bytesNull <- JsonBinaryCodec[IO, io.circe.Json].serialize(jsonWithNull)
+      strNone = new String(bytesNone, StandardCharsets.UTF_8)
+      strNull = new String(bytesNull, StandardCharsets.UTF_8)
+    } yield expect.same(strNone, strNull)
+  }
 }

--- a/src/test/scala/std/JsonBinaryHasherSuite.scala
+++ b/src/test/scala/std/JsonBinaryHasherSuite.scala
@@ -176,4 +176,54 @@ object JsonBinaryHasherSuite extends SimpleIOSuite with Checkers {
       testData.computeDigest.attempt.map(result => expect(result.isRight))
     }
   }
+
+  // --- Content-hash rule: dropNulls before RFC 8785 (docs/content-hash.md) ---
+
+  test("explicit-null object fields hash identically to absent fields") {
+    for {
+      withNulls    <- IO.fromEither(parser.parse("""{"a":1,"b":null,"c":{"d":null,"e":2},"f":[1,null,3]}"""))
+      withoutNulls <- IO.fromEither(parser.parse("""{"a":1,"c":{"e":2},"f":[1,null,3]}"""))
+      hashWith     <- withNulls.computeDigest
+      hashWithout  <- withoutNulls.computeDigest
+    } yield expect.same(hashWithout, hashWith)
+  }
+
+  test("absent ≡ null holds through Option fields (None vs decoded-from-absent)") {
+    // The sender omits the optional field entirely; the receiver decodes to None
+    // (encoded back as null by circe). Both must hash to the SAME digest.
+    val withNone = TestDataComplex("test", 42, None)
+    for {
+      digestNone <- withNone.computeDigest
+      // hash the circe encoding WITH its explicit null, as raw Json
+      jsonWithNull <- IO.pure(
+        Json.obj(
+          "id"     -> Json.fromString("test"),
+          "value"  -> Json.fromInt(42),
+          "nested" -> Json.Null
+        )
+      )
+      // and the same object with the field absent
+      jsonAbsent     <- IO.pure(Json.obj("id" -> Json.fromString("test"), "value" -> Json.fromInt(42)))
+      digestWithNull <- jsonWithNull.computeDigest
+      digestAbsent   <- jsonAbsent.computeDigest
+    } yield expect.same(digestAbsent, digestWithNull) && expect.same(digestAbsent, digestNone)
+  }
+
+  test("array nulls are PRESERVED (removing one changes the hash)") {
+    for {
+      withArrayNull <- IO.fromEither(parser.parse("""{"xs":[1,null,3]}"""))
+      withoutNull   <- IO.fromEither(parser.parse("""{"xs":[1,3]}"""))
+      hash1         <- withArrayNull.computeDigest
+      hash2         <- withoutNull.computeDigest
+    } yield expect(hash1 != hash2)
+  }
+
+  test("nulls nested inside array elements' objects are still dropped") {
+    for {
+      a     <- IO.fromEither(parser.parse("""{"xs":[{"k":1,"opt":null},null]}"""))
+      b     <- IO.fromEither(parser.parse("""{"xs":[{"k":1},null]}"""))
+      hashA <- a.computeDigest
+      hashB <- b.computeDigest
+    } yield expect.same(hashB, hashA)
+  }
 }

--- a/src/test/scala/std/JsonCanonicalizerSuite.scala
+++ b/src/test/scala/std/JsonCanonicalizerSuite.scala
@@ -87,4 +87,20 @@ object JsonCanonicalizerSuite extends SimpleIOSuite with Checkers {
       } yield expect.same(result1, result2)
     }
   }
+
+  // --- Layer distinction (docs/content-hash.md): this is the RAW value layer ---
+
+  test("raw canonicalizer PRESERVES null object fields (value layer — dropNulls is the codec's job)") {
+    for {
+      json      <- IO.fromEither(parser.parse("""{"b":null,"a":1}"""))
+      canonical <- json.toCanonical
+    } yield expect.same("""{"a":1,"b":null}""", canonical.value)
+  }
+
+  test("raw canonicalizer preserves array nulls") {
+    for {
+      json      <- IO.fromEither(parser.parse("""{"xs":[1,null,3]}"""))
+      canonical <- json.toCanonical
+    } yield expect.same("""{"xs":[1,null,3]}""", canonical.value)
+  }
 }


### PR DESCRIPTION
Jim's directive: drop-nulls-before-canonicalize standardized everywhere. metakit audit: all hash surfaces already compliant (codec, hasher, SignatureProtocol, CommittedState MPT leaves + raw-bytes catalog). Hardened: dropNulls made public on JsonBinaryCodec, raw-layer footgun warnings on CanonicalJson/JsonCanonicalizer, normative docs/content-hash.md (rule, semantics, layer distinction, the e2e incident), 11 new tests incl. CommittedCommitmentSuite pinning null-containing entries → identical MPT roots. 1105/1105, fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)