### PR TITLE
feat(gas): static JsonLogicGasEstimator — execution-free gas/fee quoting

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/JsonLogicGasEstimator.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/JsonLogicGasEstimator.scala
@@ -1,0 +1,168 @@
+package io.constellationnetwork.metagraph_sdk.json_logic.gas
+
+import io.constellationnetwork.metagraph_sdk.json_logic.core.JsonLogicOp._
+import io.constellationnetwork.metagraph_sdk.json_logic.core._
+
+/**
+ * Static, execution-free gas estimation over a JSON-Logic expression.
+ *
+ * Walks the expression tree and sums the per-op base cost, depth penalty, and var-access cost.
+ * It deliberately does NOT account for the input/output-SCALED components of the schedule
+ * (collection element counts, proof/witness shapes, produced string lengths, AND the variadic
+ * `(n-1)` charge on `+`/`*`/`-`). Most of these are data-dependent; a couple are statically
+ * derivable, but ALL are omitted on purpose, to keep this a pure `base + depthPenalty + varCost`
+ * walk that does not duplicate the evaluator's per-op scaling rules (no second copy to drift).
+ * Therefore `estimate` is:
+ *
+ *   - EXACT for expressions whose ops carry no scaling — the large common class: control flow,
+ *     logic, comparison, get/has/typeof, and var/const access; and
+ *   - a FLOOR (under-count) for ops that scale (arithmetic, collections, crypto, string building),
+ *     since their scaled term is omitted.
+ *
+ * Along the control-flow dimension it is conservative: lazy `if` is modelled as
+ * `base + sum(conditions) + max(values)` — the single worst branch, never the sum of all branches.
+ *
+ * The omitted scaled terms are recoverable by the caller when the data is in hand (the event
+ * payload + current state size the input collections; proof shape sizes the crypto ops); only
+ * intermediate/derived collection sizes need execution. The authoritative charge is always the
+ * metered evaluation — this is a cheap pre-flight "ballpark how much might this cost" quote that
+ * never runs the VM.
+ *
+ * The per-op cost table (`baseCost`) is the SINGLE SOURCE OF TRUTH shared with the evaluator
+ * (`GasAwareSemantics.getOpCost` delegates here), so an estimate can never drift from the real
+ * charge.
+ */
+object JsonLogicGasEstimator {
+
+  /** Flat per-op base cost. Shared by the evaluator (charge) and the estimator (quote). */
+  def baseCost(op: JsonLogicOp)(config: GasConfig): GasCost = op match {
+    case NoOp                 => GasCost.Zero
+    case MissingNoneOp        => config.exists
+    case ExistsOp             => config.exists
+    case MissingSomeOp        => config.missingSome
+    case IfElseOp             => config.ifElse
+    case LetOp                => config.ifElse // Similar cost to if/else (control flow)
+    case EqOp                 => config.eq
+    case EqStrictOp           => config.eqStrict
+    case NEqOp                => config.neq
+    case NEqStrictOp          => config.neqStrict
+    case NotOp                => config.not
+    case NOp                  => config.doubleNot
+    case OrOp                 => config.or
+    case AndOp                => config.and
+    case Lt                   => config.lt
+    case Leq                  => config.leq
+    case Gt                   => config.gt
+    case Geq                  => config.geq
+    case ModuloOp             => config.modulo
+    case MaxOp                => config.max
+    case MinOp                => config.min
+    case AddOp                => config.add
+    case TimesOp              => config.times
+    case MinusOp              => config.minus
+    case DivOp                => config.div
+    case MergeOp              => config.merge
+    case InOp                 => config.in
+    case CatOp                => config.cat
+    case SubStrOp             => config.substr
+    case MapOp                => config.map
+    case FilterOp             => config.filter
+    case ReduceOp             => config.reduce
+    case AllOp                => config.all
+    case NoneOp               => config.none
+    case SomeOp               => config.some
+    case MapValuesOp          => config.mapValues
+    case MapKeysOp            => config.mapKeys
+    case GetOp                => config.get
+    case IntersectOp          => config.intersect
+    case CountOp              => config.count
+    case LengthOp             => config.length
+    case FindOp               => config.find
+    case LowerOp              => config.lower
+    case UpperOp              => config.upper
+    case JoinOp               => config.join
+    case SplitOp              => config.split
+    case DefaultOp            => config.default
+    case UniqueOp             => config.unique
+    case SliceOp              => config.slice
+    case ReverseOp            => config.reverse
+    case FlattenOp            => config.flatten
+    case TrimOp               => config.trim
+    case StartsWithOp         => config.startsWith
+    case EndsWithOp           => config.endsWith
+    case AbsOp                => config.abs
+    case RoundOp              => config.round
+    case FloorOp              => config.floor
+    case CeilOp               => config.ceil
+    case PowOp                => config.pow
+    case HasOp                => config.has
+    case EntriesOp            => config.entries
+    case TypeOfOp             => config.typeOf
+    case PoseidonOp           => config.poseidon
+    case PmtVerifyOp          => config.pmtVerify
+    case Groth16VerifyOp      => config.groth16Verify
+    case EcVrfVerifyOp        => config.ecvrfVerify
+    case Bn254AddOp           => config.bn254Add
+    case Bn254MulOp           => config.bn254Mul
+    case Bn254PairingOp       => config.bn254Pairing
+    case BlsVerifyOp          => config.blsVerify
+    case BlsAggregateVerifyOp => config.blsAggregateVerify
+    case SchnorrVerifyOp      => config.schnorrVerify
+    case SmtVerifyOp          => config.smtVerify
+    case MptVerifyOp          => config.mptVerify
+    case MptPrefixVerifyOp    => config.mptPrefixVerify
+  }
+
+  /**
+   * Static gas estimate for `expr` under `config`. See the object doc for exactly what is and is
+   * not counted. The result's `cost` is the quote; `depth`/`opCount` are the structural metrics.
+   */
+  def estimate(expr: JsonLogicExpression, config: GasConfig): GasMetrics =
+    expr match {
+      case ConstExpression(_) =>
+        GasMetrics.zero
+
+      case VarExpression(Left(key), _) =>
+        // getVar charges varAccess + one unit per dot-path segment; no depth penalty.
+        GasMetrics(config.varAccess + GasCost(key.split("\\.").length.toLong), depth = 0, opCount = 1)
+
+      case VarExpression(Right(inner), _) =>
+        // Dynamic var key is itself an expression; the segment count is unknown, charge one unit.
+        val i = estimate(inner, config)
+        GasMetrics(config.varAccess + GasCost(1L) + i.cost, i.depth, i.opCount + 1)
+
+      case ArrayExpression(items) =>
+        items.foldLeft(GasMetrics.zero)((acc, e) => acc.combine(estimate(e, config)))
+
+      case MapExpression(fields) =>
+        fields.values.foldLeft(GasMetrics.zero)((acc, e) => acc.combine(estimate(e, config)))
+
+      case ApplyExpression(IfElseOp, args) =>
+        // Lazy control flow: every condition may run, but only ONE value branch is taken.
+        // Worst executed path = base + sum(conditions) + max(values). No depth penalty (the
+        // dispatch is depth-transparent — mirrors GasAwareSemantics.chargeBase).
+        // args = [cond1, val1, cond2, val2, ..., (default)]
+        val pairs = args.grouped(2).toList
+        val conds = pairs.collect { case List(c, _) => estimate(c, config) }
+        val values = pairs.collect { case List(_, v) => estimate(v, config) } ++
+          pairs.collect { case List(d) => estimate(d, config) }
+        val condCost = conds.foldLeft(GasMetrics.zero)(_.combine(_))
+        val branch = values.maxByOption(_.cost.amount).getOrElse(GasMetrics.zero)
+        GasMetrics.single(baseCost(IfElseOp)(config), depth = 0).combine(condCost).combine(branch)
+
+      case ApplyExpression(LetOp, args) =>
+        // Bindings and body are all evaluated; base charged once, no depth penalty (control flow).
+        val children = args.foldLeft(GasMetrics.zero)((acc, e) => acc.combine(estimate(e, config)))
+        GasMetrics.single(baseCost(LetOp)(config), depth = 0).combine(children)
+
+      case ApplyExpression(op, args) =>
+        // Eager op: newDepth = max(child depth) + 1; charge base + depthPenalty(newDepth).
+        // Children already accounted their own cost (charge-once), so add their aggregate.
+        val children = args.map(estimate(_, config))
+        val childDepth = if (children.isEmpty) 0 else children.map(_.depth).max
+        val newDepth = childDepth + 1
+        val childAgg = children.foldLeft(GasMetrics.zero)(_.combine(_))
+        val nodeCost = baseCost(op)(config) + config.depthPenalty(newDepth.toLong)
+        GasMetrics(nodeCost + childAgg.cost, newDepth, childAgg.opCount + 1)
+    }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/GasAwareSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/GasAwareSemantics.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 
 import io.constellationnetwork.metagraph_sdk.json_logic.core.JsonLogicOp._
 import io.constellationnetwork.metagraph_sdk.json_logic.core._
-import io.constellationnetwork.metagraph_sdk.json_logic.gas.{GasConfig, GasCost, GasLimit}
+import io.constellationnetwork.metagraph_sdk.json_logic.gas.{GasConfig, GasCost, GasLimit, JsonLogicGasEstimator}
 import io.constellationnetwork.metagraph_sdk.json_logic.ops.NumericOps.floatToPlainString
 import io.constellationnetwork.metagraph_sdk.json_logic.runtime.ResultContext
 
@@ -154,83 +154,8 @@ object GasAwareSemantics {
           }
         }
 
-      private def getOpCost(op: JsonLogicOp)(config: GasConfig): GasCost = op match {
-        case NoOp                 => GasCost.Zero
-        case MissingNoneOp        => config.exists
-        case ExistsOp             => config.exists
-        case MissingSomeOp        => config.missingSome
-        case IfElseOp             => config.ifElse
-        case LetOp                => config.ifElse // Similar cost to if/else (control flow)
-        case EqOp                 => config.eq
-        case EqStrictOp           => config.eqStrict
-        case NEqOp                => config.neq
-        case NEqStrictOp          => config.neqStrict
-        case NotOp                => config.not
-        case NOp                  => config.doubleNot
-        case OrOp                 => config.or
-        case AndOp                => config.and
-        case Lt                   => config.lt
-        case Leq                  => config.leq
-        case Gt                   => config.gt
-        case Geq                  => config.geq
-        case ModuloOp             => config.modulo
-        case MaxOp                => config.max
-        case MinOp                => config.min
-        case AddOp                => config.add
-        case TimesOp              => config.times
-        case MinusOp              => config.minus
-        case DivOp                => config.div
-        case MergeOp              => config.merge
-        case InOp                 => config.in
-        case CatOp                => config.cat
-        case SubStrOp             => config.substr
-        case MapOp                => config.map
-        case FilterOp             => config.filter
-        case ReduceOp             => config.reduce
-        case AllOp                => config.all
-        case NoneOp               => config.none
-        case SomeOp               => config.some
-        case MapValuesOp          => config.mapValues
-        case MapKeysOp            => config.mapKeys
-        case GetOp                => config.get
-        case IntersectOp          => config.intersect
-        case CountOp              => config.count
-        case LengthOp             => config.length
-        case FindOp               => config.find
-        case LowerOp              => config.lower
-        case UpperOp              => config.upper
-        case JoinOp               => config.join
-        case SplitOp              => config.split
-        case DefaultOp            => config.default
-        case UniqueOp             => config.unique
-        case SliceOp              => config.slice
-        case ReverseOp            => config.reverse
-        case FlattenOp            => config.flatten
-        case TrimOp               => config.trim
-        case StartsWithOp         => config.startsWith
-        case EndsWithOp           => config.endsWith
-        case AbsOp                => config.abs
-        case RoundOp              => config.round
-        case FloorOp              => config.floor
-        case CeilOp               => config.ceil
-        case PowOp                => config.pow
-        case HasOp                => config.has
-        case EntriesOp            => config.entries
-        case TypeOfOp             => config.typeOf
-        case PoseidonOp           => config.poseidon
-        case PmtVerifyOp          => config.pmtVerify
-        case Groth16VerifyOp      => config.groth16Verify
-        case EcVrfVerifyOp        => config.ecvrfVerify
-        case Bn254AddOp           => config.bn254Add
-        case Bn254MulOp           => config.bn254Mul
-        case Bn254PairingOp       => config.bn254Pairing
-        case BlsVerifyOp          => config.blsVerify
-        case BlsAggregateVerifyOp => config.blsAggregateVerify
-        case SchnorrVerifyOp      => config.schnorrVerify
-        case SmtVerifyOp          => config.smtVerify
-        case MptVerifyOp          => config.mptVerify
-        case MptPrefixVerifyOp    => config.mptPrefixVerify
-      }
+      private def getOpCost(op: JsonLogicOp)(config: GasConfig): GasCost =
+        JsonLogicGasEstimator.baseCost(op)(config)
 
       /**
        * Length of the string a value coerces to in `cat` / `join` (mirrors handleCatOp's

--- a/src/test/scala/json_logic/JsonLogicGasEstimatorSuite.scala
+++ b/src/test/scala/json_logic/JsonLogicGasEstimatorSuite.scala
@@ -1,0 +1,85 @@
+package json_logic
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.json_logic.core.JsonLogicOp._
+import io.constellationnetwork.metagraph_sdk.json_logic.core._
+import io.constellationnetwork.metagraph_sdk.json_logic.gas._
+import io.constellationnetwork.metagraph_sdk.json_logic.runtime.JsonLogicEvaluator
+
+import io.circe.parser.decode
+import weaver.SimpleIOSuite
+
+object JsonLogicGasEstimatorSuite extends SimpleIOSuite {
+
+  private val cfg = GasConfig.Default
+
+  private def parse(s: String): JsonLogicExpression =
+    decode[JsonLogicExpression](s).fold(e => throw new RuntimeException(s"parse failed: $e"), identity)
+
+  private def estimateCost(json: String): Long =
+    JsonLogicGasEstimator.estimate(parse(json), cfg).cost.amount
+
+  private def meteredGas(json: String, data: JsonLogicValue): IO[Long] =
+    JsonLogicEvaluator
+      .recursive[IO]
+      .evaluateWithGas(parse(json), data, None, GasLimit.Default, cfg)
+      .flatMap(IO.fromEither)
+      .map(_.gasUsed.amount)
+
+  // ---- baseCost is the shared op->cost table (single source of truth with the evaluator) ----
+  test("baseCost mirrors GasConfig for representative ops") {
+    IO.pure(
+      expect.all(
+        JsonLogicGasEstimator.baseCost(AddOp)(cfg) == cfg.add,
+        JsonLogicGasEstimator.baseCost(MapOp)(cfg) == cfg.map,
+        JsonLogicGasEstimator.baseCost(ReduceOp)(cfg) == cfg.reduce,
+        JsonLogicGasEstimator.baseCost(Groth16VerifyOp)(cfg) == cfg.groth16Verify,
+        JsonLogicGasEstimator.baseCost(IfElseOp)(cfg) == cfg.ifElse
+      )
+    )
+  }
+
+  // ---- estimate implements the documented static formula (base + depthPenalty + varCost) ----
+  test("estimate: hand-computed structural costs") {
+    IO.pure(
+      expect.all(
+        // {"+":[1,2]} = add(5) + depthPenalty(depth 1 = 5); const args are free
+        estimateCost("""{"+":[1,2]}""") == cfg.add.amount + cfg.depthPenalty(1L).amount,
+        // {"var":"a.b"} = varAccess(2) + dot-segments(2)
+        estimateCost("""{"var":"a.b"}""") == cfg.varAccess.amount + 2L,
+        // {"+":[{"var":"a"},2]} = add-node(5+5) + var "a"(2+1)
+        estimateCost("""{"+":[{"var":"a"},2]}""") ==
+          cfg.add.amount + cfg.depthPenalty(1L).amount + cfg.varAccess.amount + 1L
+      )
+    )
+  }
+
+  // ---- the estimate equals the real metered charge for NON-scaling ops (the large common class:
+  //      control flow, logic, comparison, var/const) — one grounded source of truth ----
+  test("estimate == metered gasUsed: var + nested comparison (no scaling, single path)") {
+    val j = """{"and":[{">":[{"var":"x"},1]},{"<":[{"var":"x"},100]}]}"""
+    meteredGas(j, MapValue(Map("x" -> IntValue(BigInt(5))))).map(g => expect(estimateCost(j) == g))
+  }
+
+  // ---- for ops that DO scale, the static walk omits the scaled term, so it is a floor (<=):
+  //      variadic '+' carries an input-scaled (n-1) charge the estimator does not count ----
+  test("estimate <= metered gasUsed: variadic arithmetic (scaled term omitted -> floor)") {
+    meteredGas("""{"+":[1,2]}""", MapValue.empty).map(g => expect(estimateCost("""{"+":[1,2]}""") <= g))
+  }
+
+  // ---- if is modelled as the worst branch: estimate >= actual (only one branch runs) ----
+  test("estimate(if) >= metered gasUsed (lazy branch selection)") {
+    // condition true -> the cheap then-branch runs; estimate must still cover the heavier else
+    val j = """{"if":[{"==":[1,1]},{"+":[1,2]},{"*":[{"*":[3,4]},{"*":[5,6]}]}]}"""
+    meteredGas(j, MapValue.empty).map(g => expect(estimateCost(j) >= g))
+  }
+
+  // ---- documents the known limitation: input-scaled ops are NOT counted statically ----
+  test("scaled ops (map) count base+var only — element count needs the data") {
+    // estimate has no per-element term; the metered run over a 3-element array charges more
+    val j = """{"map":[{"var":"xs"},{"+":[{"var":""},1]}]}"""
+    val data = MapValue(Map("xs" -> ArrayValue(List(IntValue(BigInt(1)), IntValue(BigInt(2)), IntValue(BigInt(3))))))
+    meteredGas(j, data).map(g => expect(estimateCost(j) > 0L && estimateCost(j) <= g))
+  }
+}


### PR DESCRIPTION
## Summary

Adds `JsonLogicGasEstimator`: a static, **execution-free** gas estimate over a `JsonLogicExpression`, for cheap pre-flight "how much might this cost" quoting (e.g. a metagraph `estimate-fee` route) without running the VM.

## What's in it

- **`baseCost(op: JsonLogicOp)(cfg: GasConfig): GasCost`** — the per-op cost table, lifted out of `GasAwareSemantics` and made public. `GasAwareSemantics.getOpCost` now **delegates to it**, so the charger and the estimator are a single source of truth and cannot drift (the 77-line private match is replaced by a one-line delegate).

- **`estimate(expr, cfg): GasMetrics`** — a static walk summing the per-op `base + depthPenalty + varCost`:
  - **Exact** for expressions whose ops don't scale — the large common class: control flow, logic, comparison, get/has/typeof, var/const.
  - **Floor** (under-count) for ops that scale (arithmetic's variadic `(n-1)` term, collections, crypto, string building) — those scaled terms are omitted *on purpose*, to avoid duplicating the evaluator's per-op scaling rules (no second copy to drift). The caller recovers them from the data when it has it (payload/state size the input collections; proof shape sizes the crypto ops).
  - Conservative along the control-flow dimension: lazy `if` is modelled as `base + sum(conditions) + max(values)` — the single worst branch, never the sum of all branches.

The authoritative charge remains the metered evaluation; this is a quote.

## Verification

- New `JsonLogicGasEstimatorSuite` (6 tests): `baseCost` mirrors `GasConfig`; hand-computed structural costs; **`estimate == metered gasUsed`** for a non-scaling comparison/logic expression (grounded against the real evaluator); **`estimate <= gasUsed`** floor for variadic arithmetic; **`estimate >= gasUsed`** for a lazy `if` (worst-branch); and the documented scaled-op gap for `map`.
- All existing gas suites pass unchanged (`GasMeteringSuite`, `GasVectorConformanceSuite`, `GasMetricsSuite`) — confirming the `getOpCost → baseCost` delegation preserves every charge.

## Motivation

Downstream (OttoChain) wants to quote a data-update fee before submission without executing the JLVM. This is the metakit-side primitive; the byte-compatible TS/Rust JLVM ports can mirror `baseCost`/`estimate` from the same table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)