### PR TITLE
feat(jlvm): hex_to_int opcode + conformance vectors

### DIFF
--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/core/JsonLogicOp.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/core/JsonLogicOp.scala
@@ -43,6 +43,7 @@ object JsonLogicOp extends Enum[JsonLogicOp] with CirceEnum[JsonLogicOp] {
   case object FloorOp extends JsonLogicOp("floor")
   case object CeilOp extends JsonLogicOp("ceil")
   case object PowOp extends JsonLogicOp("pow")
+  case object HexToIntOp extends JsonLogicOp("hex_to_int")
 
   // Array Operations
   case object MapOp extends JsonLogicOp("map")

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/GasMetering.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/GasMetering.scala
@@ -89,6 +89,9 @@ case class GasConfig(
   floor: GasCost = GasCost(3),
   ceil: GasCost = GasCost(3),
   pow: GasCost = GasCost(20),
+  // hex_to_int: parse a hex string -> unsigned big-endian BigInt. Priced identically to `modulo`
+  // (a single bounded numeric transform; no per-element scaling, so no input-scaled term).
+  hexToInt: GasCost = GasCost(10),
   map: GasCost = GasCost(10),
   filter: GasCost = GasCost(10),
   reduce: GasCost = GasCost(15),

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/JsonLogicGasEstimator.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/gas/JsonLogicGasEstimator.scala
@@ -95,6 +95,7 @@ object JsonLogicGasEstimator {
     case FloorOp              => config.floor
     case CeilOp               => config.ceil
     case PowOp                => config.pow
+    case HexToIntOp           => config.hexToInt
     case HasOp                => config.has
     case EntriesOp            => config.entries
     case TypeOfOp             => config.typeOf

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/HexOps.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/ops/HexOps.scala
@@ -1,0 +1,49 @@
+package io.constellationnetwork.metagraph_sdk.json_logic.ops
+
+import cats.syntax.either._
+
+import io.constellationnetwork.metagraph_sdk.json_logic.core._
+
+/**
+ * Pure, deterministic hex <-> number opcodes for the JLVM.
+ *
+ * Like [[CryptoOps]], every function returns `Either[JsonLogicException, JsonLogicValue]` and NEVER
+ * throws to the caller: wrong arity, a non-string argument, or malformed hex (odd-length body,
+ * non-hex chars, missing `0x`/non-lowercase prefix) all map to a `JsonLogicException`. Byte parsing
+ * is delegated to the shared [[HexBytes]] codec so the accepted hex grammar is identical to the
+ * crypto opcodes (lowercase, `0x`-prefixed, even-length, big-endian).
+ */
+object HexOps {
+
+  // ---------------------------------------------------------------------------
+  // hex_to_int: [hex] -> non-negative big-endian integer (arbitrary precision).
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Parse a single arbitrary-length hex string into raw bytes (reusing [[HexBytes.parseBytes]] with
+   * no fixed width, exactly as the crypto opcodes parse arbitrary-byte arguments) and interpret
+   * those bytes as an UNSIGNED big-endian integer (`BigInt(1, bytes)`). Empty bytes (`"0x"`) yield
+   * `0`; the result is ALWAYS non-negative. Whatever the codec accepts (the `0x` prefix, lowercase,
+   * even length) is inherited; malformed hex propagates as a `JsonLogicException`.
+   */
+  def hexToInt(values: List[JsonLogicValue]): Either[JsonLogicException, JsonLogicValue] =
+    values match {
+      case hexV :: Nil =>
+        for {
+          hex   <- expectStr("hex_to_int")(hexV)
+          bytes <- HexBytes.parseBytes(hex, None, "hex_to_int")
+        } yield IntValue(BigInt(1, bytes))
+      case _ =>
+        JsonLogicException(s"hex_to_int: expected [hex], got $values").asLeft
+    }
+
+  // ---------------------------------------------------------------------------
+  // Shared argument helpers.
+  // ---------------------------------------------------------------------------
+
+  private def expectStr(role: String)(v: JsonLogicValue): Either[JsonLogicException, String] =
+    v match {
+      case StrValue(s) => s.asRight
+      case other       => JsonLogicException(s"$role: expected a hex string, got ${other.tag}").asLeft
+    }
+}

--- a/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
+++ b/src/main/scala/io/constellationnetwork/metagraph_sdk/json_logic/semantics/JsonLogicSemantics.scala
@@ -7,7 +7,7 @@ import io.constellationnetwork.metagraph_sdk.json_logic.core.JsonLogicOp._
 import io.constellationnetwork.metagraph_sdk.json_logic.core._
 import io.constellationnetwork.metagraph_sdk.json_logic.ops.CoercionOps._
 import io.constellationnetwork.metagraph_sdk.json_logic.ops.NumericOps._
-import io.constellationnetwork.metagraph_sdk.json_logic.ops.{AuthDbOps, CryptoOps}
+import io.constellationnetwork.metagraph_sdk.json_logic.ops.{AuthDbOps, CryptoOps, HexOps}
 import io.constellationnetwork.metagraph_sdk.json_logic.runtime.ResultContext._
 import io.constellationnetwork.metagraph_sdk.json_logic.runtime.{JsonLogicRuntime, ResultContext}
 import io.constellationnetwork.metagraph_sdk.numerics.Ratio
@@ -171,6 +171,7 @@ object JsonLogicSemantics {
           case FloorOp              => handleFloorOp
           case CeilOp               => handleCeilOp
           case PowOp                => handlePowOp
+          case HexToIntOp           => handleHexToIntOp
           case HasOp                => handleHasOp
           case EntriesOp            => handleEntriesOp
           case TypeOfOp             => handleTypeOfOp
@@ -1245,6 +1246,15 @@ object JsonLogicSemantics {
           }
         }
       }
+
+      // hex_to_int parses a single arbitrary-length hex string (via the shared HexBytes codec) and
+      // returns it as an UNSIGNED big-endian IntValue (BigInt, arbitrary precision). Pure over the
+      // already-evaluated argument; structured exactly like handleModuloOp (pure Either body wrapped
+      // by withMetrics). Wrong arity / non-string / malformed hex -> JsonLogicException.
+      private def handleHexToIntOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
+        args.withMetrics { values =>
+          HexOps.hexToInt(values).map(_.pure[Result])
+        }
 
       private def handleHasOp(args: List[Result[JsonLogicValue]]): F[Either[JsonLogicException, Result[JsonLogicValue]]] =
         args.withMetrics { values =>

--- a/src/test/resources/conformance/json_logic_test_vectors.json
+++ b/src/test/resources/conformance/json_logic_test_vectors.json
@@ -1,6 +1,6 @@
 {
   "description": "JSON Logic VM test vectors for cross-language compatibility",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "tests": [
     {
       "category": "constants",
@@ -311,6 +311,24 @@
         { "expr": "{\"typeof\": [{\"*\": [4611686018427387904, 4]}]}", "data": "{}", "expected": "\"int\"" },
         { "expr": "{\">\": [18446744073709551616, 9223372036854775807]}", "data": "{}", "expected": "true", "note": "comparison beyond 2^63 is exact (2^64 > i64::MAX)" },
         { "expr": "{\"+\": [\"1e-2000000000\"]}", "data": "{}", "error": true, "note": "string->number coercion bounds the effective decimal scale at 10000 (Rust Ratio::MAX_DECIMAL_SCALE): a huge exponent must error in every impl, never materialize 10^|scale|" }
+      ]
+    },
+    {
+      "category": "hex_to_int",
+      "note": "hex_to_int: parse a 0x-prefixed lowercase big-endian hex string into raw bytes (the shared crypto hex codec) and interpret them as an UNSIGNED big-endian integer; result is always non-negative; empty body (0x) is 0; expected encoded as a decimal string so arbitrary-precision values (beyond 2^53/i64) are exact",
+      "cases": [
+        { "expr": "{\"hex_to_int\": [\"0x\"]}", "data": "{}", "expected": "0", "note": "empty body -> 0" },
+        { "expr": "{\"hex_to_int\": [\"0x00\"]}", "data": "{}", "expected": "0" },
+        { "expr": "{\"hex_to_int\": [\"0xff\"]}", "data": "{}", "expected": "255" },
+        { "expr": "{\"hex_to_int\": [\"0x0100\"]}", "data": "{}", "expected": "256", "note": "big-endian: 0x0100 = 256" },
+        { "expr": "{\"hex_to_int\": [\"0x00ff\"]}", "data": "{}", "expected": "255", "note": "leading zero byte is ignored" },
+        { "expr": "{\"hex_to_int\": [\"0xdeadbeef\"]}", "data": "{}", "expected": "3735928559" },
+        { "expr": "{\"hex_to_int\": [\"0xffffffffffffffff\"]}", "data": "{}", "expected": "18446744073709551615", "note": "2^64-1: exceeds i64/f64 exact range, so expected is a decimal string" },
+        { "expr": "{\"hex_to_int\": [\"0x010000000000000000\"]}", "data": "{}", "expected": "18446744073709551616", "note": "2^64" },
+        { "expr": "{\"hex_to_int\": [\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"]}", "data": "{}", "expected": "13407807929942597099574024998205846127479365820592393377723561443721764030073546976801874298166903427690031858186486050853753882811946569946433649006084095", "note": "64-byte all-ones -> 2^512 - 1 (arbitrary precision)" },
+        { "expr": "{\"hex_to_int\": [\"0xfff\"]}", "data": "{}", "error": true, "note": "odd-length hex body rejected by the shared codec" },
+        { "expr": "{\"hex_to_int\": [\"0xzz\"]}", "data": "{}", "error": true, "note": "non-hex characters rejected" },
+        { "expr": "{\"hex_to_int\": [5]}", "data": "{}", "error": true, "note": "non-string argument rejected" }
       ]
     },
     {

--- a/src/test/scala/json_logic/HexOpsSuite.scala
+++ b/src/test/scala/json_logic/HexOpsSuite.scala
@@ -1,0 +1,88 @@
+package json_logic
+
+import cats.effect.IO
+
+import io.constellationnetwork.metagraph_sdk.json_logic.core._
+import io.constellationnetwork.metagraph_sdk.json_logic.ops.HexOps
+import io.constellationnetwork.metagraph_sdk.json_logic.runtime.JsonLogicEvaluator
+
+import io.circe.parser
+import weaver.SimpleIOSuite
+
+/**
+ * Conformance + behavior tests for the JLVM `hex_to_int` opcode.
+ *
+ * `hex_to_int` parses a single arbitrary-length hex string (reusing the shared [[HexBytes]] codec,
+ * so it inherits the lowercase / `0x`-prefixed / even-length grammar of the crypto opcodes) and
+ * returns it as an UNSIGNED big-endian [[IntValue]] (BigInt, arbitrary precision). The result is
+ * always non-negative; the empty body `"0x"` is `0`. The canonical conformance vectors below are
+ * the cross-language math facts (identical across the Scala / Rust / TS evaluators).
+ *
+ * Each vector is exercised both end-to-end through the evaluator and directly through [[HexOps]],
+ * plus the error cases (odd-length body, non-hex chars, non-string argument).
+ */
+object HexOpsSuite extends SimpleIOSuite {
+
+  private def evalExpr(exprJson: String, dataJson: String = "{}"): IO[Either[JsonLogicException, JsonLogicValue]] =
+    for {
+      expr <- IO.fromEither(parser.parse(exprJson).flatMap(_.as[JsonLogicExpression]))
+      data <- IO.fromEither(parser.parse(dataJson).flatMap(_.as[JsonLogicValue]))
+      out  <- JsonLogicEvaluator.tailRecursive[IO].evaluate(expr, data, None)
+    } yield out
+
+  // Canonical (hex -> expected BigInt) conformance vectors. The 64-byte all-ones value is expressed
+  // as BigInt(2).pow(512) - 1 (NOT transcribed as a literal), per the shared-vector convention.
+  private val vectors: List[(String, BigInt)] = List(
+    "0x"                   -> BigInt(0),
+    "0x00"                 -> BigInt(0),
+    "0xff"                 -> BigInt(255),
+    "0x0100"               -> BigInt(256),
+    "0x00ff"               -> BigInt(255),
+    "0xdeadbeef"           -> BigInt(3735928559L),
+    "0xffffffffffffffff"   -> BigInt("18446744073709551615"), // 2^64 - 1 (> Long/Double range)
+    "0x010000000000000000" -> BigInt("18446744073709551616"), // 2^64
+    ("0x" + "f" * 128)     -> (BigInt(2).pow(512) - 1) // 64-byte all-ones
+  )
+
+  vectors.foreach {
+    case (hex, expected) =>
+      test(s"hex_to_int($hex) == $expected (end-to-end)") {
+        evalExpr(s"""{"hex_to_int":["$hex"]}""").map(r => expect(r == Right(IntValue(expected))))
+      }
+
+      pureTest(s"hex_to_int($hex) == $expected (direct)") {
+        expect(HexOps.hexToInt(List(StrValue(hex))) == Right(IntValue(expected)))
+      }
+  }
+
+  test("hex_to_int is always non-negative for a large value") {
+    evalExpr(s"""{"hex_to_int":["0x${"f" * 128}"]}""").map {
+      case Right(IntValue(v)) => expect(v >= 0) && expect(v == BigInt(2).pow(512) - 1)
+      case other              => failure(s"expected a non-negative IntValue, got $other")
+    }
+  }
+
+  // ===========================================================================
+  // Error cases: must RAISE (a JsonLogicException), not return a value.
+  // ===========================================================================
+
+  test("hex_to_int rejects an odd-length hex body (0xfff)") {
+    evalExpr("""{"hex_to_int":["0xfff"]}""").map(r => expect(r.isLeft))
+  }
+
+  test("hex_to_int rejects non-hex characters (0xzz)") {
+    evalExpr("""{"hex_to_int":["0xzz"]}""").map(r => expect(r.isLeft))
+  }
+
+  test("hex_to_int rejects a non-string argument (integer 5)") {
+    evalExpr("""{"hex_to_int":[5]}""").map(r => expect(r.isLeft))
+  }
+
+  pureTest("hex_to_int direct: error cases surface as a Left, never a thrown exception") {
+    expect(HexOps.hexToInt(List(StrValue("0xfff"))).isLeft) && // odd length
+    expect(HexOps.hexToInt(List(StrValue("0xzz"))).isLeft) && // non-hex
+    expect(HexOps.hexToInt(List(IntValue(5))).isLeft) && // non-string arg
+    expect(HexOps.hexToInt(Nil).isLeft) && // wrong arity (none)
+    expect(HexOps.hexToInt(List(StrValue("0x01"), StrValue("0x02"))).isLeft) // wrong arity (two)
+  }
+}


### PR DESCRIPTION
## Summary

New JLVM opcode **`hex_to_int`** in the canonical Scala evaluator. Sister PR for the Rust + TypeScript ports + shared vectors: `Constellation-Labs/metakit-sdk#62` (branch `feat/jlvm-hex-to-int`).

**Motivation:** `ecvrf_verify` returns `beta` as a `0x` hex string of verifiable randomness, but JLVM had no hex→number path (string coercion only parses decimal), so contracts could verify VRF output yet not use it. `hex_to_int` bridges it: `{"%": [{"hex_to_int":[{"var":"beta"}]}, n]}` → a deterministic, verifiable winner index. General-purpose (any crypto-op hex output → number).

**Semantics:** arity-1 string → reuse the shared `HexBytes` codec (`0x` + lowercase + even-length) → unsigned big-endian `IntValue(BigInt(1, bytes))`. `"0x"`→0, always non-negative; malformed / non-string / wrong-arity → `JsonLogicException`. (JLVM ints are arbitrary-precision BigInt, so a 512-bit `beta` converts losslessly; reduce with `%`.)

**Changes**
- `JsonLogicOp.scala` (enum), `JsonLogicSemantics.scala` (dispatch + handler, modeled on `handleModuloOp`), `ops/HexOps.scala` (impl)
- Gas: `GasMetering.scala` + `JsonLogicGasEstimator.scala` — **`GasCost(10)`** (= the modulo op)
- `test/.../HexOpsSuite.scala` (23 cases) + synced cross-language conformance vectors (`conformance/json_logic_test_vectors.json` → 1.5.0) so Scala runs the same `hex_to_int` vectors as Rust + TS

**Verification:** 836 `json_logic` tests (23 new) + `SharedVectorConformanceSuite [hex_to_int] 21/21`; `scalafmtCheckAll` clean. (Pre-existing, unrelated: `project/Dependencies.scala` has scalafmt drift — left untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
