### PR TITLE
feat(committed): committed-state adoption enablers (required journal + L0 hooks)

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
@@ -1,18 +1,20 @@
 package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 
-import cats.Parallel
 import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.syntax.all._
+import cats.{Applicative, Parallel}
 
 import scala.reflect.ClassTag
 
 import io.constellationnetwork.currency.dataApplication._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.schema.currency.CurrencyIncrementalSnapshot
 import io.constellationnetwork.metagraph_sdk.MetagraphCommonService
 import io.constellationnetwork.metagraph_sdk.lifecycle.{CombinerService, ValidationService}
 import io.constellationnetwork.metagraph_sdk.std.JsonBinaryCodec
 import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.Hashed
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 
@@ -55,7 +57,8 @@ object CommittedApp {
     validator: ValidationService[F, TX, PUB, PRV],
     journal: CatalogJournal[F],
     extraRoutes: Option[CommittedReader[F, PRV] => HttpRoutes[F]] = None,
-    config: CommittedConfig = CommittedConfig.default
+    config: CommittedConfig = CommittedConfig.default,
+    onConsensusResult: Option[(CommittedReader[F, PRV], Hashed[CurrencyIncrementalSnapshot]) => F[Unit]] = None
   ): F[BaseDataApplicationL0Service[F]] = {
     implicit val wrappedEncoder: Encoder[CommittedOnChain[PUB]] = CommittedOnChain.encoder[PUB]
     implicit val wrappedDecoder: Decoder[CommittedOnChain[PUB]] = CommittedOnChain.decoder[PUB]
@@ -93,6 +96,12 @@ object CommittedApp {
           with DataApplicationL0Service[F, TX, CommittedOnChain[PUB], PRV] {
 
           override def genesis: DataState[CommittedOnChain[PUB], PRV] = genesisData
+
+          /** Forward the consensus result to the dev hook (if any), handing it the committed reader. */
+          override def onSnapshotConsensusResult(
+            snapshot: Hashed[CurrencyIncrementalSnapshot]
+          )(implicit A: Applicative[F]): F[Unit] =
+            onConsensusResult.traverse_(f => f(committedState, snapshot))
 
           override def validateData(
             state: DataState[CommittedOnChain[PUB], PRV],

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
@@ -56,7 +56,7 @@ object CommittedApp {
     combiner: CombinerService[F, TX, PUB, PRV],
     validator: ValidationService[F, TX, PUB, PRV],
     journal: CatalogJournal[F],
-    extraRoutes: Option[CommittedReader[F, PRV] => HttpRoutes[F]] = None,
+    extraRoutes: Option[(CommittedReader[F, PRV], L0NodeContext[F]) => HttpRoutes[F]] = None,
     config: CommittedConfig = CommittedConfig.default,
     onConsensusResult: Option[(CommittedReader[F, PRV], Hashed[CurrencyIncrementalSnapshot]) => F[Unit]] = None
   ): F[BaseDataApplicationL0Service[F]] = {
@@ -129,7 +129,7 @@ object CommittedApp {
 
           override def routes(implicit context: L0NodeContext[F]): HttpRoutes[F] =
             new CommittedRoutes[F, PRV](committedState).public <+>
-            extraRoutes.fold(HttpRoutes.empty[F])(f => f(committedState))
+            extraRoutes.fold(HttpRoutes.empty[F])(f => f(committedState, context))
         }
       )
     }

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedApp.scala
@@ -53,16 +53,16 @@ object CommittedApp {
     genesisState: DataState[PUB, PRV],
     combiner: CombinerService[F, TX, PUB, PRV],
     validator: ValidationService[F, TX, PUB, PRV],
+    journal: CatalogJournal[F],
     extraRoutes: Option[CommittedReader[F, PRV] => HttpRoutes[F]] = None,
-    config: CommittedConfig = CommittedConfig.default,
-    journal: Option[CatalogJournal[F]] = None
+    config: CommittedConfig = CommittedConfig.default
   ): F[BaseDataApplicationL0Service[F]] = {
     implicit val wrappedEncoder: Encoder[CommittedOnChain[PUB]] = CommittedOnChain.encoder[PUB]
     implicit val wrappedDecoder: Decoder[CommittedOnChain[PUB]] = CommittedOnChain.decoder[PUB]
     val view = CommittedView[PRV]
 
     for {
-      committedState   <- CommittedState.make[F, PRV](genesisState.calculated, config, journal)
+      committedState   <- CommittedState.make[F, PRV](genesisState.calculated, journal, config)
       genesisCommitted <- committedState.committed
       genesisData = DataState(
         CommittedOnChain(genesisState.onChain, genesisCommitted.breadcrumb),

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedState.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedState.scala
@@ -33,9 +33,9 @@ import io.circe.Json
  *     breadcrumb of exactly that ordinal (from the latest SIGNED snapshot's on-chain state);
  *     verifies the value reproduces the breadcrumb's `mptRoot` and adopts its `catalogRoot`
  *     sight-unseen -- consensus attested. The catalog itself starts [[CatalogView.SeededCatalog]];
- *     if a [[CatalogJournal]] is configured and its persisted entries recompose to the attested
- *     root, the cell hydrates immediately (the restart path). Otherwise hydration arrives later
- *     via [[hydrate]].
+ *     if the [[CatalogJournal]]'s persisted entries recompose to the attested root, the cell
+ *     hydrates immediately (the restart path -- a persistent `levelDb` journal; an `inMemory`
+ *     journal is empty after a process restart). Otherwise hydration arrives later via [[hydrate]].
  *
  * ==The work cache==
  * `combine` runs BEFORE `setCalculatedState` and must emit the NEXT breadcrumb without mutating
@@ -47,7 +47,7 @@ import io.circe.Json
 final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
   view: CommittedView[S],
   val config: CommittedConfig,
-  journal: Option[CatalogJournal[F]],
+  journal: CatalogJournal[F],
   cell: AtomicCell[F, Committed[F, S]],
   work: Ref[F, Vector[(CommittedBreadcrumb, EpochCatalog[F])]]
 ) extends CommittedReader[F, S] {
@@ -112,21 +112,27 @@ final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
       }
     } yield result
 
-  /** Rebuild from the journal and accept ONLY if it recomposes to the attested roots. */
+  /**
+   * Rebuild from the journal and accept ONLY if it recomposes to the attested roots. Resolution is
+   * by ROOTS -- the catalog root cryptographically commits the full ordinal history, so a matching
+   * root uniquely determines the state -- NOT by the breadcrumb's claimed ordinal. Honest callers
+   * always pass a consensus-signed, ordinal-bound breadcrumb (the latest snapshot's on-chain
+   * state), so root-matching is sufficient. Possible future hardening: also reject a breadcrumb
+   * whose claimed ordinal is inconsistent with the recomposed catalog's frontier (defence in depth
+   * against a forged ordinal -- currently caught downstream when the derived breadcrumb diverges).
+   */
   private def journalCatalogMatching(roots: CommittedRoots): F[Option[EpochCatalog[F]]] =
-    journal.flatTraverse { j =>
-      j.contents.flatMap {
-        case (hot, level1) =>
-          EpochCatalog
-            .fromContents[F](config, CatalogContents(config.epochSize, hot, level1, SortedMap.empty))
-            .flatMap {
-              case Left(_) => none[EpochCatalog[F]].pure[F]
-              case Right(catalog) =>
-                catalog.compose(roots.mptRoot).map {
-                  case (_, composedRoot) => Option.when(composedRoot == roots.catalogRoot)(catalog)
-                }
-            }
-      }
+    journal.contents.flatMap {
+      case (hot, level1) =>
+        EpochCatalog
+          .fromContents[F](config, CatalogContents(config.epochSize, hot, level1, SortedMap.empty))
+          .flatMap {
+            case Left(_) => none[EpochCatalog[F]].pure[F]
+            case Right(catalog) =>
+              catalog.compose(roots.mptRoot).map {
+                case (_, composedRoot) => Option.when(composedRoot == roots.catalogRoot)(catalog)
+              }
+          }
     }
 
   // ---------------------------------------------------------------------------------------------
@@ -227,10 +233,8 @@ final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
           .raiseError[F, Unit]
           .whenA(b.roots != roots)
       }
-      _ <- journal.traverse_ { j =>
-        j.recordOrdinal(prev.ordinal.value.value, prev.roots.mptRoot) >>
-        sealEvent.traverse_(j.recordSeal)
-      }
+      _ <- journal.recordOrdinal(prev.ordinal.value.value, prev.roots.mptRoot) >>
+      sealEvent.traverse_(journal.recordSeal)
       stateDelta = StateDelta(ordinal, prev.roots, roots, delta.upserts, delta.removes)
       deltas = (prev.recentDeltas :+ stateDelta).takeRight(config.maxRecentDeltas)
     } yield Committed(ordinal, nextState, applied, CatalogView.LiveCatalog(nextEpochs, top), roots, deltas)
@@ -269,7 +273,7 @@ final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
   /**
    * Install full catalog contents on a SEEDED cell. Trustless: the rebuilt rollup must recompose
    * to the breadcrumb-attested catalog root, so any peer (or operator) can supply the payload. A
-   * hydrated cell is returned unchanged. On success the journal (if any) is rewritten to match.
+   * hydrated cell is returned unchanged. On success the journal is rewritten to match.
    */
   def hydrate(contents: CatalogContents): F[Either[CommittedStateError, Committed[F, S]]] =
     cell.evalModify { prev =>
@@ -289,7 +293,7 @@ final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
                     ).pure[F]
                   else {
                     val hydrated = prev.copy(catalog = CatalogView.LiveCatalog(epochs, top))
-                    journal.traverse_(_.reset(contents.hot, contents.level1)).as((hydrated, hydrated.asRight[CommittedStateError]))
+                    journal.reset(contents.hot, contents.level1).as((hydrated, hydrated.asRight[CommittedStateError]))
                   }
               }
           }
@@ -307,8 +311,8 @@ object CommittedState {
    */
   private[committed] def make[F[_]: Async: JsonBinaryHasher, S](
     genesisState: S,
-    config: CommittedConfig = CommittedConfig.default,
-    journal: Option[CatalogJournal[F]] = None
+    journal: CatalogJournal[F],
+    config: CommittedConfig = CommittedConfig.default
   )(implicit view: CommittedView[S]): F[CommittedState[F, S]] =
     for {
       trie   <- CommittedCommitment.buildTrie[F](view.entries(genesisState))

--- a/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
@@ -55,11 +55,14 @@ object CommittedAppSuite extends SimpleIOSuite {
     }
 
   private def makeService: IO[BaseDataApplicationL0Service[IO]] =
-    CommittedApp.makeL0[IO, ToyTx, ToyPub, ToyPrv](
-      DataState(ToyPub(0), ToyPrv(s0)),
-      combiner,
-      validator
-    )
+    CatalogJournal.inMemory[IO].flatMap { j =>
+      CommittedApp.makeL0[IO, ToyTx, ToyPub, ToyPrv](
+        DataState(ToyPub(0), ToyPrv(s0)),
+        combiner,
+        validator,
+        journal = j
+      )
+    }
 
   private def get(service: BaseDataApplicationL0Service[IO], path: String): IO[Response[IO]] =
     service.routes.orNotFound.run(Request[IO](Method.GET, Uri.unsafeFromString(path)))
@@ -67,7 +70,7 @@ object CommittedAppSuite extends SimpleIOSuite {
   test("genesis on-chain state carries the genesis breadcrumb (correct by construction)") {
     for {
       service  <- makeService
-      expected <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      expected <- mkCommitted(s0).flatMap(_.committed)
     } yield
       service.genesis.onChain match {
         case CommittedOnChain(ToyPub(0), breadcrumb) =>
@@ -85,7 +88,7 @@ object CommittedAppSuite extends SimpleIOSuite {
       service <- makeService
       out     <- service.combine(service.genesis, List.empty)
       // committing the same transition produces the same breadcrumb
-      reference <- CommittedState.make[IO, ToyState](s0).flatMap(st => st.setCommitted(ord(1), s0))
+      reference <- mkCommitted(s0).flatMap(st => st.setCommitted(ord(1), s0))
     } yield
       out.onChain match {
         case CommittedOnChain(ToyPub(0), breadcrumb) =>
@@ -114,7 +117,7 @@ object CommittedAppSuite extends SimpleIOSuite {
     for {
       service  <- makeService
       h        <- service.hashCalculatedState(ToyPrv(s1))
-      expected <- CommittedState.make[IO, ToyState](s0).flatMap(_.hashFor(s1, None))
+      expected <- mkCommitted(s0).flatMap(_.hashFor(s1, None))
     } yield expect(h == expected)
   }
 
@@ -132,7 +135,7 @@ object CommittedAppSuite extends SimpleIOSuite {
       _         <- service.setCalculatedState(ord(1), ToyPrv(s1))
       res       <- get(service, "/committed/root")
       json      <- res.as[Json]
-      reference <- CommittedState.make[IO, ToyState](s0).flatMap(st => st.setCommitted(ord(1), s1))
+      reference <- mkCommitted(s0).flatMap(st => st.setCommitted(ord(1), s1))
     } yield
       expect.all(
         res.status == Status.Ok,
@@ -197,7 +200,7 @@ object CommittedAppSuite extends SimpleIOSuite {
       attestation <- OrdinalCatalogProofVerifier
         .verify[IO](root, proof, CommittedConfig.DefaultEpochSize)
         .flatMap(IO.fromEither(_))
-      genesisRoots <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      genesisRoots <- mkCommitted(s0).flatMap(_.committed)
     } yield
       expect.all(
         res.status == Status.Ok,

--- a/src/test/scala/lifecycle/committed/CommittedBootstrapSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedBootstrapSuite.scala
@@ -25,9 +25,14 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
   /** A source chain advanced to ordinal `n`. */
   private def source(n: Int, journal: Option[CatalogJournal[IO]] = None): IO[CommittedState[IO, ToyState]] =
     for {
-      st <- CommittedState.make[IO, ToyState](state(0), config, journal)
+      j  <- journal.fold(CatalogJournal.inMemory[IO])(IO.pure)
+      st <- CommittedState.make[IO, ToyState](state(0), j, config)
       _  <- (1 to n).toList.traverse_(i => st.setCommitted(ord(i.toLong), state(i)))
     } yield st
+
+  /** A "fresh downloading node": its own empty in-memory journal (behaves like the old None). */
+  private val freshNode: IO[CommittedState[IO, ToyState]] =
+    CatalogJournal.inMemory[IO].flatMap(CommittedState.make[IO, ToyState](state(0), _, config))
 
   test("O(1) bootstrap: hashCalculatedState is verifiable from state + breadcrumb alone") {
     for {
@@ -35,7 +40,7 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
       cSrc <- src.committed
       bc = cSrc.breadcrumb
 
-      fresh <- CommittedState.make[IO, ToyState](state(0), config)
+      fresh <- freshNode
       // the downloading node has NO history; it hashes the fetched state with the attested breadcrumb
       h <- fresh.hashFor(state(5), Some(bc))
     } yield expect(h == cSrc.roots.combinedHash)
@@ -45,7 +50,7 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
     for {
       src    <- source(5)
       cSrc   <- src.committed
-      fresh  <- CommittedState.make[IO, ToyState](state(0), config)
+      fresh  <- freshNode
       seeded <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
     } yield
       expect.all(
@@ -60,7 +65,7 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
     for {
       src          <- source(5)
       cSrc         <- src.committed
-      fresh        <- CommittedState.make[IO, ToyState](state(0), config)
+      fresh        <- freshNode
       wrongState   <- fresh.setCommitted(ord(5), state(4), Some(cSrc.breadcrumb)).attempt
       wrongOrdinal <- fresh.setCommitted(ord(6), state(5), Some(cSrc.breadcrumb)).attempt
       noBreadcrumb <- fresh.setCommitted(ord(5), state(5), None).attempt
@@ -76,7 +81,7 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
     for {
       src     <- source(5)
       cSrc    <- src.committed
-      fresh   <- CommittedState.make[IO, ToyState](state(0), config)
+      fresh   <- freshNode
       seeded  <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
       attempt <- fresh.advanceWork(seeded.breadcrumb, ToyState.view.entries(state(6))).attempt
     } yield expect(attempt.left.exists(_.isInstanceOf[CommittedStateError.BreadcrumbUnresolvable]))
@@ -88,7 +93,7 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
       cSrc <- src.committed
       contents = cSrc.catalogContents.getOrElse(throw new RuntimeException("source must be hydrated"))
 
-      fresh <- CommittedState.make[IO, ToyState](state(0), config)
+      fresh <- freshNode
       _     <- fresh.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
 
       forged = contents.copy(hot = contents.hot.map { case (o, _) => o -> cSrc.roots.mptRoot })
@@ -110,12 +115,12 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
 
   test("journal restart: a seeded cell hydrates immediately from its own persisted catalog") {
     for {
-      journal <- CatalogJournal.inMemory[IO].map(_.some)
-      src     <- source(5, journal) // writes through to the journal on every transition
+      journal <- CatalogJournal.inMemory[IO]
+      src     <- source(5, journal.some) // writes through to the journal on every transition
       cSrc    <- src.committed
 
       // 'restart': a new cell over the SAME journal, seeded from the attested breadcrumb
-      restarted <- CommittedState.make[IO, ToyState](state(0), config, journal)
+      restarted <- CommittedState.make[IO, ToyState](state(0), journal, config)
       seeded    <- restarted.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb))
 
       // and it can continue producing transitions in lock-step with the source
@@ -160,7 +165,7 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
         // second 'process': fresh cell, SAME db path -- the journal alone hydrates the seed
         seeded <- CatalogJournal.levelDb[IO](dir).use { journal =>
           CommittedState
-            .make[IO, ToyState](state(0), config, journal.some)
+            .make[IO, ToyState](state(0), journal, config)
             .flatMap(_.setCommitted(ord(5), state(5), Some(cSrc.breadcrumb)))
         }
       } yield expect.all(seeded.isHydrated, seeded.roots == cSrc.roots)
@@ -189,8 +194,12 @@ object CommittedBootstrapSuite extends SimpleIOSuite {
       forged = c4.breadcrumb.copy(roots = c4.roots.copy(mptRoot = cSrc.roots.mptRoot))
       rejected <- src.advanceWork(forged, ToyState.view.entries(state(5))).attempt
 
-      // forged at an unknown ordinal: unresolvable, equally fatal
-      unknown = CommittedBreadcrumb(ord(9), c4.roots)
+      // forged roots that correspond to NO committed state (a real mptRoot paired with a catalog
+      // root that does not recompose from it): not the cell, not the work cache, unreproducible
+      // from the journal -- unresolvable, equally fatal. Resolution is by ROOTS, not the claimed
+      // ordinal: a populated journal legitimately resolves genuine historical roots (the restart /
+      // replay path), so the "unresolvable" case must use roots the node never committed.
+      unknown = CommittedBreadcrumb(ord(9), c4.roots.copy(catalogRoot = cSrc.roots.catalogRoot))
       unresolvable <- src.advanceWork(unknown, ToyState.view.entries(state(5))).attempt
     } yield
       expect.all(

--- a/src/test/scala/lifecycle/committed/CommittedProofSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedProofSuite.scala
@@ -29,7 +29,7 @@ object CommittedProofSuite extends SimpleIOSuite {
 
   test("single-key proof verifies against the committed mptRoot; absent key is PathNotFound") {
     for {
-      c       <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      c       <- mkCommitted(s0).flatMap(_.committed)
       proof   <- c.proveKey(CommitKey.unsafe("fiber/aaa")).flatMap(IO.fromEither(_))
       ok      <- MerklePatriciaVerifier.make[IO](c.roots.mptRoot).confirm(proof)
       missing <- c.proveKey(CommitKey.unsafe("fiber/zzz"))
@@ -39,7 +39,7 @@ object CommittedProofSuite extends SimpleIOSuite {
   test("batch proof covers all requested keys and verifies") {
     val keys = List(CommitKey.unsafe("fiber/aaa"), CommitKey.unsafe("registry/alpha"))
     for {
-      c     <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      c     <- mkCommitted(s0).flatMap(_.committed)
       proof <- c.proveKeys(keys).flatMap(IO.fromEither(_))
       ok    <- MerklePatriciaBatchInclusionVerifier.make[IO](c.roots.mptRoot).confirm(proof)
     } yield expect.all(ok.isRight, proof.paths.toSet == keys.map(_.toHex).toSet)
@@ -47,7 +47,7 @@ object CommittedProofSuite extends SimpleIOSuite {
 
   test("namespace attestation covers exactly the namespace's keys and verifies") {
     for {
-      c     <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      c     <- mkCommitted(s0).flatMap(_.committed)
       proof <- c.attestNamespace(CommitNamespace.unsafe("fiber")).flatMap(IO.fromEither(_))
       ok    <- MerklePatriciaBatchInclusionVerifier.make[IO](c.roots.mptRoot).confirm(proof)
     } yield
@@ -65,7 +65,7 @@ object CommittedProofSuite extends SimpleIOSuite {
       json.as[JsonLogicValue].fold(e => throw new RuntimeException(s"bad bridge: $e"), identity)
 
     for {
-      c     <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      c     <- mkCommitted(s0).flatMap(_.committed)
       proof <- c.attestNamespace(ns).flatMap(IO.fromEither(_))
       entriesJlv = MapValue(entries.map { case (k, v) => k.toHex.value -> jlv(v) }.toMap)
       args = List[JsonLogicValue](
@@ -83,7 +83,7 @@ object CommittedProofSuite extends SimpleIOSuite {
 
   test("TOP catalog: current:mpt binds the state-dict root; an unknown family is provably absent") {
     for {
-      st <- CommittedState.make[IO, ToyState](s0)
+      st <- mkCommitted(s0)
       _  <- st.setCommitted(ord(1), s1)
       c2 <- st.setCommitted(ord(2), s2)
       verifier = SparseMerkleVerifier.make[IO]
@@ -109,10 +109,10 @@ object CommittedProofSuite extends SimpleIOSuite {
 
   test("ordinal attestations: historical membership at every ordinal, and NON-membership of an absent one") {
     for {
-      st           <- CommittedState.make[IO, ToyState](s0)
+      st           <- mkCommitted(s0)
       c1           <- st.setCommitted(ord(1), s1)
       c2           <- st.setCommitted(ord(2), s2)
-      genesisRoots <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed).map(_.roots)
+      genesisRoots <- mkCommitted(s0).flatMap(_.committed).map(_.roots)
 
       p0 <- c2.proveOrdinal(ord(0)).flatMap(IO.fromEither(_))
       a0 <- OrdinalCatalogProofVerifier.verify[IO](c2.roots.catalogRoot, p0, CommittedConfig.DefaultEpochSize).flatMap(IO.fromEither(_))
@@ -134,7 +134,7 @@ object CommittedProofSuite extends SimpleIOSuite {
 
   test("ordinal proof JSON round-trips (route payload format)") {
     for {
-      st    <- CommittedState.make[IO, ToyState](s0)
+      st    <- mkCommitted(s0)
       _     <- st.setCommitted(ord(1), s1)
       c     <- st.committed
       proof <- c.proveOrdinal(ord(0)).flatMap(IO.fromEither(_))

--- a/src/test/scala/lifecycle/committed/CommittedReplicationSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedReplicationSuite.scala
@@ -32,7 +32,7 @@ object CommittedReplicationSuite extends SimpleIOSuite {
 
   test("a replica applying the delta stream matches the source's roots at every step") {
     for {
-      source  <- CommittedState.make[IO, ToyState](s0)
+      source  <- mkCommitted(s0)
       genesis <- source.committed
       replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
 
@@ -51,7 +51,7 @@ object CommittedReplicationSuite extends SimpleIOSuite {
     val config = CommittedConfig(epochSize = 2, sealedEpochRetention = 2)
     val states = (1 to 6).toList.map(i => ToyState(Map("aaa" -> i), Map.empty))
     for {
-      source  <- CommittedState.make[IO, ToyState](s0, config)
+      source  <- mkCommitted(s0, config)
       genesis <- source.committed
       replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis), config).flatMap(IO.fromEither(_))
 
@@ -73,7 +73,7 @@ object CommittedReplicationSuite extends SimpleIOSuite {
 
   test("a tampered delta is rejected (modified upsert, dropped remove, forged roots)") {
     for {
-      source  <- CommittedState.make[IO, ToyState](s0)
+      source  <- mkCommitted(s0)
       genesis <- source.committed
       replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
       c1      <- source.setCommitted(ord(1), stream(1))
@@ -98,7 +98,7 @@ object CommittedReplicationSuite extends SimpleIOSuite {
 
   test("a forged catalog root is rejected by the replica's local recomputation") {
     for {
-      source  <- CommittedState.make[IO, ToyState](s0)
+      source  <- mkCommitted(s0)
       genesis <- source.committed
       replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
       c1      <- source.setCommitted(ord(1), stream.head)
@@ -110,7 +110,7 @@ object CommittedReplicationSuite extends SimpleIOSuite {
 
   test("a delta that does not chain from the replica's roots is rejected") {
     for {
-      source  <- CommittedState.make[IO, ToyState](s0)
+      source  <- mkCommitted(s0)
       genesis <- source.committed
       replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
       _       <- source.setCommitted(ord(1), stream.head)
@@ -122,7 +122,7 @@ object CommittedReplicationSuite extends SimpleIOSuite {
 
   test("a snapshot that does not reproduce its claimed roots is rejected") {
     for {
-      genesis <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      genesis <- mkCommitted(s0).flatMap(_.committed)
       forged = snapshotOf(genesis).copy(entries = snapshotOf(genesis).entries - CommitKey.unsafe("fiber/aaa"))
       result <- CommittedReplica.fromSnapshot[IO](forged)
     } yield expect(result.left.exists(_.isInstanceOf[ReplicationError.SnapshotRootsMismatch]))
@@ -130,7 +130,7 @@ object CommittedReplicationSuite extends SimpleIOSuite {
 
   test("ring-buffer eviction forces the snapshot fallback, after which the stream resumes") {
     for {
-      source  <- CommittedState.make[IO, ToyState](s0, CommittedConfig(maxRecentDeltas = 1))
+      source  <- mkCommitted(s0, CommittedConfig(maxRecentDeltas = 1))
       genesis <- source.committed
       replica <- CommittedReplica.fromSnapshot[IO](snapshotOf(genesis)).flatMap(IO.fromEither(_))
 

--- a/src/test/scala/lifecycle/committed/CommittedStateSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedStateSuite.scala
@@ -32,17 +32,17 @@ object CommittedStateSuite extends SimpleIOSuite {
     val b = ToyState(Map("k4" -> 4, "k3" -> 3, "k2" -> 2, "k1" -> 1), Map("r" -> "v"))
 
     for {
-      c1 <- CommittedState.make[IO, ToyState](a).flatMap(_.committed)
-      c2 <- CommittedState.make[IO, ToyState](b).flatMap(_.committed)
+      c1 <- mkCommitted(a).flatMap(_.committed)
+      c2 <- mkCommitted(b).flatMap(_.committed)
     } yield expect.all(c1.roots == c2.roots, c1.roots.combinedHash == c2.roots.combinedHash)
   }
 
   test("delta-apply == full rebuild (and equals a fresh genesis at the new state)") {
     for {
-      st      <- CommittedState.make[IO, ToyState](s0)
+      st      <- mkCommitted(s0)
       c1      <- st.setCommitted(ord(1), s1)
       derived <- CommittedCommitment.buildTrie[IO](ToyState.view.entries(s1))
-      fresh   <- CommittedState.make[IO, ToyState](s1).flatMap(_.committed)
+      fresh   <- mkCommitted(s1).flatMap(_.committed)
     } yield
       expect.all(
         c1.roots.mptRoot == derived.rootNode.digest,
@@ -52,7 +52,7 @@ object CommittedStateSuite extends SimpleIOSuite {
 
   test("empty <-> nonempty boundary stays canonical in both directions") {
     for {
-      st        <- CommittedState.make[IO, ToyState](ToyState.empty)
+      st        <- mkCommitted(ToyState.empty)
       c1        <- st.setCommitted(ord(1), s0)
       c2        <- st.setCommitted(ord(2), ToyState.empty)
       derived   <- CommittedCommitment.buildTrie[IO](ToyState.view.entries(s0))
@@ -66,7 +66,7 @@ object CommittedStateSuite extends SimpleIOSuite {
 
   test("combined hash is sha256(rawBytes(mptRoot) ++ rawBytes(liveCatalogRoot))") {
     for {
-      st <- CommittedState.make[IO, ToyState](s0)
+      st <- mkCommitted(s0)
       c1 <- st.setCommitted(ord(1), s1)
       manual = Hash.fromBytes(Hex(c1.roots.mptRoot.value).toBytes ++ Hex(c1.roots.catalogRoot.value.value).toBytes)
     } yield expect(c1.roots.combinedHash == manual)
@@ -74,10 +74,10 @@ object CommittedStateSuite extends SimpleIOSuite {
 
   test("the live catalog COMMITS history: same state value at different ordinals -> different catalog roots") {
     for {
-      st <- CommittedState.make[IO, ToyState](s0)
+      st <- mkCommitted(s0)
       c1 <- st.setCommitted(ord(1), s1)
       c2 <- st.setCommitted(ord(2), s0) // back to the s0 VALUE, but with two ordinals of history
-      g  <- CommittedState.make[IO, ToyState](s0).flatMap(_.committed)
+      g  <- mkCommitted(s0).flatMap(_.committed)
     } yield
       expect.all(
         c2.roots.mptRoot == g.roots.mptRoot, // tier 1 is pure in the value
@@ -89,7 +89,7 @@ object CommittedStateSuite extends SimpleIOSuite {
 
   test("hashFor on the steady-state path equals the next transition's combined hash") {
     for {
-      st <- CommittedState.make[IO, ToyState](s0)
+      st <- mkCommitted(s0)
       h  <- st.hashFor(s1, None) // cell at genesis = parent of ordinal 1
       c1 <- st.setCommitted(ord(1), s1)
     } yield expect(h == c1.roots.combinedHash)
@@ -97,7 +97,7 @@ object CommittedStateSuite extends SimpleIOSuite {
 
   test("re-committing the same ordinal is idempotent for the same value and refused for a different one") {
     for {
-      st     <- CommittedState.make[IO, ToyState](s0)
+      st     <- mkCommitted(s0)
       c1     <- st.setCommitted(ord(1), s1)
       again  <- st.setCommitted(ord(1), s1)
       forged <- st.setCommitted(ord(1), s0).attempt
@@ -115,7 +115,8 @@ object CommittedStateSuite extends SimpleIOSuite {
     }
 
     for {
-      st <- CommittedState.make[IO, ToyState](s0, CommittedConfig.default)(
+      journal <- CatalogJournal.inMemory[IO]
+      st <- CommittedState.make[IO, ToyState](s0, journal, CommittedConfig.default)(
         IO.asyncForIO,
         JsonBinaryHasher.deriveFromCodec[IO],
         lyingView
@@ -133,7 +134,7 @@ object CommittedStateSuite extends SimpleIOSuite {
     )
 
     for {
-      st <- CommittedState.make[IO, ToyState](s0, CommittedConfig(maxRecentDeltas = 2))
+      st <- mkCommitted(s0, CommittedConfig(maxRecentDeltas = 2))
       _  <- states.zipWithIndex.traverse { case (s, i) => st.setCommitted(ord(i.toLong + 1), s) }
       c  <- st.committed
     } yield

--- a/src/test/scala/lifecycle/committed/EpochCatalogSuite.scala
+++ b/src/test/scala/lifecycle/committed/EpochCatalogSuite.scala
@@ -22,7 +22,7 @@ object EpochCatalogSuite extends SimpleIOSuite {
   /** Drive a fresh committed cell through ordinals 1..n (committing state(i) at ordinal i). */
   private def driveTo(n: Int, config: CommittedConfig): IO[(CommittedState[IO, ToyState], Vector[Committed[IO, ToyState]])] =
     for {
-      st <- CommittedState.make[IO, ToyState](state(0), config)
+      st <- mkCommitted(state(0), config)
       g  <- st.committed
       cs <- (1 to n).toList.traverse(i => st.setCommitted(ord(i.toLong), state(i)))
     } yield (st, g +: cs.toVector)

--- a/src/test/scala/lifecycle/committed/ToyFixtures.scala
+++ b/src/test/scala/lifecycle/committed/ToyFixtures.scala
@@ -1,5 +1,7 @@
 package io.constellationnetwork.metagraph_sdk.lifecycle.committed
 
+import cats.effect.IO
+
 import scala.collection.immutable.SortedMap
 
 import io.constellationnetwork.currency.dataApplication.{DataCalculatedState, DataOnChainState, DataUpdate}
@@ -13,6 +15,14 @@ import io.circe.{Decoder, Encoder, Json}
  * assembly internals (`CommittedState.make`) for white-box tests.
  */
 object ToyFixtures {
+
+  /**
+   * Shared committed-state constructor for the non-bootstrap suites: wires a fresh empty in-memory
+   * journal. An empty journal cannot recompose any attested catalog root, so this behaves exactly
+   * like the old journal-less default for every seed/unhydrated test.
+   */
+  def mkCommitted(s: ToyState, config: CommittedConfig = CommittedConfig.default): IO[CommittedState[IO, ToyState]] =
+    CatalogJournal.inMemory[IO].flatMap(CommittedState.make[IO, ToyState](s, _, config))
 
   final case class ToyState(fibers: Map[String, Int], registry: Map[String, String])
 


### PR DESCRIPTION
Three small, related changes that make the `committed` lifecycle module actually adoptable by a downstream metagraph L0 (ottochain). All scoped to `lifecycle/committed`; full suite green (1111/1111).

### 1. Require the catalog journal (the load-bearing fix)
`CommittedApp.makeL0` / `CommittedState.make` took `journal: Option[CatalogJournal[F]] = None`. The journal is **load-bearing**: a node that *seeds* (restart or download-to-join) with no journal lands in a `SeededCatalog`, and the next `combine` raises `BreadcrumbUnresolvable` → the metagraph stalls. Now a required `CatalogJournal[F]`, with `inMemory`/`levelDb` the explicit opt-outs. Also documents that breadcrumb resolution is by **roots, not the claimed ordinal** (the catalog root commits the full ordinal history).

### 2. `onConsensusResult` hook on `makeL0`
`makeL0` returns an erased `BaseDataApplicationL0Service`, so a metagraph needing `onSnapshotConsensusResult` (webhook dispatch, a notification-side state cache) otherwise had to wrap it in a ~20-method delegating service. Added an optional `onConsensusResult: (CommittedReader, Hashed[CurrencyIncrementalSnapshot]) => F[Unit]` the service forwards, handing the dev the committed reader for current-state reads.

### 3. Pass `L0NodeContext` to `extraRoutes`
The extra-routes callback received only the `CommittedReader`; pass the `L0NodeContext` alongside so extra routes can read node-context state (e.g. the on-chain snapshot). Default `extraRoutes` (None) unaffected.

Downstream consumer: ottochain committed-state migration (scasplte2/ottochain#164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)