### PR TITLE
fix(committed): resolve genesis breadcrumb after the cell advances

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedState.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/lifecycle/committed/CommittedState.scala
@@ -108,7 +108,11 @@ final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
       }
       result <- fromWork match {
         case s @ Some(_) => (s: Option[EpochCatalog[F]]).pure[F]
-        case None        => journalCatalogMatching(bc.roots)
+        case None =>
+          journalCatalogMatching(bc.roots).flatMap {
+            case s @ Some(_) => (s: Option[EpochCatalog[F]]).pure[F]
+            case None        => emptyCatalogMatching(bc.roots)
+          }
       }
     } yield result
 
@@ -133,6 +137,27 @@ final class CommittedState[F[_]: Async: JsonBinaryHasher, S] private (
                 case (_, composedRoot) => Option.when(composedRoot == roots.catalogRoot)(catalog)
               }
           }
+    }
+
+  /**
+   * The genesis fallback. The genesis breadcrumb's catalog is the EMPTY epoch catalog (no ordinals
+   * recorded yet); once the cell advances past genesis its catalog is no longer the live cell, and
+   * the journal can never reproduce it either, because the genesis->1 transition records ordinal 0
+   * into the journal -- so a journal rebuild yields a catalog that already contains ordinal 0, which
+   * recomposes to a DIFFERENT root than the (empty-catalog) genesis root.
+   *
+   * tessellation re-runs `combine(parent = genesis)` while accepting the first incremental snapshot,
+   * AFTER `setCalculatedState` may have advanced the cell; without this fallback that re-run raises
+   * [[CommittedStateError.BreadcrumbUnresolvable]] and the metagraph stalls at ordinal 1. Rebuild the
+   * empty catalog and accept it ONLY if it recomposes to the attested roots -- true only for genesis,
+   * where the state-dict carries just the genesis mptRoot and no history, so this never matches a
+   * non-genesis breadcrumb.
+   */
+  private def emptyCatalogMatching(roots: CommittedRoots): F[Option[EpochCatalog[F]]] =
+    EpochCatalog.empty[F](config).flatMap { empty =>
+      empty.compose(roots.mptRoot).map {
+        case (_, composedRoot) => Option.when(composedRoot == roots.catalogRoot)(empty)
+      }
     }
 
   // ---------------------------------------------------------------------------------------------

--- a/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
+++ b/src/test/scala/lifecycle/committed/CommittedAppSuite.scala
@@ -97,6 +97,21 @@ object CommittedAppSuite extends SimpleIOSuite {
       }
   }
 
+  test("combine resolves the genesis breadcrumb after the cell advanced (tessellation re-run; the e2e stall)") {
+    // tessellation interleaves combine and setCalculatedState and RE-RUNS combine(parent=genesis)
+    // for the first incremental AFTER setCalculatedState has advanced the cell. Reproduce that: advance
+    // the cell to ordinal 1 WITHOUT going through combine (so the work cache never holds the genesis
+    // breadcrumb), then combine from genesis. Only the empty-catalog fallback in resolveCatalog can
+    // resolve the genesis breadcrumb here (the cell is past it, work is empty, and the journal — which
+    // now records ordinal 0 — recomposes to a non-empty catalog). Without it: BreadcrumbUnresolvable
+    // and the metagraph stalls at ordinal 1.
+    for {
+      service <- makeService
+      _       <- service.setCalculatedState(ord(1), ToyPrv(s0))
+      rerun   <- service.combine(service.genesis, List.empty).attempt
+    } yield expect(rerun.isRight)
+  }
+
   test("combine rejects a forged incoming breadcrumb (follower-side transition validation)") {
     for {
       service <- makeService


### PR DESCRIPTION
Follow-up to #48 (clean branch off current `dev` — supersedes #49, which carried the pre-squash commits and conflicted).

The committed-state e2e against ottochain stalls the metagraph at **ordinal 1**: tessellation re-runs `combine(parent = genesis)` while accepting the first incremental snapshot, AFTER `setCalculatedState` has advanced the cell. `resolveCatalog` then can't find the genesis catalog — not the live cell, work cache cleared, and the journal (now recording ordinal 0) recomposes to a *non-empty* catalog — so it raises `BreadcrumbUnresolvable` and no snapshot finalizes (`CalculatedStateHashDoesNotMatchMajority` downstream).

Fix: an empty-catalog fallback in `resolveCatalog`. The genesis breadcrumb's catalog is `EpochCatalog.empty`; rebuild it and accept it **only if** it recomposes to the attested roots — true only for genesis, so it never matches a non-genesis breadcrumb. Regression test replicates the `combine → setCalculatedState → combine-rerun` sequence (passes only with the fix).

**Needs to be in rc.3** — the rc.3 tag (`c754201`) does not have this, so a metagraph on rc.3 stalls at ordinal 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)